### PR TITLE
ci(test): include functions/src tests in the unit-test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,6 @@ jobs:
       # we relied on `shopt -s globstar`, which silently dropped sdk/src
       # tests because they weren't listed and dropped depth-0 files on
       # systems where globstar isn't enabled.)
-      - run: node --experimental-test-module-mocks --test --import tsx 'src/**/*.test.ts' 'core/src/**/*.test.ts' 'sdk/src/**/*.test.ts'
+      - run: node --experimental-test-module-mocks --test --import tsx 'src/**/*.test.ts' 'core/src/**/*.test.ts' 'sdk/src/**/*.test.ts' 'functions/src/**/*.test.ts'
       - run: npm run test:e2e
       - run: npm run test:integration


### PR DESCRIPTION
## Summary

Adds `functions/src/**/*.test.ts` to the CI unit-test glob list. After [#147](https://github.com/kychee-com/run402/pull/147) hoisted `jsonwebtoken` to the root `node_modules/` via npm workspaces, the functions tests now resolve their deps under a single `npm ci` and can finally be run in CI.

## Why a separate PR

[#148](https://github.com/kychee-com/run402/pull/148) deliberately deferred functions tests because they import `jsonwebtoken` and would have failed on `Cannot find module` without workspaces in place. With #147 merged, this dependency is gone — this is now safe.

## Local verification

```
node --experimental-test-module-mocks --test --import tsx 'src/**/*.test.ts' 'core/src/**/*.test.ts' 'sdk/src/**/*.test.ts' 'functions/src/**/*.test.ts'
ℹ tests 470
ℹ pass 470
ℹ fail 0
```

vs 453 in #148. 17 functions tests previously skipped by CI now run.

## Test plan

- [x] Local: command runs, 17 additional tests picked up, all 470 pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)