### PR TITLE
docs: sync SKILL.md + llms-cli.txt to db(req) / adminDb() dual surface

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -267,20 +267,27 @@ Deploy a serverless function (Node 22) to a project. Functions are invoked via H
 
 **DB access inside functions:**
 ```typescript
-import { db, email, getUser } from 'run402-functions';
+import { db, adminDb, email, getUser } from 'run402-functions';
 ```
 
-**TypeScript types**: `npm install run402-functions` — gives full autocomplete for `db.from()`, `getUser()`, `email.send()`, `ai.translate()`. Works in any Node.js/TypeScript project. Both `'run402-functions'` and legacy `'@run402/functions'` work in deployed functions.
+The SDK exposes two distinct DB clients:
 
-**db.sql(query, params?)** — raw SQL, returns `{ status, schema, rows, rowCount }`.
+- **`db(req).from(table)`** — caller-context client. Forwards the incoming request's `Authorization` header to PostgREST; RLS policies evaluate against the caller's role. Routes to `/rest/v1/*`. Use this by default.
+- **`adminDb().from(table)`** — BYPASSRLS client. Uses the project's `service_key`. Routes to `/admin/v1/rest/*` (the gateway rejects `role=service_role` on `/rest/v1/*`, so bypass traffic lives on its own surface). Use only when the function acts on behalf of the platform, not the caller — audit logs, webhook handlers, cron cleanup, platform-authored writes.
+
+**TypeScript types**: `npm install run402-functions` — gives full autocomplete for `db(req)`, `adminDb()`, `getUser()`, `email.send()`, `ai.translate()`. For static site generation, use `adminDb().from()` at build time with `RUN402_SERVICE_KEY` + `RUN402_PROJECT_ID` in your `.env`. Both `'run402-functions'` and legacy `'@run402/functions'` work in deployed functions.
+
+**adminDb().sql(query, params?)** — raw SQL, always BYPASSRLS. Returns `{ status, schema, rows, rowCount }`.
 - SELECT: `rows` = matching rows, `rowCount` = row count
 - INSERT/UPDATE/DELETE: `rows` = `[]`, `rowCount` = affected rows
-- Parameterized: `db.sql('SELECT * FROM t WHERE id = $1', [42])`
+- Parameterized: `adminDb().sql('SELECT * FROM t WHERE id = $1', [42])`
 
-**db.from(table)** — PostgREST-style queries (service_role, bypasses RLS). Returns a plain array of row objects.
+**Fluent query surface** (same on both `db(req).from(t)` and `adminDb().from(t)`):
 Chainable read methods: `.select(cols?)`, `.eq(col, val)`, `.neq()`, `.gt()`, `.lt()`, `.gte()`, `.lte()`, `.like()`, `.ilike()`, `.in(col, [vals])`, `.order(col, { ascending? })`, `.limit(n)`, `.offset(n)`
 Chainable write methods: `.insert(obj | obj[])`, `.update(obj)`, `.delete()` — all return array of affected rows.
 Column narrowing: `.insert({...}).select('col1, col2')` returns only specified columns.
+
+**Legacy `db.from(...)` / `db.sql(...)`** (without the `(req)` call) remains as a deprecation shim that routes through `adminDb()` and warns once per cold start. Will be removed in the next release — port to `db(req)` or `adminDb()`.
 
 **email.send(opts)** — send email from the project's mailbox. Auto-discovers the mailbox on first call (project must have a mailbox created via `create_mailbox`).
 - Template mode: `await email.send({ to: "user@example.com", template: "notification", variables: { project_name: "My App", message: "Hello!" } })`

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -254,26 +254,17 @@ Requires active tier and a provisioned project. Deploys to an existing project: 
 
 ### functions
 Node 22 runtime. Must export `default async (req: Request) => Response`.
