### PR TITLE
feat(deploy): add list() and events() across SDK + MCP + CLI (#137)

### DIFF
--- a/cli/lib/deploy-v2.mjs
+++ b/cli/lib/deploy-v2.mjs
@@ -77,9 +77,36 @@ Output:
   stderr: one JSON event per line (suppressed with --quiet)
 `;
 
+const LIST_HELP = `run402 deploy list — List recent deploy operations for a project
+
+Usage:
+  run402 deploy list [--project <id>] [--limit <n>]
+
+Options:
+  --project <id>          Project ID to list operations for (default: active project)
+  --limit <n>             Maximum number of operations to return
+
+Output:
+  stdout: { "status": "ok", "operations": [...], "cursor": "..." | null }
+`;
+
+const EVENTS_HELP = `run402 deploy events — Fetch the recorded event stream for a deploy operation
+
+Usage:
+  run402 deploy events <operation_id> [--project <id>]
+
+Options:
+  --project <id>          Project ID that owns the operation (default: active project)
+
+Output:
+  stdout: { "status": "ok", "events": [...] }
+`;
+
 export async function runDeployV2(sub, args) {
   if (sub === "apply") return await applyCmd(args);
   if (sub === "resume") return await resumeCmd(args);
+  if (sub === "list") return await listCmd(args);
+  if (sub === "events") return await eventsCmd(args);
   console.error(JSON.stringify({ status: "error", message: `Unknown deploy subcommand: ${sub}` }));
   process.exit(1);
 }
@@ -181,6 +208,50 @@ async function resumeCmd(args) {
     const result = await getSdk().deploy.resume(opts.operationId, {
       onEvent: makeStderrEventWriter(opts.quiet),
     });
+    console.log(JSON.stringify({ status: "ok", ...result }, null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function listCmd(args) {
+  const opts = { project: null, limit: null };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--help" || args[i] === "-h") { console.log(LIST_HELP); process.exit(0); }
+    if (args[i] === "--project" && args[i + 1]) { opts.project = args[++i]; continue; }
+    if (args[i] === "--limit" && args[i + 1]) { opts.limit = Number(args[++i]); continue; }
+  }
+
+  const project = resolveProjectId(opts.project);
+  allowanceAuthHeaders("/deploy/v2/operations");
+
+  try {
+    const sdkOpts = { project };
+    if (opts.limit !== null && Number.isFinite(opts.limit)) sdkOpts.limit = opts.limit;
+    const result = await getSdk().deploy.list(sdkOpts);
+    console.log(JSON.stringify({ status: "ok", ...result }, null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function eventsCmd(args) {
+  const opts = { operationId: null, project: null };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--help" || args[i] === "-h") { console.log(EVENTS_HELP); process.exit(0); }
+    if (args[i] === "--project" && args[i + 1]) { opts.project = args[++i]; continue; }
+    if (!args[i].startsWith("-") && !opts.operationId) opts.operationId = args[i];
+  }
+  if (!opts.operationId) {
+    console.error(JSON.stringify({ status: "error", message: "Usage: run402 deploy events <operation_id>" }));
+    process.exit(1);
+  }
+
+  const project = resolveProjectId(opts.project);
+  allowanceAuthHeaders("/deploy/v2/operations");
+
+  try {
+    const result = await getSdk().deploy.events(opts.operationId, { project });
     console.log(JSON.stringify({ status: "ok", ...result }, null, 2));
   } catch (err) {
     reportSdkError(err);

--- a/cli/lib/deploy.mjs
+++ b/cli/lib/deploy.mjs
@@ -258,11 +258,15 @@ export async function run(args) {
   // Subcommand dispatch (v1.34+):
   //   run402 deploy apply  ...    → unified deploy primitive (deploy.apply)
   //   run402 deploy resume <op>   → resume an activation_pending operation
+  //   run402 deploy list          → list recent deploy operations
+  //   run402 deploy events <op>   → fetch recorded event stream for an operation
   //   run402 deploy --manifest …  → legacy bundle deploy (still works)
   const sub = args[0];
   switch (sub) {
     case "apply":
-    case "resume": {
+    case "resume":
+    case "list":
+    case "events": {
       const { runDeployV2 } = await import("./deploy-v2.mjs");
       await runDeployV2(sub, args.slice(1));
       return;

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -175,6 +175,15 @@ run402 deploy resume <operation_id>
 
 The gateway re-runs only the failed phase forward — SQL is never replayed.
 
+**Inspect deploy history**: list recent operations for a project, or pull the recorded phase-event stream for a specific operation (after the fact — for live progress events during an in-flight deploy, the `apply` command already streams them on stderr):
+
+```bash
+run402 deploy list --project prj_... --limit 10
+run402 deploy events <operation_id> --project prj_...
+```
+
+`list` returns `{ operations: [...], cursor }` (page through with `--cursor` against the gateway when the cursor is non-null). `events` returns the same `DeployEvent` shapes that `apply` emits inline.
+
 **Migration registry**: each migration is identified by `(id, checksum)`. Re-shipping the same `id` + same SQL is a registry noop; same `id` + different SQL is a hard error (`MIGRATION_CHECKSUM_MISMATCH`). Ship idempotent migrations (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS` in a `DO` block) and re-deploys are free.
 
 ---
