### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 Developer tools for [Run402](https://run402.com) — provision Postgres databases, deploy static sites, serverless functions, generate images, and manage x402 wallets. Available as an MCP server, an OpenClaw skill, and a CLI.
 
+<a href="https://glama.ai/mcp/servers/kychee-com/run402">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/kychee-com/run402/badge" alt="run402 MCP server" />
+</a>
+
 English | [简体中文](./README.zh-CN.md)
 
 ## Integrations


### PR DESCRIPTION
This PR adds a badge for the [run402](https://glama.ai/mcp/servers/kychee-com/run402) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kychee-com/run402">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/kychee-com/run402/badge" alt="run402 MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.