-Built-in helper: `import { db, email, ai, getUser } from 'run402-functions'`
+Built-in helper: `import { db, adminDb, email, ai, getUser } from 'run402-functions'`
+- `db(req)` — caller-context DB client. Forwards the caller's `Authorization` header to PostgREST; RLS policies apply to the caller's role. Routes to `/rest/v1/*`. Use this by default.
+- `adminDb()` — BYPASSRLS DB client. Uses the project's service_key. Routes to `/admin/v1/rest/*` (the gateway rejects `role=service_role` on `/rest/v1/*`). Use ONLY when the function acts on behalf of the platform, not the caller — audit logs, webhook handlers, cron cleanup.
 - `getUser(req)` — verify caller's JWT, returns `{ id, role }` or `null`
 - `email.send(opts)` — send email from the project's mailbox (see email section below)
 
-**TypeScript types**: `npm install run402-functions` to get full autocomplete for `db.from()`, `getUser()`, `email.send()`, and `ai.translate()`. Works in any Node.js/TypeScript project (Astro, Next.js, plain TS). Both `import { db } from 'run402-functions'` and legacy `import { db } from '@run402/functions'` work in deployed functions.
+**TypeScript types**: `npm install run402-functions` to get full autocomplete for `db(req)`, `adminDb()`, `getUser()`, `email.send()`, and `ai.translate()`. Works in any Node.js/TypeScript project (Astro, Next.js, plain TS). For static site generation, use `adminDb().from()` at build time with `RUN402_SERVICE_KEY` + `RUN402_PROJECT_ID` in your `.env`. Both `import { db } from 'run402-functions'` and legacy `import { db } from '@run402/functions'` work in deployed functions.
 
-#### db.sql(query, params?)
-Raw SQL. Returns `{ status, schema, rows, rowCount }`.
-- SELECT: `rows` = matching rows, `rowCount` = row count
-- INSERT/UPDATE/DELETE: `rows` = `[]`, `rowCount` = affected rows
-- Parameterized: `db.sql('SELECT * FROM t WHERE id = $1', [42])`
+#### db(req).from(table) — caller-context, RLS applies
 
-```
-const result = await db.sql('SELECT * FROM users WHERE active = true');
-// { status: "ok", schema: "p0001", rows: [{ id: 1, name: "Alice" }], rowCount: 1 }
-const rows = result.rows;
-```
-
-#### db.from(table)
-PostgREST-style queries (service_role, bypasses RLS). Returns a plain array of row objects.
+PostgREST-style queries scoped to the caller's JWT role. Returns a plain array of row objects. Unauthenticated callers resolve to `role=anon` and see only what anon policies allow.
 
 Reads:
 - `.select(cols?)` — columns to return (default `"*"`)
@@ -284,8 +275,11 @@ Reads:
 - `.limit(n)`, `.offset(n)` — pagination
 
 ```
-const users = await db.from('users').select('name, email').eq('active', true).limit(10);
-// [{ name: "Alice", email: "a@b.com" }, ...]
+export default async (req: Request) => {
+  // Runs with the caller's JWT — RLS decides what they see.
+  const myItems = await db(req).from('items').select('title, done').limit(10);
+  return new Response(JSON.stringify(myItems), { headers: { 'content-type': 'application/json' } });
+};
 ```
 
 Writes (also return an array of affected rows):
@@ -294,17 +288,40 @@ Writes (also return an array of affected rows):
 - `.delete()` — delete matched rows (combine with `.eq()`)
 
 ```
-const created = await db.from('items').insert({ title: 'New', done: false });
-// [{ id: 1, title: "New", done: false, created_at: "..." }]
-
-await db.from('items').update({ done: true }).eq('id', 1);
-// [{ id: 1, title: "New", done: true, created_at: "..." }]
-
-await db.from('items').delete().eq('id', 1);
-// [{ id: 1, ... }]  (returns deleted row)
+// All three run as the caller — RLS policies decide if the write is allowed.
+const created = await db(req).from('items').insert({ title: 'New', done: false });
+await db(req).from('items').update({ done: true }).eq('id', 1);
+await db(req).from('items').delete().eq('id', 1);
 ```
 
 Column narrowing works with writes: `.insert({...}).select('id, title')` returns only those columns.