@@ -357,7 +366,11 @@ SQL supports DDL + queries, returns JSON. REST uses PostgREST syntax (`select=`,
 User auth: password + Google OAuth. See "User Auth" section below.
 
 ### deploy
-- `run402 deploy --manifest app.json [--project <id>]`
+- `run402 deploy --manifest app.json [--project <id>]` — legacy bundle deploy, routes through the v2 primitive
+- `run402 deploy apply --manifest app.json [--project <id>] [--quiet]` — unified deploy primitive (v1.34+)
+- `run402 deploy resume <operation_id> [--quiet]` — re-run a stuck operation forward
+- `run402 deploy list [--project <id>] [--limit <n>]` — list recent deploy operations
+- `run402 deploy events <operation_id> [--project <id>]` — fetch the recorded event stream for an operation
 
 Requires active tier and a provisioned project. Deploys to an existing project: runs migrations, applies RLS, sets secrets, deploys functions, deploys static site, and claims subdomain. The manifest must include `project_id` (or use `--project` flag, or omit both to use the active project).
 

--- a/sdk/src/namespaces/deploy.test.ts
+++ b/sdk/src/namespaces/deploy.test.ts
@@ -1114,3 +1114,121 @@ describe("Deploy.start (events iterator lifecycle)", () => {
     assert.notEqual(winner, "timeout", "events() iterator hung after failed deploy");
   });
 });
