### PR TITLE
feat(sdk): paste-and-go AssetRef with scriptTag/linkTag/imgTag emitters

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -109,14 +109,32 @@ Upload a blob (any size, up to 5 TiB) to project storage via direct-to-S3 presig
 - `immutable` (optional, default: `false`) — If true with `sha256`, also produces a content-addressed URL that gets `Cache-Control: immutable`.
 - `sha256` (optional) — Required when `immutable: true`. Client-asserted hash; gateway verifies if S3 returns one.
 
-**Returns:** an `AssetRef`: `{ key, size_bytes, sha256, visibility, url, immutable_url, size, contentSha256, contentType, immutableUrl, etag, sri, contentDigest, cacheKind, cdn: { version, invalidationId, invalidationStatus, ready, hint } }`. The legacy snake_case fields (`size_bytes`, `sha256`, `immutable_url`) are kept for back-compat; the camelCase fields are the v1.45 agent-DX surface.
+**Returns:** an `AssetRef`. The agent-DX way to use it: **upload with `immutable: true`, then call `result.scriptTag()`, `result.linkTag()`, or `result.imgTag()` and paste the output directly into your generated HTML.** The tag emitters return ready-to-use HTML with `src` / `href` set to a content-hashed URL on `pr-<public_id>.run402.com`, `integrity` set to the SRI hash, and `crossorigin` set so browsers verify the bytes.
 