+
+#### adminDb().from(table) — BYPASSRLS, opt-in
+
+Identical fluent surface to `db(req).from(...)` but uses the service_key. Returns all rows regardless of RLS. Use for server-side work where the function itself is the principal.
+
+```
+// Audit log — must capture every event regardless of who called the function.
+await adminDb().from('audit_log').insert({ event: 'payment_succeeded', user_id: userId });
+
+// Cron cleanup — no caller context.
+await adminDb().from('sessions').delete().lt('expires_at', new Date().toISOString());
+```
+
+#### adminDb().sql(query, params?) — raw SQL, always BYPASSRLS
+
+Returns `{ status, schema, rows, rowCount }`.
+- SELECT: `rows` = matching rows, `rowCount` = row count
+- INSERT/UPDATE/DELETE: `rows` = `[]`, `rowCount` = affected rows
+- Parameterized: `adminDb().sql('SELECT * FROM t WHERE id = $1', [42])`
+
+```
+const result = await adminDb().sql('SELECT * FROM users WHERE active = true');
+// { status: "ok", schema: "p0001", rows: [{ id: 1, name: "Alice" }], rowCount: 1 }
+const rows = result.rows;
+```
+
+**Legacy `db.from(...)` / `db.sql(...)`** (without the `(req)` call) remains as a deprecation shim that routes through `adminDb()` and emits a one-time console warning on first use. Will be removed in the next release — port to `db(req)` or `adminDb()`.
 
 #### Calling functions from the browser
 

--- a/openspec/specs/functions-db-docs/spec.md
+++ b/openspec/specs/functions-db-docs/spec.md
@@ -1,22 +1,40 @@
-### Requirement: SKILL.md documents db.sql with params and return type
+### Requirement: SKILL.md documents dual-surface DB clients (db(req) and adminDb())
+
+The SKILL.md "DB access inside functions" section SHALL document BOTH DB clients the SDK provides and make the caller-context default explicit:
+
+- `db(req).from(table)` — caller-context client. Forwards the incoming request's `Authorization` header to PostgREST; RLS applies to the caller's role. Routes to `/rest/v1/*`. Documented as the default for end-user requests.
+- `adminDb().from(table)` — BYPASSRLS client. Uses the project's service_key. Routes to `/admin/v1/rest/*` (the gateway rejects `role=service_role` on `/rest/v1/*`). Documented as explicit opt-in for platform-authored work.
+
+The section SHALL explain *when* to reach for each (default to `db(req)`; use `adminDb()` only when the function is the principal, not the caller) and SHALL note that the legacy `db.from(...)` / `db.sql(...)` call shape remains as a deprecation shim that warns once and routes through `adminDb()`.
+
+#### Scenario: Agent picks the correct client for caller-scoped reads
+- **WHEN** an agent reads SKILL.md to implement a function that returns the logged-in user's items
+- **THEN** it finds a `db(req).from(...)` example and understands that RLS will scope the rows to the caller
+
+#### Scenario: Agent picks the correct client for platform-authored writes
+- **WHEN** an agent reads SKILL.md to implement an audit-log or cron cleanup function
+- **THEN** it finds an `adminDb().from(...)` example and understands that BYPASSRLS is the explicit opt-in
+
+### Requirement: SKILL.md documents adminDb().sql() with params and return type
+
 The SKILL.md "DB access inside functions" section SHALL document:
-- `db.sql(query, params?)` signature with optional params
+- `adminDb().sql(query, params?)` signature with optional params (always BYPASSRLS — there is no caller-context SQL path)
 - Return type: `{ status, schema, rows, rowCount }`
 - SELECT behavior: `rows` = matching rows, `rowCount` = row count
 - INSERT/UPDATE/DELETE behavior: `rows` = `[]`, `rowCount` = affected rows
-- Parameterized example: `db.sql('SELECT * FROM t WHERE id = $1', [42])`
+- Parameterized example: `adminDb().sql('SELECT * FROM t WHERE id = $1', [42])`
 