+
+describe("Deploy.list", () => {
+  it("GETs /deploy/v2/operations with the project's apikey", async () => {
+    const w = makeWiring();
+    const sample = {
+      operations: [
+        {
+          operation_id: "op_1",
+          project_id: "prj_test",
+          plan_id: "plan_1",
+          status: "ready",
+          base_release_id: null,
+          target_release_id: "rel_1",
+          release_id: "rel_1",
+          urls: { project: "https://prj.run402.test" },
+          payment_required: null,
+          error: null,
+          activate_attempts: 1,
+          last_activate_attempt_at: null,
+          created_at: "2026-04-29T00:00:00Z",
+          updated_at: "2026-04-29T00:00:01Z",
+        },
+      ],
+      cursor: null,
+    };
+    w.setHandler((req) => {
+      if (req.path === "/deploy/v2/operations") return sample;
+      throw new Error(`unexpected ${req.path}`);
+    });
+
+    const deploy = new Deploy(w.client);
+    const result = await deploy.list({ project: "prj_test" });
+
+    assert.equal(result.operations.length, 1);
+    assert.equal(result.operations[0].operation_id, "op_1");
+    assert.equal(result.cursor, null);
+    assert.equal(w.requests.length, 1);
+    assert.equal(w.requests[0].path, "/deploy/v2/operations");
+  });
+
+  it("forwards limit as a query string", async () => {
+    const w = makeWiring();
+    w.setHandler(() => ({ operations: [], cursor: null }));
+    const deploy = new Deploy(w.client);
+    await deploy.list({ project: "prj_test", limit: 5 });
+    assert.equal(w.requests[0].path, "/deploy/v2/operations?limit=5");
+  });
+});
+
+describe("Deploy.events", () => {
+  it("GETs /deploy/v2/operations/:id/events and returns the event list", async () => {
+    const w = makeWiring();
+    const sample = {
+      events: [
+        { type: "plan.started" },
+        { type: "ready", releaseId: "rel_1", urls: { project: "https://prj.run402.test" } },
+      ],
+    };
+    w.setHandler((req) => {
+      if (req.path === "/deploy/v2/operations/op_42/events") return sample;
+      throw new Error(`unexpected ${req.path}`);
+    });
+
+    const deploy = new Deploy(w.client);
+    const result = await deploy.events("op_42", { project: "prj_test" });
+
+    assert.equal(result.events.length, 2);
+    assert.equal(result.events[0].type, "plan.started");
+    const last = result.events[1] as Extract<DeployEvent, { type: "ready" }>;
+    assert.equal(last.releaseId, "rel_1");
+  });
+
+  it("rejects empty operation id without issuing a request", async () => {
+    const w = makeWiring();
+    const deploy = new Deploy(w.client);
+    await assert.rejects(
+      () => deploy.events("", { project: "prj_test" }),
+      (err: unknown) =>
+        err instanceof Run402DeployError &&
+        (err as Run402DeployError).code === "OPERATION_NOT_FOUND",
+    );
+    assert.equal(w.requests.length, 0);
+  });
+
+  it("rejects non-`op_`-prefixed operation id without issuing a request", async () => {
+    const w = makeWiring();
+    const deploy = new Deploy(w.client);
+    await assert.rejects(
+      () => deploy.events("notop_xx", { project: "prj_test" }),
+      (err: unknown) =>
+        err instanceof Run402DeployError &&
+        (err as Run402DeployError).code === "OPERATION_NOT_FOUND",
+    );
+    assert.equal(w.requests.length, 0);
+  });
+
+  it("translates a gateway 404 into a structured Run402DeployError", async () => {
+    const w = makeWiring();
+    w.setHandler((req) => {
+      if (req.path === "/deploy/v2/operations/op_missing/events") {
+        throw new ApiError(
+          "API error while fetching deploy events (HTTP 404)",
+          404,
+          { code: "operation_not_found", message: "operation not found" },
+          "fetching deploy events",
+        );
+      }
+      throw new Error(`unexpected ${req.path}`);
+    });
+    const deploy = new Deploy(w.client);
+    await assert.rejects(
+      () => deploy.events("op_missing", { project: "prj_test" }),
+      (err: unknown) =>
+        err instanceof Run402DeployError &&
+        (err as Run402DeployError).code === "OPERATION_NOT_FOUND",
+    );
+  });
+});