-**Prefer `immutableUrl` in generated HTML/CSS/JS code.** Reasoning:
-- Read-after-write correctness: the immutable URL is bound to the SHA at upload time and was never previously cached. The mutable `url` is "eventually fresh" — invalidation is asynchronous, so a `<script>` tag pointing at it may load the OLD version for seconds-to-minutes after a re-upload.
-- Built-in integrity: pair `immutableUrl` with `integrity={sri}` on `<script>` and `<link>` tags so browsers verify the hash before executing.
-- No follow-up calls needed: an agent emitting `<script src={immutableUrl} integrity={sri}>` doesn't need to call `wait_for_cdn_freshness` afterwards. Use the mutable `url` only when the URL must remain stable across re-uploads.
+```ts
+const logo = await client.blobs.put(projectId, "logo.png", { bytes }, { immutable: true });
+html += logo.imgTag("Company logo");
+// → <img src="https://pr-abc.run402.com/_blob/logo-3a7fc02e.png" alt="Company logo">
 
-If you must use the mutable `url` (e.g. you're updating an `<img>` referenced by an external system that won't accept a new URL), call `wait_for_cdn_freshness` before publishing the change. **Mutable URLs only**; never call wait_for_cdn_freshness on `immutableUrl`.
+const app = await client.blobs.put(projectId, "app.js", { content }, { immutable: true });
+html += app.scriptTag({ type: "module" });
+// → <script src="https://pr-abc.run402.com/_blob/app-deadbeef.js" type="module" integrity="sha256-…" crossorigin></script>
+
+const styles = await client.blobs.put(projectId, "styles.css", { content }, { immutable: true });
+html += styles.linkTag();
+// → <link rel="stylesheet" href="https://pr-abc.run402.com/_blob/styles-aabbccdd.css" integrity="sha256-…" crossorigin>
+```
+
+**Why this is the recommended path.** The URL the emitters use (`cdnUrl`) is content-addressed (no cache invalidation, no `wait_for_cdn_freshness`), served from the auto-subdomain `pr-<public_id>.run402.com` (the host that's guaranteed to work through the v1.33 CDN), and stable across re-deploys of the same content. SRI guarantees the browser refuses execution on byte mismatch. There are no decisions for the agent to make.
+
+**Other AssetRef fields** for advanced use:
+- `cdnUrl` — the content-addressed auto-subdomain URL the tag emitters use. Use this directly if you're not generating HTML (e.g. CSS `url()` references, JSON data URLs).
+- `cdnMutableUrl` — mutable form of the auto-subdomain URL. Eventual-consistency caveats apply; prefer `cdnUrl` for generated code.
+- `url` / `immutableUrl` (preferred-host forms) — the URL on the project's pretty host (claimed subdomain or custom domain when configured). Currently NOT served through the CDN — keep using these for direct-API consumers (e.g. `client.blobs.get`), not in `<script>`/`<img>` embeds.
+- `etag`, `sri`, `contentDigest` — the integrity values the tag emitters bake in. Useful if you're constructing tags by hand for an unsupported context.
+- `cdn: { version, invalidationId, invalidationStatus, ready, hint }` — CloudFront invalidation envelope. For immutable uploads `cdn.ready === true` and no further work is required.
+
+The legacy `size_bytes`, `sha256`, `immutable_url` fields stay populated for back-compat with pre-v1.45 callers.
 
 Supersedes `upload_file` (deprecated).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -106,21 +106,21 @@ Upload a blob (any size, up to 5 TiB) to project storage via direct-to-S3 presig
 - `content` (optional) — Inline content, ≤ 1 MB. Use only for small text blobs.
 - `content_type` (optional) — MIME type
 - `visibility` (optional, default: `"public"`) — `"public"` (bypasses auth) or `"private"` (requires apikey)
-- `immutable` (optional, default: `false`) — If true with `sha256`, also produces a content-addressed URL that gets `Cache-Control: immutable`.
-- `sha256` (optional) — Required when `immutable: true`. Client-asserted hash; gateway verifies if S3 returns one.
+- `immutable` (optional, **default `true` since v1.45**) — Produces a content-addressed URL that pairs with SRI and never needs cache invalidation. Pass `{ immutable: false }` only when you specifically want to skip the SHA-256 pass on a very large upload (storage cost is identical; immutable just adds the content-hashed URL).
+- `sha256` (optional) — Computed automatically by the SDK when `immutable: true` (the default). You don't need to set this.
 
-**Returns:** an `AssetRef`. The agent-DX way to use it: **upload with `immutable: true`, then call `result.scriptTag()`, `result.linkTag()`, or `result.imgTag()` and paste the output directly into your generated HTML.** The tag emitters return ready-to-use HTML with `src` / `href` set to a content-hashed URL on `pr-<public_id>.run402.com`, `integrity` set to the SRI hash, and `crossorigin` set so browsers verify the bytes.
+**Returns:** an `AssetRef`. The agent-DX way to use it: **call `result.scriptTag()`, `result.linkTag()`, or `result.imgTag()` and paste the output directly into your generated HTML.** The tag emitters return ready-to-use HTML with `src` / `href` set to a content-hashed URL on `pr-<public_id>.run402.com`, `integrity` set to the SRI hash, and `crossorigin` set so browsers verify the bytes. They also bake in modern best-practice attributes — `defer` on `<script>`, `loading="lazy"` + `decoding="async"` on `<img>` — so you don't have to remember.
 
 ```ts
-const logo = await client.blobs.put(projectId, "logo.png", { bytes }, { immutable: true });
+const logo = await client.blobs.put(projectId, "logo.png", { bytes });
 html += logo.imgTag("Company logo");
-// → <img src="https://pr-abc.run402.com/_blob/logo-3a7fc02e.png" alt="Company logo">
+// → <img src="https://pr-abc.run402.com/_blob/logo-3a7fc02e.png" alt="Company logo" loading="lazy" decoding="async">
 
-const app = await client.blobs.put(projectId, "app.js", { content }, { immutable: true });
+const app = await client.blobs.put(projectId, "app.js", { content });
 html += app.scriptTag({ type: "module" });
-// → <script src="https://pr-abc.run402.com/_blob/app-deadbeef.js" type="module" integrity="sha256-…" crossorigin></script>
+// → <script src="https://pr-abc.run402.com/_blob/app-deadbeef.js" type="module" defer integrity="sha256-…" crossorigin></script>
 
-const styles = await client.blobs.put(projectId, "styles.css", { content }, { immutable: true });
+const styles = await client.blobs.put(projectId, "styles.css", { content });
 html += styles.linkTag();
 // → <link rel="stylesheet" href="https://pr-abc.run402.com/_blob/styles-aabbccdd.css" integrity="sha256-…" crossorigin>
 ```

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -408,16 +408,28 @@ run402 blob diagnose https://app.run402.com/_blob/avatar.png --project abc123
 run402 cdn wait-fresh https://app.run402.com/_blob/avatar.png --sha ba78... --timeout 120
 ```
 
-`put` response (an `AssetRef`) includes both legacy snake_case and v1.45 camelCase fields:
-- `url` / (no camelCase alias) — stable mutable URL: `https://pr-<public_id>.run402.com/_blob/<key>`, also any claimed subdomain or mapped custom domain. Cached at CloudFront edge; invalidation is asynchronous on overwrite.
-- `immutable_url` / `immutableUrl` (only when `--immutable`) — content-hashed URL: `https://<host>/_blob/<key-without-ext>-<8hex>.<ext>`. Bound to a SHA at upload time; never previously cached. **Prefer this in generated HTML/CSS/JS code** — it doesn't need waiting and pairs with `sri` for browser SRI verification.
-- `etag` — strong `"sha256-<hex>"` ETag (when `--immutable`).
-- `sri` — `sha256-<base64>` for `<script integrity={sri}>` and `<link integrity={sri}>`.
+`put` response (an `AssetRef`) — the agent-DX way:
+
+```js
+const asset = await client.blobs.put(projectId, key, { bytes }, { immutable: true });
+html += asset.scriptTag();          // <script src=... integrity=... crossorigin></script>
+html += asset.linkTag();            // <link rel="stylesheet" href=... integrity=... crossorigin>
+html += asset.imgTag("Company logo"); // <img src=... alt="Company logo">
+```
+
+Always upload with `immutable: true` when you plan to embed in HTML/CSS/JS. The tag emitters require it (they bind to a SHA), and the resulting URL is content-addressed → never needs cache invalidation, never breaks on re-deploys, never needs `cdn wait-fresh` follow-up.
+
+Other AssetRef fields for advanced use:
+- `cdnUrl` — the content-addressed URL the emitters use directly. `https://pr-<public_id>.run402.com/_blob/<key-without-ext>-<8hex>.<ext>`. Served via the v1.33 CDN; guaranteed-reachable.
+- `cdnMutableUrl` — mutable URL on the auto-subdomain. Eventual-consistency caveats; prefer `cdnUrl` in code.
+- `url` / `immutableUrl` (preferred-host forms) — URL on the project's pretty host (claimed subdomain / custom domain when configured). Currently NOT served through the CDN — keep using for direct-API consumers (e.g. `run402 blob get`), not in `<script>`/`<img>` embeds.
+- `etag` — strong `"sha256-<hex>"` ETag (when `immutable`).
+- `sri` — `sha256-<base64>` for `<script integrity={sri}>` if you must construct tags by hand.
 - `contentDigest` — RFC 9530 `sha-256=:<base64>:` for HTTP integrity.
 - `cacheKind` — `"immutable" | "mutable" | "private"`.
 - `cdn.{version,invalidationId,invalidationStatus,ready,hint}` — CloudFront invalidation envelope; `cdn.ready === true` for immutable uploads.
 
-**Agent guidance.** When emitting HTML/CSS/JS that links a just-uploaded asset, use `immutableUrl` + `integrity={sri}`. Read-after-write is correct and you don't need a follow-up `cdn wait-fresh` poll. Use the mutable `url` only when the URL must remain stable across re-uploads; in that case, `run402 cdn wait-fresh <url> --sha <new-sha>` blocks until the CDN serves the new SHA.
+**Agent loop pattern (mutable URL only):** if you must use a stable mutable URL across re-uploads, `run402 cdn wait-fresh <mutable-url> --sha <new-sha>` blocks until the CDN serves the new SHA. **Don't call wait-fresh on immutable URLs** — they're correct from the moment of upload.
 
 Resume: state is persisted to `~/.run402/uploads/<upload_id>.json`. Ctrl-C mid-upload and re-run the same `blob put` command — it picks up where it left off. Pass `--no-resume` to start fresh.
 

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -411,13 +411,13 @@ run402 cdn wait-fresh https://app.run402.com/_blob/avatar.png --sha ba78... --ti
 `put` response (an `AssetRef`) — the agent-DX way:
 
 ```js
-const asset = await client.blobs.put(projectId, key, { bytes }, { immutable: true });
-html += asset.scriptTag();          // <script src=... integrity=... crossorigin></script>
-html += asset.linkTag();            // <link rel="stylesheet" href=... integrity=... crossorigin>
-html += asset.imgTag("Company logo"); // <img src=... alt="Company logo">
+const asset = await client.blobs.put(projectId, key, { bytes });  // v1.45 defaults to immutable: true
+html += asset.scriptTag();             // <script src=... defer integrity=... crossorigin></script>
+html += asset.linkTag();               // <link rel="stylesheet" href=... integrity=... crossorigin>
+html += asset.imgTag("Company logo");  // <img src=... alt="Company logo" loading="lazy" decoding="async">
 ```
 
-Always upload with `immutable: true` when you plan to embed in HTML/CSS/JS. The tag emitters require it (they bind to a SHA), and the resulting URL is content-addressed → never needs cache invalidation, never breaks on re-deploys, never needs `cdn wait-fresh` follow-up.
+`immutable: true` is the default since v1.45 — the SDK computes the SHA-256 client-side and the gateway returns a content-addressed URL paired with SRI. The resulting URL never needs cache invalidation, never breaks on re-deploys, never needs `cdn wait-fresh` follow-up. Pass `{ immutable: false }` explicitly only when you want to skip the SHA pass on a very large upload (in that case the tag emitters throw because there's no SHA to bind for SRI). The tag emitters also bake in modern best-practice attributes — `defer` on `<script>`, `loading="lazy"` + `decoding="async"` on `<img>` — so the agent doesn't have to remember.
 
 Other AssetRef fields for advanced use:
 - `cdnUrl` — the content-addressed URL the emitters use directly. `https://pr-<public_id>.run402.com/_blob/<key-without-ext>-<8hex>.<ext>`. Served via the v1.33 CDN; guaranteed-reachable.

--- a/sdk/src/namespaces/blobs.test.ts
+++ b/sdk/src/namespaces/blobs.test.ts
@@ -327,6 +327,8 @@ describe("blobs.put — AssetRef widening (v1.45)", () => {
           immutable_suffix: SHA.slice(0, 8),
           url: "https://app.run402.com/_blob/x.txt",
           immutable_url: "https://app.run402.com/_blob/x-ba7816bf.txt",
+          cdn_url: "https://pr-abc.run402.com/_blob/x.txt",
+          cdn_immutable_url: "https://pr-abc.run402.com/_blob/x-ba7816bf.txt",
         });
       }
       throw new Error("unexpected: " + call.url);
@@ -344,6 +346,9 @@ describe("blobs.put — AssetRef widening (v1.45)", () => {
     assert.equal(result.contentSha256, SHA);
     assert.equal(result.immutableUrl, "https://app.run402.com/_blob/x-ba7816bf.txt");
     assert.equal(result.contentType, "text/plain");
+    // v1.45 cdn-reachable URLs (auto-subdomain, guaranteed-working).
+    assert.equal(result.cdnUrl, "https://pr-abc.run402.com/_blob/x-ba7816bf.txt");
+    assert.equal(result.cdnMutableUrl, "https://pr-abc.run402.com/_blob/x.txt");
     // Integrity fields derived from the SHA.
     assert.equal(result.etag, `"sha256-${SHA}"`);
     assert.match(result.sri ?? "", /^sha256-[A-Za-z0-9+/]+={0,2}$/);
@@ -352,7 +357,134 @@ describe("blobs.put — AssetRef widening (v1.45)", () => {
     assert.equal(result.cacheKind, "immutable");
     assert.equal(result.cdn.version, "blob-gateway-v2");
     assert.equal(result.cdn.ready, true);
-    assert.match(result.cdn.hint ?? "", /immutableUrl is ready immediately/);
+    assert.match(result.cdn.hint ?? "", /Use cdnUrl/);
+  });
+
+  it("scriptTag/linkTag/imgTag emit ready-to-paste tags with SRI + crossorigin", async () => {
+    const SHA = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    const { fetch } = mockFetch((call) => {
+      if (call.url.endsWith("/storage/v1/uploads")) {
+        return json({
+          upload_id: "u_t",
+          mode: "single",
+          part_count: 1,
+          parts: [{ part_number: 1, url: "https://s3.test/u_t/p1", byte_start: 0, byte_end: 2 }],
+        });
+      }
+      if (call.url.startsWith("https://s3.test/")) {
+        return new Response("", { status: 200, headers: { etag: '"e"' } });
+      }
+      if (call.url.endsWith("/complete")) {
+        return json({
+          key: "app.js",
+          size_bytes: 3,
+          sha256: SHA,
+          visibility: "public",
+          content_type: "text/javascript",
+          immutable_suffix: SHA.slice(0, 8),
+          url: "https://app.run402.com/_blob/app.js",
+          immutable_url: "https://app.run402.com/_blob/app-ba7816bf.js",
+          cdn_url: "https://pr-abc.run402.com/_blob/app.js",
+          cdn_immutable_url: "https://pr-abc.run402.com/_blob/app-ba7816bf.js",
+        });
+      }
+      throw new Error("unexpected: " + call.url);
+    });
+    const sdk = makeSdk(fetch);
+    const asset = await sdk.blobs.put("prj_known", "app.js", { content: "abc" }, { immutable: true });
+
+    // Default scriptTag.
+    const tag = asset.scriptTag();
+    assert.match(tag, /^<script /);
+    assert.match(tag, /src="https:\/\/pr-abc\.run402\.com\/_blob\/app-ba7816bf\.js"/);
+    assert.match(tag, /integrity="sha256-[A-Za-z0-9+/]+={0,2}"/);
+    assert.match(tag, /crossorigin/);
+
+    // Module + defer.
+    const moduleTag = asset.scriptTag({ type: "module", defer: true });
+    assert.match(moduleTag, /type="module"/);
+    assert.match(moduleTag, / defer /);
+
+    // Default linkTag (stylesheet).
+    const link = asset.linkTag();
+    assert.match(link, /^<link /);
+    assert.match(link, /rel="stylesheet"/);
+    assert.match(link, /href="https:\/\/pr-abc\.run402\.com\/_blob\/app-ba7816bf\.js"/);
+    assert.match(link, /integrity="sha256-/);
+
+    // Custom rel + as (preload).
+    const preload = asset.linkTag({ rel: "preload", as: "font" });
+    assert.match(preload, /rel="preload"/);
+    assert.match(preload, /as="font"/);
+
+    // imgTag with alt.
+    const img = asset.imgTag("Company logo");
+    assert.match(img, /^<img /);
+    assert.match(img, /src="https:\/\/pr-abc\.run402\.com\/_blob\/app-ba7816bf\.js"/);
+    assert.match(img, /alt="Company logo"/);
+    // No SRI on <img>.
+    assert.equal(/integrity=/.test(img), false);
+  });
+
+  it("tag emitters escape HTML special chars in alt + url + sri", async () => {
+    // sha256 of "abc"
+    const SHA = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    // URL with characters that need attribute escaping.
+    const HOSTILE_URL = "https://pr-abc.run402.com/_blob/a&b\"c<d>.png";
+    const { fetch } = mockFetch((call) => {
+      if (call.url.endsWith("/storage/v1/uploads")) {
+        return json({
+          upload_id: "u_e", mode: "single", part_count: 1,
+          parts: [{ part_number: 1, url: "https://s3.test/u_e/p1", byte_start: 0, byte_end: 2 }],
+        });
+      }
+      if (call.url.startsWith("https://s3.test/")) {
+        return new Response("", { status: 200, headers: { etag: '"e"' } });
+      }
+      if (call.url.endsWith("/complete")) {
+        return json({
+          key: 'a&b"c<d>.png',
+          size_bytes: 3, sha256: SHA, visibility: "public",
+          content_type: "image/png", immutable_suffix: SHA.slice(0, 8),
+          url: HOSTILE_URL, immutable_url: HOSTILE_URL,
+          cdn_url: HOSTILE_URL, cdn_immutable_url: HOSTILE_URL,
+        });
+      }
+      throw new Error("unexpected: " + call.url);
+    });
+    const sdk = makeSdk(fetch);
+    const asset = await sdk.blobs.put("prj_known", 'a&b"c<d>.png', { content: "abc" }, { immutable: true });
+    const img = asset.imgTag('Bad <alt> "quoted"');
+    assert.match(img, /alt="Bad &lt;alt&gt; &quot;quoted&quot;"/);
+    assert.match(img, /a&amp;b&quot;c&lt;d&gt;\.png/);
+  });
+
+  it("tag emitters throw on non-immutable uploads with an actionable hint", async () => {
+    const { fetch } = mockFetch((call) => {
+      if (call.url.endsWith("/storage/v1/uploads")) {
+        return json({
+          upload_id: "u_n", mode: "single", part_count: 1,
+          parts: [{ part_number: 1, url: "https://s3.test/u_n/p1", byte_start: 0, byte_end: 2 }],
+        });
+      }
+      if (call.url.startsWith("https://s3.test/")) {
+        return new Response("", { status: 200, headers: { etag: '"e"' } });
+      }
+      if (call.url.endsWith("/complete")) {
+        return json({
+          key: "x.png", size_bytes: 3, sha256: null, visibility: "public",
+          content_type: "image/png", immutable_suffix: null,
+          url: "https://app.run402.com/_blob/x.png", immutable_url: null,
+          cdn_url: "https://pr-abc.run402.com/_blob/x.png", cdn_immutable_url: null,
+        });
+      }
+      throw new Error("unexpected: " + call.url);
+    });
+    const sdk = makeSdk(fetch);
+    const asset = await sdk.blobs.put("prj_known", "x.png", { content: "abc" });
+    assert.throws(() => asset.scriptTag(), /immutable: true/);
+    assert.throws(() => asset.linkTag(), /immutable: true/);
+    assert.throws(() => asset.imgTag(), /immutable: true/);
   });
 
   it("leaves integrity fields null on non-immutable upload (sha256 not computed)", async () => {

--- a/sdk/src/namespaces/blobs.test.ts
+++ b/sdk/src/namespaces/blobs.test.ts
@@ -91,7 +91,15 @@ describe("blobs.put", () => {
     });
 
     const sdk = makeSdk(fetch);
-    const result = await sdk.blobs.put("prj_known", "hello.txt", { content: "hello world\n" });
+    // Pass `immutable: false` explicitly: this test verifies the basic flow
+    // shape (init → PUT → complete) and the legacy non-immutable behavior
+    // (no SHA pre-computation, immutable: false propagated to the gateway).
+    // The v1.45 default is `immutable: true`; the dedicated default-and-
+    // tag-emitter tests below cover that path.
+    const result = await sdk.blobs.put(
+      "prj_known", "hello.txt", { content: "hello world\n" },
+      { immutable: false },
+    );
 
     assert.equal(calls.length, 3);
     assert.equal(calls[0]!.url, "https://api.example.test/storage/v1/uploads");
@@ -110,6 +118,52 @@ describe("blobs.put", () => {
     assert.equal(calls[2]!.url, "https://api.example.test/storage/v1/uploads/u_42/complete");
     assert.equal(result.key, "hello.txt");
     assert.equal(result.url, "https://cdn.test/hello.txt");
+  });
+
+  it("defaults to immutable: true (v1.45) — computes SHA + sends content-hashed flag", async () => {
+    let initBody: Record<string, unknown> | null = null;
+    const { fetch } = mockFetch((call) => {
+      if (call.url.endsWith("/storage/v1/uploads")) {
+        initBody = JSON.parse(call.body as string);
+        return json({
+          upload_id: "u_d",
+          mode: "single",
+          part_count: 1,
+          parts: [{ part_number: 1, url: "https://s3.test/u_d/p1", byte_start: 0, byte_end: 2 }],
+        });
+      }
+      if (call.url.startsWith("https://s3.test/")) {
+        return new Response("", { status: 200, headers: { etag: '"e"' } });
+      }
+      if (call.url.endsWith("/complete")) {
+        return json({
+          key: "hello.txt",
+          size_bytes: 3,
+          sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+          visibility: "public",
+          content_type: "text/plain",
+          immutable_suffix: "ba7816bf",
+          url: "https://cdn.test/hello.txt",
+          immutable_url: "https://cdn.test/hello-ba7816bf.txt",
+          cdn_url: "https://pr-abc.run402.com/_blob/hello.txt",
+          cdn_immutable_url: "https://pr-abc.run402.com/_blob/hello-ba7816bf.txt",
+        });
+      }
+      throw new Error("unexpected: " + call.url);
+    });
+    const sdk = makeSdk(fetch);
+    // No opts — relying on v1.45 defaults.
+    const asset = await sdk.blobs.put("prj_known", "hello.txt", { content: "abc" });
+    assert.equal(initBody!.immutable, true);
+    assert.equal(
+      initBody!.sha256,
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    assert.ok(asset.cdnUrl, "cdnUrl populated by default");
+    assert.ok(asset.sri, "sri populated by default");
+    // Tag emitters work without the agent ever passing { immutable: true }.
+    const tag = asset.scriptTag();
+    assert.match(tag, /integrity="sha256-/);
   });
 
   it("attaches parts with etags in multipart mode", async () => {
@@ -137,7 +191,12 @@ describe("blobs.put", () => {
       throw new Error("unexpected");
     });
     const sdk = makeSdk(fetch);
-    await sdk.blobs.put("prj_known", "multi.bin", { bytes: new Uint8Array(12) });
+    // Pin immutable: false — this test asserts on the multipart-complete
+    // shape, not on the sha-computation path.
+    await sdk.blobs.put(
+      "prj_known", "multi.bin", { bytes: new Uint8Array(12) },
+      { immutable: false },
+    );
     const completeBody = JSON.parse(calls[3]!.body as string);
     assert.deepEqual(completeBody.parts, [
       { part_number: 1, etag: '"e1"' },
@@ -393,17 +452,29 @@ describe("blobs.put — AssetRef widening (v1.45)", () => {
     const sdk = makeSdk(fetch);
     const asset = await sdk.blobs.put("prj_known", "app.js", { content: "abc" }, { immutable: true });
 
-    // Default scriptTag.
+    // Default scriptTag — emits `defer` by default (modern best practice).
     const tag = asset.scriptTag();
     assert.match(tag, /^<script /);
     assert.match(tag, /src="https:\/\/pr-abc\.run402\.com\/_blob\/app-ba7816bf\.js"/);
+    assert.match(tag, /\bdefer\b/);
     assert.match(tag, /integrity="sha256-[A-Za-z0-9+/]+={0,2}"/);
     assert.match(tag, /crossorigin/);
+    // No async by default.
+    assert.equal(/\basync\b/.test(tag), false);
 
-    // Module + defer.
+    // Explicit defer: false opts out.
+    const noDefer = asset.scriptTag({ defer: false });
+    assert.equal(/\bdefer\b/.test(noDefer), false);
+
+    // Module + explicit defer.
     const moduleTag = asset.scriptTag({ type: "module", defer: true });
     assert.match(moduleTag, /type="module"/);
-    assert.match(moduleTag, / defer /);
+    assert.match(moduleTag, /\bdefer\b/);
+
+    // async: true overrides defer (mutually exclusive per HTML spec).
+    const asyncTag = asset.scriptTag({ async: true });
+    assert.match(asyncTag, /\basync\b/);
+    assert.equal(/\bdefer\b/.test(asyncTag), false);
 
     // Default linkTag (stylesheet).
     const link = asset.linkTag();
@@ -411,18 +482,23 @@ describe("blobs.put — AssetRef widening (v1.45)", () => {
     assert.match(link, /rel="stylesheet"/);
     assert.match(link, /href="https:\/\/pr-abc\.run402\.com\/_blob\/app-ba7816bf\.js"/);
     assert.match(link, /integrity="sha256-/);
+    assert.match(link, /crossorigin/);
 
-    // Custom rel + as (preload).
+    // Custom rel + as (preload). crossorigin still emitted (required for
+    // SRI to be enforced AND for preload-fetch deduping).
     const preload = asset.linkTag({ rel: "preload", as: "font" });
     assert.match(preload, /rel="preload"/);
     assert.match(preload, /as="font"/);
+    assert.match(preload, /crossorigin/);
 
-    // imgTag with alt.
+    // imgTag — emits loading="lazy" + decoding="async" by default.
     const img = asset.imgTag("Company logo");
     assert.match(img, /^<img /);
     assert.match(img, /src="https:\/\/pr-abc\.run402\.com\/_blob\/app-ba7816bf\.js"/);
     assert.match(img, /alt="Company logo"/);
-    // No SRI on <img>.
+    assert.match(img, /loading="lazy"/);
+    assert.match(img, /decoding="async"/);
+    // No SRI on <img> per HTML spec.
     assert.equal(/integrity=/.test(img), false);
   });
 

--- a/sdk/src/namespaces/blobs.ts
+++ b/sdk/src/namespaces/blobs.ts
@@ -82,11 +82,25 @@ interface UploadCompleteResponse {
   etag?: string;
   url: string | null;
   immutable_url: string | null;
+  /** v1.45+ agent-DX URLs from the gateway. Always on the auto-subdomain
+   *  (`pr-<public_id>.run402.com`) which is guaranteed to work through the
+   *  v1.33 CDN path. May be null on private uploads or older gateway
+   *  versions that don't emit them. */
+  cdn_url?: string | null;
+  cdn_immutable_url?: string | null;
   /** Optional: future gateway versions emit a `cdn` envelope on completion
    *  with the CloudFront invalidation ID + status for mutable overwrites
    *  (and `ready: true` for immutable uploads). When absent (current
    *  gateway), the SDK fills in safe defaults from local information. */
   cdn?: Partial<BlobCdnEnvelope>;
+}
+
+function escapeHtmlAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 /**
@@ -132,6 +146,12 @@ function buildAssetRef(
   const sri = sha ? `sha256-${hexToBase64(sha)}` : null;
   const contentDigest = sha ? `sha-256=:${hexToBase64(sha)}:` : null;
 
+  // v1.45 agent-DX URLs — guaranteed CDN-reachable on the auto-subdomain.
+  // Older gateway versions don't emit them; null in that case (callers fall
+  // back to the preferred-host `url` / `immutableUrl`).
+  const cdnUrl = resp.cdn_immutable_url ?? null;
+  const cdnMutableUrl = resp.cdn_url ?? null;
+
   // The cdn envelope: prefer what the gateway returns; fall back to
   // best-effort defaults so older gateway versions don't break the SDK
   // surface. immutable URLs are always-ready by definition.
@@ -144,9 +164,22 @@ function buildAssetRef(
     hint:
       cdnFromGw.hint ??
       (immutable
-        ? "immutableUrl is ready immediately."
-        : "For mutable URLs, propagation is asynchronous. Prefer immutableUrl in generated HTML/CSS/JS, or call wait_for_cdn_freshness."),
+        ? "Use cdnUrl + scriptTag()/linkTag()/imgTag() — paste-and-go."
+        : "For mutable URLs, propagation is asynchronous. Prefer cdnUrl (immutable, content-hashed) for generated HTML/CSS/JS, or call wait_for_cdn_freshness."),
   };
+
+  // Emitter helpers. Throw with an actionable hint when the SHA is null
+  // (non-immutable upload) — the agent should re-upload with `immutable:
+  // true` to get content-hashed URLs that pair with SRI.
+  function requireImmutable(name: string): { url: string; sri: string } {
+    if (!cdnUrl || !sri) {
+      throw new Error(
+        `${name}() requires an immutable upload (pass { immutable: true } to blobs.put). ` +
+          `Without immutable, there is no SHA to bind for SRI and the URL would change on re-upload.`,
+      );
+    }
+    return { url: cdnUrl, sri };
+  }
 
   return {
     key: resp.key,
@@ -159,11 +192,44 @@ function buildAssetRef(
     contentSha256: sha,
     contentType,
     immutableUrl: resp.immutable_url,
+    cdnUrl,
+    cdnMutableUrl,
     etag,
     sri,
     contentDigest,
     cacheKind,
     cdn,
+
+    scriptTag(opts) {
+      const { url, sri } = requireImmutable("scriptTag");
+      const attrs: string[] = [`src="${escapeHtmlAttr(url)}"`];
+      if (opts?.type === "module") attrs.push(`type="module"`);
+      if (opts?.defer) attrs.push("defer");
+      if (opts?.async) attrs.push("async");
+      attrs.push(`integrity="${escapeHtmlAttr(sri)}"`);
+      attrs.push("crossorigin");
+      return `<script ${attrs.join(" ")}></script>`;
+    },
+
+    linkTag(opts) {
+      const { url, sri } = requireImmutable("linkTag");
+      const rel = opts?.rel ?? "stylesheet";
+      const attrs: string[] = [`rel="${escapeHtmlAttr(rel)}"`];
+      attrs.push(`href="${escapeHtmlAttr(url)}"`);
+      if (opts?.as) attrs.push(`as="${escapeHtmlAttr(opts.as)}"`);
+      attrs.push(`integrity="${escapeHtmlAttr(sri)}"`);
+      attrs.push("crossorigin");
+      return `<link ${attrs.join(" ")}>`;
+    },
+
+    imgTag(alt) {
+      // <img> doesn't take SRI per HTML5 spec — agents who need integrity
+      // for images should fetch + verify Content-Digest server-side. We
+      // still require immutable so the URL is stable across re-deploys.
+      const { url } = requireImmutable("imgTag");
+      const a = alt ?? "";
+      return `<img src="${escapeHtmlAttr(url)}" alt="${escapeHtmlAttr(a)}">`;
+    },
   };
 }
 

--- a/sdk/src/namespaces/blobs.ts
+++ b/sdk/src/namespaces/blobs.ts
@@ -201,17 +201,30 @@ function buildAssetRef(
     cdn,
 
     scriptTag(opts) {
+      // Default `defer: true` — modern best practice. Defer prevents
+      // render-blocking when placed in <head> and is a no-op when placed
+      // at the end of <body> (the script runs after DOMContentLoaded
+      // either way). Pass `{ defer: false }` to opt out for the rare
+      // case requiring synchronous execution. `async` and `defer` are
+      // mutually exclusive; passing async overrides defer.
       const { url, sri } = requireImmutable("scriptTag");
       const attrs: string[] = [`src="${escapeHtmlAttr(url)}"`];
       if (opts?.type === "module") attrs.push(`type="module"`);
-      if (opts?.defer) attrs.push("defer");
-      if (opts?.async) attrs.push("async");
+      const wantsAsync = opts?.async === true;
+      const wantsDefer = opts?.defer ?? !wantsAsync;
+      if (wantsAsync) attrs.push("async");
+      else if (wantsDefer) attrs.push("defer");
       attrs.push(`integrity="${escapeHtmlAttr(sri)}"`);
       attrs.push("crossorigin");
       return `<script ${attrs.join(" ")}></script>`;
     },
 
     linkTag(opts) {
+      // Always emit crossorigin — required for SRI to actually be
+      // enforced. Without crossorigin the browser silently ignores the
+      // integrity attribute (HTML spec). This applies to rel="preload"
+      // too: matching crossorigin on the preload + the eventual fetch is
+      // what lets the browser dedupe instead of double-fetching.
       const { url, sri } = requireImmutable("linkTag");
       const rel = opts?.rel ?? "stylesheet";
       const attrs: string[] = [`rel="${escapeHtmlAttr(rel)}"`];
@@ -223,12 +236,18 @@ function buildAssetRef(
     },
 
     imgTag(alt) {
-      // <img> doesn't take SRI per HTML5 spec — agents who need integrity
-      // for images should fetch + verify Content-Digest server-side. We
-      // still require immutable so the URL is stable across re-deploys.
+      // Defaults: loading="lazy" + decoding="async" — modern best
+      // practice. Lazy is harmless for above-fold images (browsers
+      // handle the heuristic) and a flat win for the much more common
+      // below-fold case. Async decoding moves the decode off the main
+      // thread. Both are baseline-supported in all major browsers.
+      // <img> doesn't accept SRI per HTML5; the URL is content-hashed
+      // so it's still stable across re-deploys. Agents who need
+      // byte-level integrity for images should verify Content-Digest
+      // server-side.
       const { url } = requireImmutable("imgTag");
       const a = alt ?? "";
-      return `<img src="${escapeHtmlAttr(url)}" alt="${escapeHtmlAttr(a)}">`;
+      return `<img src="${escapeHtmlAttr(url)}" alt="${escapeHtmlAttr(a)}" loading="lazy" decoding="async">`;
     },
   };
 }
@@ -270,7 +289,13 @@ export class Blobs {
     }
 
     const contentType = opts.contentType ?? guessContentType(key);
-    const sha256 = opts.immutable ? await sha256Hex(bytes) : undefined;
+    // v1.45 default: `immutable: true`. The agent-DX surface (cdnUrl, sri,
+    // scriptTag/linkTag/imgTag) only works for content-addressed uploads,
+    // so the default reaches for the best path. Pass `{ immutable: false }`
+    // explicitly when you specifically want a non-content-hashed URL
+    // (e.g. very large file where you want to skip the SHA pass).
+    const immutable = opts.immutable ?? true;
+    const sha256 = immutable ? await sha256Hex(bytes) : undefined;
 
     // 1. Init upload — gateway returns presigned S3 URLs for each part.
     const init = await this.client.request<UploadInitResponse>("/storage/v1/uploads", {
@@ -284,7 +309,7 @@ export class Blobs {
         size_bytes: sizeBytes,
         content_type: contentType,
         visibility: opts.visibility ?? "public",
-        immutable: opts.immutable ?? false,
+        immutable,
         sha256,
       },
       context: "initializing upload",

--- a/sdk/src/namespaces/blobs.types.ts
+++ b/sdk/src/namespaces/blobs.types.ts
@@ -50,21 +50,32 @@ export interface BlobCdnEnvelope {
 }
 
 /**
- * Stable URL reference returned by `client.blobs.put`. Includes both the
- * legacy snake_case fields (back-compat with pre-v1.45 SDK) and the v1.45+
- * agent-DX fields:
+ * Stable URL reference returned by `client.blobs.put`.
  *
- *   - `immutableUrl` — content-addressed URL; correct from upload time, no
- *     wait. Prefer this in generated HTML/CSS/JS code.
- *   - `etag`, `sri`, `contentDigest` — strong integrity headers derived from
- *     the SHA-256, suitable for `<script integrity=...>` and Subresource
- *     Integrity verification.
- *   - `cdn` — CloudFront invalidation envelope (mostly meaningful for
- *     mutable overwrites; immutable URLs always have `cdn.ready = true`).
+ * **The recommended agent-DX fields are `cdnUrl` + the tag emitters
+ * (`scriptTag`, `linkTag`, `imgTag`).** These give you a paste-and-go HTML
+ * tag with content-addressed URL + SRI + `crossorigin` already wired. No
+ * decisions about mutable vs. immutable, no `wait_for_cdn_freshness` polls,
+ * no manual integrity attribute construction — the URL is bound to a SHA at
+ * upload time, served from `pr-<public_id>.run402.com` (the host that
+ * always works through the v1.33 CDN), and never invalidated.
  *
- * The legacy fields (`size_bytes`, `sha256`, `immutable_url`) are kept for
- * back-compat — existing consumers that destructure those keys continue to
- * work unchanged.
+ * The other fields are present for compatibility / advanced use:
+ *   - `url` / `immutable_url` (snake_case): legacy v1.0+ fields. May be on
+ *     a claimed-subdomain or custom-domain host (which is "prettier" but
+ *     currently can NOT serve `/_blob/*` through the CDN — those subdomains'
+ *     KVS values lack a `project_id`. Fix tracked separately).
+ *   - `immutableUrl`: same value as `immutable_url`, camelCase.
+ *   - `cdnMutableUrl`: mutable form of the auto-subdomain URL — useful only
+ *     when you need a stable URL that always reflects the latest content.
+ *     Comes with eventual-consistency caveats (CloudFront invalidation is
+ *     async); prefer `cdnUrl` for generated code.
+ *   - `etag`, `sri`, `contentDigest`: integrity values derived from the
+ *     SHA-256.
+ *   - `cdn`: CloudFront invalidation envelope.
+ *
+ * Tag emitters require the SHA-256 (only computed when uploaded with
+ * `immutable: true`). On non-immutable uploads, calling them throws.
  */
 export interface AssetRef {
   // ---- v1.0+ legacy fields (back-compat) -----------------------------------
@@ -75,20 +86,27 @@ export interface AssetRef {
   url: string | null;
   immutable_url: string | null;
   // ---- v1.45+ agent-DX fields ---------------------------------------------
-  /** Same value as `size_bytes`, just the camelCase form used by the new
-   *  agent-facing surface. */
+  /** Same value as `size_bytes`, camelCase form. */
   size: number;
   /** Hex SHA-256 of the bytes. Same as `sha256` (camelCase alias). */
   contentSha256: string | null;
   /** Effective Content-Type (auto-detected from the key extension when not
    *  set explicitly via `BlobPutOptions.contentType`). */
   contentType: string;
-  /** Same value as `immutable_url`. Camel-case alias for the v1.45+ surface.
-   *  **Prefer this in generated HTML/CSS/JS** — it never needs cache
-   *  invalidation. */
+  /** Same value as `immutable_url` (preferred-host form), camelCase. */
   immutableUrl: string | null;
-  /** Strong ETag of the form `"sha256-<hex>"`. Null when `sha256` is null
-   *  (only computed when `--immutable` was passed at upload). */
+  /** **The recommended URL for generated HTML/CSS/JS.** Content-addressed
+   *  (immutable), served from the auto-subdomain
+   *  (`pr-<public_id>.run402.com/_blob/<key-with-suffix>.<ext>`) which is
+   *  guaranteed to work through the v1.33 CDN path. Pair with `sri` for
+   *  Subresource Integrity. Null on non-immutable uploads (the SHA isn't
+   *  computed) and on private uploads. */
+  cdnUrl: string | null;
+  /** Mutable form of the auto-subdomain URL. Use only when a stable URL
+   *  must always reflect the latest content (eventual consistency on
+   *  re-upload). Prefer `cdnUrl` for generated code. */
+  cdnMutableUrl: string | null;
+  /** Strong ETag of the form `"sha256-<hex>"`. Null when `sha256` is null. */
   etag: string | null;
   /** Browser SRI form: `sha256-<base64>`. Use as the `integrity` attribute
    *  value in `<script>`/`<link>` tags. */
@@ -97,9 +115,49 @@ export interface AssetRef {
   contentDigest: string | null;
   /** Semantic cache-kind hint matching the gateway's response header. */
   cacheKind: BlobCacheKind;
-  /** CloudFront invalidation envelope for the mutable URL. Always populated;
-   *  for immutable uploads `cdn.ready === true`. */
+  /** CloudFront invalidation envelope. For immutable uploads `cdn.ready ===
+   *  true` and no further action is needed. */
   cdn: BlobCdnEnvelope;
+
+  // ---- v1.45+ HTML tag emitters --------------------------------------------
+  // These are inline methods (not network calls). They construct the
+  // exact HTML tag an agent would otherwise have to assemble by hand.
+  // Throw when `cdnUrl` is null (non-immutable upload); use `--immutable`
+  // at upload time to guarantee these work.
+
+  /**
+   * Returns a ready-to-paste `<script>` tag with the content-addressed
+   * URL + Subresource Integrity + `crossorigin`. The browser will refuse
+   * to execute the script if the bytes don't match the SHA.
+   *
+   * @example
+   *   const asset = await client.blobs.put(p, "app.js", { content }, { immutable: true });
+   *   html += asset.scriptTag();
+   *   // → <script src="https://pr-abc.run402.com/_blob/app-3a7fc02e.js" integrity="sha256-…" crossorigin></script>
+   */
+  scriptTag(opts?: { type?: "module" | "text/javascript"; defer?: boolean; async?: boolean }): string;
+
+  /**
+   * Returns a ready-to-paste `<link>` tag (default `rel="stylesheet"`)
+   * with content-addressed URL + SRI + `crossorigin`.
+   *
+   * @example
+   *   asset.linkTag();                       // stylesheet by default
+   *   asset.linkTag({ rel: "preload", as: "font" });
+   */
+  linkTag(opts?: { rel?: string; as?: string }): string;
+
+  /**
+   * Returns a ready-to-paste `<img>` tag with the content-addressed URL.
+   * `alt` is the image's accessibility text (default `""`). Browsers don't
+   * support SRI on `<img>`, so no `integrity` attribute is emitted —
+   * integrity is still verifiable by reading `Content-Digest` server-side.
+   *
+   * @example
+   *   asset.imgTag("Company logo")
+   *   // → <img src="https://pr-abc.run402.com/_blob/logo-a1b2c3d4.png" alt="Company logo">
+   */
+  imgTag(alt?: string): string;
 }
 
 /**

--- a/sdk/src/namespaces/blobs.types.ts
+++ b/sdk/src/namespaces/blobs.types.ts
@@ -19,7 +19,20 @@ export interface BlobPutOptions {
   contentType?: string;
   /** Default: `"public"`. Public blobs get a CDN URL; private requires auth. */
   visibility?: BlobVisibility;
-  /** When true, the returned URL includes a content-hash suffix — overwrites produce distinct URLs. Forces sha256 computation. */
+  /**
+   * Default (v1.45+): `true`. Returns an `AssetRef` with `cdnUrl` populated
+   * and the `scriptTag()` / `linkTag()` / `imgTag()` emitters working —
+   * this is the agent-DX flow (paste-and-go HTML with SRI baked in).
+   *
+   * Cost: one SHA-256 pass over the bytes on the client side. For small
+   * assets (the typical case — images, JS, CSS, fonts, JSON < 1 MB) it's
+   * a few ms dominated by network. Pass `false` to skip the SHA pass for
+   * very large uploads where you specifically don't need a content-hashed
+   * URL or SRI.
+   *
+   * When `false`, the returned `AssetRef` has `cdnUrl: null`, `sri: null`,
+   * and the tag emitters throw with an "immutable: true required" hint.
+   */
   immutable?: boolean;
 }
 
@@ -130,32 +143,54 @@ export interface AssetRef {
    * URL + Subresource Integrity + `crossorigin`. The browser will refuse
    * to execute the script if the bytes don't match the SHA.
    *
+   * **Defaults:** `defer: true`. Modern best practice — non-render-
+   * blocking when placed in `<head>` and a no-op at end of `<body>`.
+   * Pass `{ defer: false }` for the rare case requiring sync execution.
+   * `async: true` overrides defer (the two are mutually exclusive).
+   *
    * @example
-   *   const asset = await client.blobs.put(p, "app.js", { content }, { immutable: true });
+   *   const asset = await client.blobs.put(p, "app.js", { content });
    *   html += asset.scriptTag();
-   *   // → <script src="https://pr-abc.run402.com/_blob/app-3a7fc02e.js" integrity="sha256-…" crossorigin></script>
+   *   // → <script src="https://pr-abc.run402.com/_blob/app-3a7fc02e.js" defer integrity="sha256-…" crossorigin></script>
+   *
+   *   asset.scriptTag({ type: "module" });
+   *   // → <script src="…" type="module" defer integrity="…" crossorigin></script>
    */
   scriptTag(opts?: { type?: "module" | "text/javascript"; defer?: boolean; async?: boolean }): string;
 
   /**
    * Returns a ready-to-paste `<link>` tag (default `rel="stylesheet"`)
-   * with content-addressed URL + SRI + `crossorigin`.
+   * with content-addressed URL + SRI + `crossorigin`. `crossorigin` is
+   * always emitted — required for SRI to actually be enforced (also
+   * required for rel="preload" to dedupe with the matching fetch).
    *
    * @example
-   *   asset.linkTag();                       // stylesheet by default
+   *   asset.linkTag();                            // stylesheet
    *   asset.linkTag({ rel: "preload", as: "font" });
+   *   asset.linkTag({ rel: "modulepreload" });
    */
   linkTag(opts?: { rel?: string; as?: string }): string;
 
   /**
    * Returns a ready-to-paste `<img>` tag with the content-addressed URL.
-   * `alt` is the image's accessibility text (default `""`). Browsers don't
-   * support SRI on `<img>`, so no `integrity` attribute is emitted —
-   * integrity is still verifiable by reading `Content-Digest` server-side.
+   *
+   * **Defaults:** `loading="lazy"` + `decoding="async"`. Modern best
+   * practice — lazy loads below-fold images on demand, async decoding
+   * moves the decode off the main thread. Both are baseline-supported
+   * in all major browsers. Agents who specifically need an above-fold
+   * eager image can wrap the result and override.
+   *
+   * Browsers don't support SRI on `<img>`, so no `integrity` attribute
+   * is emitted. The URL is content-hashed so it's still stable across
+   * re-deploys; for byte-level verification, read `Content-Digest`
+   * server-side.
+   *
+   * `alt` is the image's accessibility text (default `""` for decorative
+   * images). Pass a description when the image conveys information.
    *
    * @example
    *   asset.imgTag("Company logo")
-   *   // → <img src="https://pr-abc.run402.com/_blob/logo-a1b2c3d4.png" alt="Company logo">
+   *   // → <img src="https://pr-abc.run402.com/_blob/logo-a1b2c3d4.png" alt="Company logo" loading="lazy" decoding="async">
    */
   imgTag(alt?: string): string;
 }


### PR DESCRIPTION
## Summary

The agent-DX rewrite of `client.blobs.put` return shape. The agent's flow becomes one line:

```ts
const asset = await client.blobs.put(p, "logo.png", { bytes }, { immutable: true });
html += asset.imgTag("Company logo");
// → <img src="https://pr-abc.run402.com/_blob/logo-3a7fc02e.png" alt="Company logo">

const styles = await client.blobs.put(p, "styles.css", { content }, { immutable: true });
html += styles.linkTag();
// → <link rel="stylesheet" href="https://pr-abc.run402.com/_blob/styles-aabbccdd.css" integrity="sha256-…" crossorigin>

const app = await client.blobs.put(p, "app.js", { content }, { immutable: true });
html += app.scriptTag({ type: "module" });
// → <script src="https://pr-abc.run402.com/_blob/app-deadbeef.js" type="module" integrity="sha256-…" crossorigin></script>
```

No URL-form decision (just paste it), no SRI plumbing (baked in), no `wait_for_cdn_freshness` follow-up (URL is content-addressed → always served correctly first try).

## Changes

### `AssetRef`
- **NEW** `cdnUrl` — content-addressed URL on `pr-<public_id>.run402.com`, the host guaranteed to work through the v1.33 `/_blob/*` CDN behavior. Null on non-immutable or private uploads.
- **NEW** `cdnMutableUrl` — mutable form on auto-subdomain. Eventual-consistency caveats; prefer `cdnUrl` for generated code.
- **NEW** `scriptTag(opts?)` / `linkTag(opts?)` / `imgTag(alt?)` — paste-and-go HTML tag emitters. Throw with an actionable hint on non-immutable uploads.
- All existing fields (`url`, `immutable_url`, `immutableUrl`, `etag`, `sri`, `contentDigest`, `cdn`) kept unchanged.

### Tag emitters
- `scriptTag({ type?, defer?, async? })` — emits `<script>` with `integrity` + `crossorigin`.
- `linkTag({ rel = "stylesheet", as? })` — emits `<link>` with `integrity` + `crossorigin`. Supports `preload` / `prefetch` via `rel`.
- `imgTag(alt = "")` — emits `<img>` with `src` + `alt`. No `integrity` (HTML5 doesn't support SRI on `<img>`), but the URL is content-hashed so it's still stable across re-deploys.
- All inputs HTML-attribute-escaped.
- Throw on non-immutable uploads with a hint pointing at `{ immutable: true }`.

### Docs
- `SKILL.md` — `blob_put` rewritten to lead with the tag-emitter flow. AssetRef field reference reorganized so the agent-DX fields come first.
- `cli/llms-cli.txt` — same agent-DX guidance for the CLI / SDK reference section.

## Coordinated change

Pairs with the gateway PR [run402-private#73](https://github.com/kychee-com/run402-private/pull/73) which emits `cdn_url` + `cdn_immutable_url` on the upload-completion response. The SDK falls back gracefully against older gateway versions: `cdnUrl` is null and the tag emitters throw with an actionable hint.

## Test plan

- [x] `npx tsc --noEmit` clean (SDK + MCP + CLI)
- [x] SDK blob tests pass: 25 / 25 (4 new — `cdnUrl` widening, tag-emitter shape, HTML attribute escaping, non-immutable error)
- [x] Existing tests still pass: `client.blobs.put`, `get`, `ls`, `rm`, `sign`, `diagnoseUrl`, `waitFresh`
- [ ] After merge: rebuild SDK + smoke-test against deployed gateway: full upload returns the new fields populated, tag emitters render valid HTML pointing at the auto-subdomain URL, browser fetch of that URL returns 200 with matching SHA

## Followup (separate PR)

Make claimed subdomains and custom domains serve `/_blob/*` through the v1.33 CDN. Today they 404 from `BlobRoutingV2` because the KVS values lack `project_id`. The SDK steers agents around this via the auto-subdomain URL — but it's worth fixing so `result.url` (preferred host) becomes embed-safe too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)