### PR TITLE
ci(test): include sdk/src tests, quote globs so Node expands them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,12 @@ jobs:
       - run: npm run build
       - run: npm run test:skill
       - run: npm run test:sync
-      # Use bash globstar so `**` recurses into nested dirs AND matches files
-      # at depth 0. Without this, files like src/keystore.test.ts (at depth 0)
-      # were silently skipped by CI for 20+ days. Also explicitly run the
-      # core/src tests, which were never matched by the old glob.
-      - shell: bash
-        run: |
-          shopt -s globstar
-          node --experimental-test-module-mocks --test --import tsx src/**/*.test.ts core/src/**/*.test.ts
+      # Quote the globs so Node handles expansion natively. Node's --test
+      # glob matching recurses into nested dirs AND matches depth-0 files,
+      # so it works regardless of the shell's globstar support. (Earlier
+      # we relied on `shopt -s globstar`, which silently dropped sdk/src
+      # tests because they weren't listed and dropped depth-0 files on
+      # systems where globstar isn't enabled.)
+      - run: node --experimental-test-module-mocks --test --import tsx 'src/**/*.test.ts' 'core/src/**/*.test.ts' 'sdk/src/**/*.test.ts'
       - run: npm run test:e2e
       - run: npm run test:integration


### PR DESCRIPTION
## Summary

Two small fixes to `.github/workflows/test.yml`:

1. **Add `sdk/src/**/*.test.ts` to the unit-test step.** The previous bash globstar block listed only `src/` and `core/src/`, silently dropping every SDK test from CI — including the regression tests added in v1.50.1 for [#123](https://github.com/kychee-com/run402/issues/123) / [#127](https://github.com/kychee-com/run402/issues/127) / [#128](https://github.com/kychee-com/run402/issues/128) / [#134](https://github.com/kychee-com/run402/issues/134) / [#135](https://github.com/kychee-com/run402/issues/135) / [#138](https://github.com/kychee-com/run402/issues/138) / [#140](https://github.com/kychee-com/run402/issues/140) / [#145](https://github.com/kychee-com/run402/issues/145). Locally `npm test` ran them; CI didn't.

2. **Quote the glob patterns so Node expands them natively.** Node's `--test` glob matching always recurses and matches depth-0 files, regardless of shell. Removes the dependency on `shopt -s globstar` (a no-op on bash <4 — including macOS's default bash 3.2). More robust and shorter.

## Local verification

```
node --experimental-test-module-mocks --test --import tsx 'src/**/*.test.ts' 'core/src/**/*.test.ts' 'sdk/src/**/*.test.ts'
ℹ tests 453
ℹ pass 453
ℹ fail 0
```

vs the previous bash-expanded form on a bash 3.2 host (no globstar): 404 tests. ~49 SDK tests had been silently dropped.

## Why a separate PR

Spotted while inspecting CI for the workspaces conversion ([#147](https://github.com/kychee-com/run402/pull/147)) — independent gap, not strictly tied to that change. `functions/src/**/*.test.ts` is **not** added in this PR because the functions tests import `jsonwebtoken`, which only resolves cleanly from `functions/node_modules/` after the workspaces conversion lands. That follow-up will stack on #147.

## Test plan

- [x] Local: command runs with quoted globs, picks up 453 tests including SDK
- [x] No diff in test results besides the 49 SDK tests being added
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)