--- a/sdk/src/namespaces/deploy.ts
+++ b/sdk/src/namespaces/deploy.ts
@@ -34,6 +34,8 @@ import type {
   ContentRef,
   ContentSource,
   DeployEvent,
+  DeployEventsResponse,
+  DeployListResponse,
   DeployOperation,
   DeployResult,
   FileSet,
@@ -223,6 +225,60 @@ export class Deploy {
       `/deploy/v2/operations/${operationId}`,
       { headers, context: "fetching deploy operation" },
     );
+  }
+
+  /**
+   * List recent deploy operations for a project. The endpoint requires
+   * `apikey` auth, so `project` is required. `limit` is forwarded to the
+   * gateway as a query string when set; the gateway picks a default
+   * otherwise.
+   */
+  async list(opts: {
+    project: string;
+    limit?: number;
+  }): Promise<DeployListResponse> {
+    const headers = await apikeyHeaders(this.client, opts.project);
+    const qs = new URLSearchParams();
+    if (opts.limit !== undefined) qs.set("limit", String(opts.limit));
+    const path =
+      qs.toString().length > 0
+        ? `/deploy/v2/operations?${qs.toString()}`
+        : `/deploy/v2/operations`;
+    return this.client.request<DeployListResponse>(path, {
+      headers,
+      context: "listing deploy operations",
+    });
+  }
+
+  /**
+   * Fetch the synthesized phase event stream for an operation. Returns the
+   * events the gateway has recorded so far — useful for inspecting a deploy
+   * after the fact, or resuming an event subscription from a different
+   * process. For live subscription during an in-flight deploy, use
+   * {@link Deploy.start} and iterate `op.events()`.
+   *
+   * The endpoint requires `apikey` auth, so `project` is required.
+   */
+  async events(
+    operationId: string,
+    opts: { project: string },
+  ): Promise<DeployEventsResponse> {
+    if (!operationId || !operationId.startsWith("op_")) {
+      throw new Run402DeployError(`Invalid operation id: "${operationId}"`, {
+        code: "OPERATION_NOT_FOUND",
+        retryable: false,
+        context: "fetching deploy events",
+      });
+    }
+    const headers = await apikeyHeaders(this.client, opts.project);
+    try {
+      return await this.client.request<DeployEventsResponse>(
+        `/deploy/v2/operations/${encodeURIComponent(operationId)}/events`,
+        { headers, context: "fetching deploy events" },
+      );
+    } catch (err) {
+      throw translateDeployError(err, "events", null, operationId);
+    }
   }
 
   /**

--- a/sdk/src/namespaces/deploy.types.ts
+++ b/sdk/src/namespaces/deploy.types.ts
@@ -301,6 +301,22 @@ export interface OperationSnapshot {
   updated_at: string;
 }
 
+/** Response from `GET /deploy/v2/operations`. The gateway may return a
+ *  pagination cursor when there are more operations than the requested
+ *  page size; clients pass it back as `?cursor=` to fetch the next page. */
+export interface DeployListResponse {
+  operations: OperationSnapshot[];
+  cursor?: string | null;
+}
+
+/** Response from `GET /deploy/v2/operations/:id/events`. Returns the
+ *  synthesized phase event stream the gateway has recorded so far for the
+ *  operation. Same shape as the events emitted by `r.deploy.start().events()`
+ *  during an in-flight deploy. */
+export interface DeployEventsResponse {
+  events: DeployEvent[];
+}
+
 /** Wire-shape for a structured deploy error from the gateway. The SDK
  *  translates this into `Run402DeployError` for callers. The gateway is
  *  permitted to omit `message` for terse validation errors (e.g. just

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { deploySiteSchema, handleDeploySite } from "./tools/deploy-site.js";
 import { deploySiteDirSchema, handleDeploySiteDir } from "./tools/deploy-site-dir.js";
 import { deploySchema, handleDeploy } from "./tools/deploy.js";
 import { deployResumeSchema, handleDeployResume } from "./tools/deploy-resume.js";
+import { deployListSchema, handleDeployList } from "./tools/deploy-list.js";
+import { deployEventsSchema, handleDeployEvents } from "./tools/deploy-events.js";
 import { claimSubdomainSchema, handleClaimSubdomain } from "./tools/subdomain.js";
 import { deleteSubdomainSchema, handleDeleteSubdomain } from "./tools/subdomain.js";
 import { deployFunctionSchema, handleDeployFunction } from "./tools/deploy-function.js";
@@ -357,6 +359,20 @@ server.tool(
   "Resume a deploy operation that ended in `activation_pending` or `schema_settling` (e.g. transient gateway failure between SQL commit and the pointer-swap activation). The gateway re-runs only the failed phase forward — SQL is never replayed. Idempotent: calling on an already-terminal operation returns the snapshot without re-running.",
   deployResumeSchema,
   async (args) => handleDeployResume(args),
+);
+
+server.tool(
+  "deploy_list",
+  "List recent deploy operations for a project. Returns operation_id, status, release_id, and timestamps. Use this to build deploy-history UIs or to find a recent operation_id to feed into `deploy_resume` / `deploy_events`. Pass `limit` to bound the result set; the gateway also returns a `cursor` for pagination when there are more.",
+  deployListSchema,
+  async (args) => handleDeployList(args),
+);
+
+server.tool(
+  "deploy_events",
+  "Fetch the recorded phase-event stream for a deploy operation. Returns the same `DeployEvent` shapes the `deploy` tool emits inline during an in-flight deploy — useful for inspecting a deploy after the fact (e.g., a deploy that the agent didn't observe directly, or one being resumed from a different process).",
+  deployEventsSchema,
+  async (args) => handleDeployEvents(args),
 );
 
 server.tool(

--- a/src/tools/deploy-events.ts
+++ b/src/tools/deploy-events.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { getSdk } from "../sdk.js";
+import { mapSdkError } from "../errors.js";
+import { requireAllowanceAuth } from "../allowance-auth.js";
+import { Run402DeployError } from "../../sdk/dist/index.js";
+
+/**
+ * MCP `deploy_events` tool — fetch the recorded phase event stream for a
+ * deploy operation.
+ *
+ * Wraps `r.deploy.events()` over `GET /deploy/v2/operations/:id/events`.
+ * Useful for inspecting a deploy after the fact (no live subscription) —
+ * for live progress events during an in-flight deploy, the `deploy` tool
+ * already returns them inline in its response.
+ */
+
+export const deployEventsSchema = {
+  operation_id: z
+    .string()
+    .describe(
+      "Operation id returned by a prior `deploy` call. Must start with `op_`.",
+    ),
+  project_id: z
+    .string()
+    .describe(
+      "Project ID that owns the operation. Required (apikey-gated endpoint).",
+    ),
+};
+
+export async function handleDeployEvents(args: {
+  operation_id: string;
+  project_id: string;
+}): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const auth = requireAllowanceAuth("/deploy/v2/operations");
+  if ("error" in auth) return auth.error;
+
+  try {
+    const result = await getSdk().deploy.events(args.operation_id, {
+      project: args.project_id,
+    });
+
+    const lines: string[] = [
+      `## Deploy Events`,
+      ``,
+      `| Field | Value |`,
+      `|-------|-------|`,
+      `| operation_id | \`${args.operation_id}\` |`,
+      `| project_id | \`${args.project_id}\` |`,
+      `| event_count | ${result.events.length} |`,
+    ];
+
+    return {
+      content: [
+        { type: "text", text: lines.join("\n") },
+        {
+          type: "text",
+          text: ["### Events", "", "```json", JSON.stringify(result.events, null, 2), "```"].join("\n"),
+        },
+      ],
+    };
+  } catch (err) {
+    if (err instanceof Run402DeployError) {
+      const lines = [
+        `## Fetch Events Failed`,
+        ``,
+        `**Code:** \`${err.code}\``,
+      ];
+      if (err.phase) lines.push(`**Phase:** \`${err.phase}\``);
+      if (err.resource) lines.push(`**Resource:** \`${err.resource}\``);
+      lines.push(`**Retryable:** ${err.retryable}`);
+      lines.push(``, err.message);
+      return {
+        content: [{ type: "text", text: lines.join("\n") }],
+        isError: true,
+      };
+    }
+    return mapSdkError(err, "fetching deploy events");
+  }
+}