-#### Scenario: Agent reads SKILL.md for db.sql usage
-- **WHEN** an agent reads the SKILL.md functions section
-- **THEN** it finds documentation for parameterized queries with `db.sql(query, params?)` and understands the return type shape
+#### Scenario: Agent reads SKILL.md for raw-SQL usage
+- **WHEN** an agent reads SKILL.md to run parameterized SQL
+- **THEN** it finds `adminDb().sql(query, params?)` documented with the return type shape
 
-### Requirement: SKILL.md documents db.from chainable API
-The SKILL.md "DB access inside functions" section SHALL document:
-- `db.from(table)` returns a PostgREST-style query builder (service_role, bypasses RLS) that returns a plain array of row objects
+### Requirement: SKILL.md documents the shared fluent query surface
+
+The SKILL.md section SHALL document the fluent query-builder methods that work identically on both `db(req).from(t)` and `adminDb().from(t)`:
 - Chainable read methods: `.select(cols?)`, `.eq(col, val)`, `.neq()`, `.gt()`, `.lt()`, `.gte()`, `.lte()`, `.like()`, `.ilike()`, `.in(col, [vals])`, `.order(col, { ascending? })`, `.limit(n)`, `.offset(n)`
 - Chainable write methods: `.insert(obj | obj[])`, `.update(obj)`, `.delete()` — all return array of affected rows
 - Column narrowing: `.insert({...}).select('col1, col2')` returns only specified columns
 
-#### Scenario: Agent reads SKILL.md for db.from usage
-- **WHEN** an agent reads the SKILL.md functions section
-- **THEN** it finds the full chainable API for `db.from()` including read methods, write methods, and column narrowing
+#### Scenario: Agent reads SKILL.md for chainable API coverage
+- **WHEN** an agent reads SKILL.md to build a filtered, ordered, paginated query
+- **THEN** it finds the full chainable API applicable to either client (caller-context or admin)


### PR DESCRIPTION
Mirrors [run402-private#51](https://github.com/kychee-com/run402-private/pull/51) (functions-sdk-caller-context). Layer `run402-functions-runtime:10` + SDK v1.1.0 are live in production; these public docs need to describe the shipped contract.

## Changes

### SKILL.md (DB access inside functions)
- Two explicit clients now: `db(req).from(table)` (caller-context, RLS applies, routes `/rest/v1/*`) and `adminDb().from(table)` (BYPASSRLS, routes `/admin/v1/rest/*`).
- `db.sql` renamed to `adminDb().sql` (always BYPASSRLS — no caller-context SQL path).
- Added short "when to use which" guidance — default to `db(req)`; reach for `adminDb()` only when the function is the principal (audit logs, webhook handlers, cron cleanup).
- Legacy `db.from(...)` / `db.sql(...)` flagged as a one-release deprecation shim that warns on first use and routes through `adminDb()`.

### cli/llms-cli.txt (Functions section)
- Same restructure, plus refreshed runnable examples that use `db(req)` for user-scoped reads/writes and `adminDb()` for admin paths.
- Static-site-generation guidance updated to point `adminDb().from()` at build time.

### openspec/specs/functions-db-docs/spec.md
- Requirements rewritten around the dual-surface model so validation tracks the new contract (no more "db.from() uses service_role and bypasses RLS" — that's now the opt-in).

## Why now

Gateway rejects `role=service_role` on `/rest/v1/*` as of [PR #51](https://github.com/kychee-com/run402-private/pull/51). Any agent reading the old public docs would write a function that gets 403s in production. This PR closes that gap.

## Test plan
- [x] `rg 'db\\.from|db\\.sql'` in SKILL.md and cli/llms-cli.txt only matches the deprecation-shim callout
- [x] Both files reference `db(req)` and `adminDb()` with matching routes (`/rest/v1/*` and `/admin/v1/rest/*`)
- [x] Private-repo prod E2E 258/258 after step-17 alignment — this docs PR describes what that test now asserts

## Follow-ups
- Next SDK release (run402-functions 1.2.0) removes the legacy `db.from` / `db.sql` shim. Update these docs again to drop the deprecation callout at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)