--- a/src/tools/deploy-list.ts
+++ b/src/tools/deploy-list.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { getSdk } from "../sdk.js";
+import { mapSdkError } from "../errors.js";
+import { requireAllowanceAuth } from "../allowance-auth.js";
+
+/**
+ * MCP `deploy_list` tool — list recent deploy operations for a project.
+ *
+ * Wraps `r.deploy.list()` over `GET /deploy/v2/operations`. Returns a
+ * markdown summary table and the structured operation snapshots for the
+ * agent to reason over (status, release_id, timestamps).
+ */
+
+export const deployListSchema = {
+  project_id: z
+    .string()
+    .describe("Project ID to list operations for. Required (apikey-gated)."),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "Maximum number of operations to return. Forwarded to the gateway as `?limit=`; the gateway picks a default when omitted.",
+    ),
+};
+
+export async function handleDeployList(args: {
+  project_id: string;
+  limit?: number;
+}): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const auth = requireAllowanceAuth("/deploy/v2/operations");
+  if ("error" in auth) return auth.error;
+
+  try {
+    const result = await getSdk().deploy.list({
+      project: args.project_id,
+      limit: args.limit,
+    });
+
+    const lines: string[] = [
+      `## Deploy Operations`,
+      ``,
+      `Project: \`${args.project_id}\``,
+      `Returned: ${result.operations.length}`,
+    ];
+    if (result.cursor) {
+      lines.push(`Next cursor: \`${result.cursor}\``);
+    }
+    lines.push(``);
+    if (result.operations.length === 0) {
+      lines.push("No operations found.");
+    } else {
+      lines.push(
+        `| Operation | Status | Release | Updated |`,
+        `|-----------|--------|---------|---------|`,
+      );
+      for (const op of result.operations) {
+        lines.push(
+          `| \`${op.operation_id}\` | ${op.status} | ${op.release_id ?? "—"} | ${op.updated_at} |`,
+        );
+      }
+    }
+
+    return {
+      content: [
+        { type: "text", text: lines.join("\n") },
+        {
+          type: "text",
+          text: ["### Raw operations", "", "```json", JSON.stringify(result, null, 2), "```"].join("\n"),
+        },
+      ],
+    };
+  } catch (err) {
+    return mapSdkError(err, "listing deploy operations");
+  }
+}

--- a/sync.test.ts
+++ b/sync.test.ts
@@ -199,6 +199,8 @@ const SURFACE: Capability[] = [
   // ── Unified deploy (v1.34+) ──────────────────────────────────────────────
   { id: "deploy",            endpoint: "POST /deploy/v2/plans",                            mcp: "deploy",            cli: "deploy:apply",      openclaw: "deploy:apply" },
   { id: "deploy_resume",     endpoint: "POST /deploy/v2/operations/:id/resume",            mcp: "deploy_resume",     cli: "deploy:resume",     openclaw: "deploy:resume" },
+  { id: "deploy_list",       endpoint: "GET /deploy/v2/operations",                        mcp: "deploy_list",       cli: "deploy:list",       openclaw: "deploy:list" },
+  { id: "deploy_events",     endpoint: "GET /deploy/v2/operations/:id/events",             mcp: "deploy_events",     cli: "deploy:events",     openclaw: "deploy:events" },
 
   // ── Marketplace ──────────────────────────────────────────────────────────
   { id: "browse_apps",       endpoint: "GET /apps/v1",                              mcp: "browse_apps",   cli: "apps:browse",   openclaw: "apps:browse" },
@@ -376,6 +378,8 @@ const SDK_BY_CAPABILITY: Record<string, string | null> = {
   // Unified deploy (v1.34+)
   deploy: "deploy.apply",
   deploy_resume: "deploy.resume",
+  deploy_list: "deploy.list",
+  deploy_events: "deploy.events",
 
   // Bundle / marketplace
   bundle_deploy: "apps.bundleDeploy",
@@ -860,14 +864,13 @@ describe("llms.txt alignment", { skip: !llmsTxtAvailable && "~/Developer/run402-
       "GET /storage/v1/uploads/{id}",
       "POST /storage/v1/uploads/{id}/complete",
       "DELETE /storage/v1/uploads/{id}",
-      // Unified deploy v2 (v1.34+) — these are internal plumbing for the
-      // `deploy` and `deploy_resume` MCP tools. The SDK orchestrates plan +
-      // upload + commit + poll + resume across them; agents call
-      // `deploy.apply` / `deploy.resume`, not these endpoints directly.
+      // Unified deploy v2 (v1.34+) — internal plumbing for the deploy
+      // primitive. The SDK orchestrates plan + upload + commit + poll across
+      // these; agents call `deploy.apply` / `deploy.resume` /
+      // `deploy.list` / `deploy.events`. The :id snapshot endpoint is exposed
+      // as `r.deploy.status()` on the SDK but not as its own MCP/CLI tool.
       "POST /deploy/v2/plans/:id/commit",
-      "GET /deploy/v2/operations",
       "GET /deploy/v2/operations/:id",
-      "GET /deploy/v2/operations/:id/events",
       // CAS content service — internal substrate shared by deploy.apply,
       // blobs.put, and the manifest-ref escape hatch. Not surfaced as its
       // own tool; the SDK uses it transparently.


### PR DESCRIPTION
## Summary

Closes [#137](https://github.com/kychee-com/run402/issues/137). The gateway already exposes `GET /deploy/v2/operations` and `GET /deploy/v2/operations/:id/events`, but the SDK didn't surface them — consumers had to call via raw `fetch()`, defeating the SDK abstraction. This adds matching methods at every layer (SDK → MCP → CLI).

The user reframed this as a **bug** (documented endpoints with no SDK access), not just an enhancement, when prioritizing the issue.

## Changes

### SDK ([sdk/src/namespaces/deploy.ts](sdk/src/namespaces/deploy.ts))
- `r.deploy.list({ project, limit? })` → `DeployListResponse`
- `r.deploy.events(operationId, { project })` → `DeployEventsResponse`
  - Validates `operationId` (non-empty + `op_` prefix) before issuing the request, mirroring the `resume()` hardening from v1.50.1
  - Wraps gateway errors via `translateDeployError` so consumers see structured `Run402DeployError` envelopes (not raw HTML 404s on bad ids)

New response types in [sdk/src/namespaces/deploy.types.ts](sdk/src/namespaces/deploy.types.ts).

### MCP tools
- [src/tools/deploy-list.ts](src/tools/deploy-list.ts) — `deploy_list`
- [src/tools/deploy-events.ts](src/tools/deploy-events.ts) — `deploy_events`

Each is a thin shim over the SDK that renders a markdown summary plus the raw JSON. Registered alongside `deploy` / `deploy_resume` in [src/index.ts](src/index.ts).

### CLI
- `run402 deploy list [--project <id>] [--limit <n>]`
- `run402 deploy events <operation_id> [--project <id>]`

Both emit `{ status: "ok", ... }` JSON on stdout. Subcommand dispatch routes through the existing [cli/lib/deploy.mjs](cli/lib/deploy.mjs) → [cli/lib/deploy-v2.mjs](cli/lib/deploy-v2.mjs) pattern. OpenClaw picks them up automatically (its [openclaw/scripts/deploy.mjs](openclaw/scripts/deploy.mjs) is a re-export).

### Sync surface + docs
- [sync.test.ts](sync.test.ts) SURFACE: 2 new entries + `SDK_BY_CAPABILITY` mappings. Removed `GET /deploy/v2/operations` and `.../events` from `IGNORED_ENDPOINTS` (they're no longer "internal plumbing").
- [cli/llms-cli.txt](cli/llms-cli.txt): documented in the Deploy section + the subcommand index.

## Verification

- 6 new SDK unit tests pass: list happy path, limit forwarding, events happy path, empty-id rejection, non-`op_`-prefix rejection, gateway 404 → structured `Run402DeployError`.
- `npm test`: **722 tests pass** (445 unit + 271 e2e + 6 new), 2 skipped (real-network), 0 failed.
- `npm run build` clean.
- `node cli/cli.mjs deploy list --help` / `events --help` print the expected usage.

## Test plan

- [x] SDK unit tests for both new methods (happy + sad paths)
- [x] Full `npm test` green locally
- [x] CLI `--help` smoke for both new subcommands
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)