### PR TITLE
docs(auth): document manifest.json file pattern, drop legacy rls template

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ npx run402-mcp
 | `provision_postgres_project` | Provision a Postgres database. Handles x402 payment. Saves credentials locally. |
 | `run_sql` | Execute SQL (DDL or queries). Returns markdown table. |
 | `rest_query` | Query/mutate via PostgREST. GET/POST/PATCH/DELETE with query params. |
-| `setup_rls` | Apply row-level security templates to tables. |
+| `apply_expose` | Apply a declarative authorization manifest to a project (tables/views/RPCs reachable via PostgREST). |
+| `get_expose` | Get the current authorization manifest (`source: applied | introspected`). |
 | `get_schema` | Introspect database schema — tables, columns, types, constraints, RLS policies. |
 | `get_usage` | Get project usage report — API calls, storage, limits, lease expiry. |
 | `deploy_function` | Deploy a serverless function (Node 22) to a project. |
@@ -74,7 +75,7 @@ npx run402-mcp
 | `claim_subdomain` | Claim custom subdomain (e.g. myapp.run402.com). Free. |
 | `delete_subdomain` | Release a subdomain. |
 | `list_subdomains` | List all subdomains claimed by a project. |
-| `bundle_deploy` | One-call full-stack deploy: database + migrations + RLS + secrets + functions + site + subdomain. |
+| `bundle_deploy` | One-call full-stack deploy: database + migrations + authorization manifest (`manifest.json` in `files[]`) + secrets + functions + site + subdomain. |
 | `browse_apps` | Browse public apps available for forking. |
 | `fork_app` | Fork a published app into a new project. |
 | `publish_app` | Publish a project as a forkable app. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -762,18 +762,34 @@ run_sql(project_id: "prj_...", sql: "CREATE TABLE todos (id serial PRIMARY KEY, 
 
 Design tables based on what the user needs. Add `user_id uuid` columns if you plan to use row-level security.
 
-### Step 3: Enable row-level security (optional)
+### Step 3: Declare authorization (optional)
 
-Use `run_sql` to apply RLS if users should only see their own rows:
+Tables you create are **dark by default** — `anon` and `authenticated` can't read them until your manifest declares them with `expose: true`. Closes the "agent created a table, forgot to set RLS, data leaked" footgun.
+
+Use the `apply_expose` tool to apply a declarative authorization manifest:
 
 ```
-run_sql(project_id: "prj_...", sql: "-- Use the /projects/v1/admin/:id/rls endpoint via HTTP for RLS templates")
+apply_expose(project_id: "prj_...", manifest: {
+  version: "1",
+  tables: [
+    { name: "todos", expose: true, policy: "user_owns_rows", owner_column: "user_id", force_owner_on_insert: true }
+  ]
+})
 ```
 
-Three RLS templates are available via the API. **Prefer `user_owns_rows` for anything user-scoped.**
-- **`user_owns_rows`** — Users can only access rows where the owner column matches `auth.uid()`. Best for user-scoped data (todos, workouts, messages). `uuid` owner columns get an index-friendly policy; other types fall back to a `::text` cast (the response includes a warning). The endpoint auto-creates a btree index on the owner column.
-- **`public_read_authenticated_write`** — Anyone can read. **Any authenticated user can INSERT/UPDATE/DELETE any row** (not just their own). Appropriate for collaborative content like shared boards or announcements; do not use where users should only edit their own rows.
-- **`public_read_write_UNRESTRICTED`** — ⚠ Fully open. Anyone (including `anon_key`) can read, insert, update, or delete any row. Only appropriate for intentionally public tables (guestbooks, waitlists, feedback forms). This template **requires** `"i_understand_this_is_unrestricted": true` in the request body and logs an audit line on the gateway.
+JSON Schema: `https://run402.com/schemas/manifest.v1.json` — point your editor's `$schema` at it for autocomplete.
+
+**Built-in policies** (one per table):
+- **`user_owns_rows`** — owner column matches `auth.uid()`. Requires `owner_column`. With `force_owner_on_insert: true`, a `BEFORE INSERT` trigger sets `owner_column := auth.uid()` automatically. Best for user-scoped data (todos, workouts, messages).
+- **`public_read_authenticated_write`** — anyone reads; **any authenticated user can INSERT/UPDATE/DELETE any row** (not just their own). For collaborative content (shared boards, announcements).
+- **`public_read_write_UNRESTRICTED`** — ⚠ fully open; `anon_key` can read AND write any row. Only for intentionally public tables (guestbooks, waitlists, feedback forms). **Requires** `"i_understand_this_is_unrestricted": true` on the table entry.
+- **`custom`** — escape hatch. Provide `custom_sql` with `CREATE POLICY` statements; runs inside the apply transaction after RLS is enabled and forced.
+
+The manifest is **convergent**: applying the same manifest twice is a no-op; tables removed between applies have their policies revoked, grants revoked, triggers dropped. Include everything you want exposed in every apply.
+
+Use `get_expose` to inspect the current manifest. `source: "applied"` means it came from a prior `apply_expose`; `source: "introspected"` means it was reconstructed from live DB state (no manifest has ever been applied).
+
+For full-stack deploys, the same manifest can travel with your code as `manifest.json` in the bundle's `files[]` — see the `bundle_deploy` and `deploy` tools.
 
 ### Step 4: Insert data
 
@@ -840,7 +856,7 @@ Prototype uses testnet tokens — no real money needed. With x402: Base Sepolia 
 
 **SQL blocklist:** The SQL endpoint blocks dangerous operations: `CREATE EXTENSION`, `COPY ... PROGRAM`, `ALTER SYSTEM`, `SET search_path`, `CREATE/DROP SCHEMA`, `GRANT/REVOKE`, `CREATE/DROP ROLE`. If you hit a 403, check the `hint` field for alternatives.
 
-**No GRANT needed:** Table and sequence permissions are managed automatically. Use RLS templates for access control instead of GRANT/REVOKE.
+**No GRANT needed:** Table and sequence permissions are managed automatically. Declare what's reachable via the authorization manifest (`apply_expose`, or `manifest.json` in a bundle's `files[]`) instead of GRANT/REVOKE.
 
 **Key usage patterns:**
 - Use `service_key` (via `run_sql` or `key_type: "service"`) for: table creation, RLS setup, seeding data, admin queries

--- a/cli/lib/deploy.mjs
+++ b/cli/lib/deploy.mjs
@@ -93,17 +93,16 @@ Manifest format (JSON):
     "project_id": "prj_...",
     "migrations": "CREATE TABLE items (...)",
     "migrations_file": "setup.sql",
-    "rls": {
-      "template": "public_read_write_UNRESTRICTED",
-      "tables": [{ "table": "items" }],
-      "i_understand_this_is_unrestricted": true
-    },
     "secrets": [{ "key": "OPENAI_API_KEY", "value": "sk-..." }],
     "functions": [{
       "name": "my-fn",
       "code": "export default async (req) => new Response('ok')"
     }],
     "files": [
+      {
+        "file": "manifest.json",
+        "data": "{\\"version\\":\\"1\\",\\"tables\\":[{\\"name\\":\\"items\\",\\"expose\\":true,\\"policy\\":\\"public_read_write_UNRESTRICTED\\",\\"i_understand_this_is_unrestricted\\":true}]}"
+      },
       { "file": "index.html", "data": "<html>...</html>" },
       { "file": "style.css", "path": "./dist/style.css" }
     ],
@@ -129,23 +128,34 @@ Manifest format (JSON):
   Paths are resolved relative to the manifest file's directory.
   Binary files (images, fonts, etc.) are auto-detected and base64-encoded.
 
-  RLS templates (prefer user_owns_rows for anything user-scoped):
-    user_owns_rows                    users see only their own rows (requires
-                                      owner_column per table; uuid columns get
-                                      index-friendly policies automatically)
-    public_read_authenticated_write   anyone reads; any authenticated user can
-                                      INSERT/UPDATE/DELETE any row (not just
-                                      their own). For collaborative content
-                                      like shared boards or announcements.
-    public_read_write_UNRESTRICTED    ⚠  fully open — anon_key can read AND
-                                      write any row. Only for intentionally
-                                      public tables (guestbooks, waitlists,
-                                      feedback forms). REQUIRES the manifest's
-                                      rls block to include
-                                      "i_understand_this_is_unrestricted": true.
+  Authorization (manifest.json file pattern):
+    Tables are dark by default — anon/authenticated can't read them until a
+    manifest declares them with expose:true. Ship a "manifest.json" entry in
+    files[] (preferred — auth-as-SDLC) and the platform reads, validates,
+    applies, and strips it before the site deploys. Schema:
+    https://run402.com/schemas/manifest.v1.json
 
-  ⚠️  Without RLS, tables are read-only via anon_key. If your app writes
-  data from the browser, you almost certainly need an rls block.
+    Per-table policies:
+      user_owns_rows                    users see only their own rows. Requires
+                                        "owner_column"; with
+                                        "force_owner_on_insert": true the gateway
+                                        sets it from auth.uid() automatically.
+                                        uuid columns get index-friendly policies.
+      public_read_authenticated_write   anyone reads; any authenticated user can
+                                        INSERT/UPDATE/DELETE any row (not just
+                                        their own). For collaborative content
+                                        like shared boards or announcements.
+      public_read_write_UNRESTRICTED    ⚠  fully open — anon_key can read AND
+                                        write any row. Only for intentionally
+                                        public tables (guestbooks, waitlists,
+                                        feedback forms). REQUIRES
+                                        "i_understand_this_is_unrestricted":
+                                        true on the table entry.
+      custom                            escape hatch. Provide "custom_sql" with
+                                        CREATE POLICY statements.
+
+  ⚠️  Without a manifest, tables are unreachable via anon_key. If your app
+  reads or writes data from the browser, you need a manifest.json entry.
 
 Examples:
   run402 deploy --manifest app.json

--- a/cli/lib/projects.mjs
+++ b/cli/lib/projects.mjs
@@ -19,8 +19,7 @@ Subcommands:
   rest  [id] <table> [params]             Query a table via the REST API (PostgREST)
   usage [id]                              Show compute/storage usage for a project
   schema [id]                             Inspect the database schema
-  rls   [id] <template> <tables_json>     ⚠ DEPRECATED (sunset 2026-05-23) - use 'apply-expose' instead
-  apply-expose [id] <manifest_json>       Apply a declarative authorization manifest (supersedes 'rls')
+  apply-expose [id] <manifest_json>       Apply a declarative authorization manifest
   apply-expose [id] --file <path>         Apply a manifest from a JSON file
   get-expose   [id]                       Get the current authorization manifest
   delete [id]                             Immediately and irreversibly delete a project (cascade purge) and remove from local state
@@ -41,7 +40,6 @@ Examples:
   run402 projects rest abc123 users "limit=10&select=id,name"
   run402 projects usage abc123
   run402 projects schema abc123
-  run402 projects rls abc123 public_read_authenticated_write '[{"table":"posts"}]'
   run402 projects apply-expose abc123 --file manifest.json
   run402 projects get-expose abc123
   run402 projects keys abc123
@@ -54,19 +52,19 @@ Notes:
     any first positional that doesn't is treated as the next argument instead.
   - 'rest' uses PostgREST query syntax (table name + optional query string)
   - 'provision' requires a funded allowance — payment is automatic via x402
-  - RLS templates (prefer user_owns_rows for user-scoped data):
-      user_owns_rows                    users access only their own rows (requires owner_column)
-      public_read_authenticated_write   anyone reads; any authenticated user writes any row
-      public_read_write_UNRESTRICTED    fully open (anon_key writes); use 'run402 deploy' with a manifest
-                                        that includes "i_understand_this_is_unrestricted": true
-  - 'rls' is deprecated (sunset 2026-05-23) — migrate to 'apply-expose'.
-    The expose manifest declares the full authorization surface (tables, views,
-    RPCs) in one convergent call. Tables not listed with expose:true are dark
-    by default. Sample manifest:
+  - 'apply-expose' declares the full authorization surface (tables, views, RPCs)
+    in one convergent call. Tables not listed with expose:true are dark by
+    default. Schema: https://run402.com/schemas/manifest.v1.json. Sample:
       {"version":"1",
        "tables":[{"name":"posts","expose":true,"policy":"user_owns_rows","owner_column":"user_id","force_owner_on_insert":true}],
        "views":[],
        "rpcs":[]}
+    Per-table policies: user_owns_rows (requires owner_column;
+    force_owner_on_insert sets it from auth.uid() automatically),
+    public_read_authenticated_write (anyone reads, any auth'd user writes any
+    row), public_read_write_UNRESTRICTED (fully open; requires
+    "i_understand_this_is_unrestricted": true on the entry), custom (provide
+    custom_sql with CREATE POLICY statements).
 `;
 
 const SUB_HELP = {

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -208,11 +208,6 @@ Create a manifest file `app.json` (use the `project_id` from provision):
   "project_id": "prj_1741340000_42",
   "migrations": "CREATE TABLE items (id serial PRIMARY KEY, title text NOT NULL, done boolean DEFAULT false); INSERT INTO items (title) VALUES ('Buy groceries'), ('Read a book');",
   "migrations_file": "setup.sql",
-  "rls": {
-    "template": "public_read_write_UNRESTRICTED",
-    "tables": [{ "table": "items" }],
-    "i_understand_this_is_unrestricted": true
-  },
   "secrets": [{ "key": "OPENAI_API_KEY", "value": "sk-..." }],
   "functions": [{
     "name": "my-fn",
@@ -220,6 +215,10 @@ Create a manifest file `app.json` (use the `project_id` from provision):
     "config": { "timeout": 30, "memory": 256 }
   }],
   "files": [
+    {
+      "file": "manifest.json",
+      "data": "{\"$schema\":\"https://run402.com/schemas/manifest.v1.json\",\"version\":\"1\",\"tables\":[{\"name\":\"items\",\"expose\":true,\"policy\":\"public_read_write_UNRESTRICTED\",\"i_understand_this_is_unrestricted\":true}]}"
+    },
     { "file": "index.html", "data": "<!DOCTYPE html><html>...</html>" },
     { "file": "style.css", "data": "body { margin: 0; }" },
     { "file": "logo.png", "data": "iVBORw0KGgo...", "encoding": "base64" }
@@ -252,38 +251,35 @@ END $$;
 
 This pattern is safe to re-run on every deploy. Put your `CREATE TABLE IF NOT EXISTS` first, then one `DO` block per new column (or group them in a single block).
 
-Authorization policy templates (prefer `user_owns_rows` for anything user-scoped):
-- `user_owns_rows` — users access only their own rows (requires `owner_column` per table; `uuid` columns are index-friendly, others fall back to `::text` cast with a warning; a btree index is auto-created)
+**Authorization (the `manifest.json` file pattern)**
+
+Tables you create are **dark by default** — `anon` and `authenticated` can't read them until your manifest declares them with `expose: true`. Closes the "agent created a table, forgot to set RLS, data leaked" footgun.
+
+JSON Schema: `https://run402.com/schemas/manifest.v1.json` — point your editor's `$schema` at it for autocomplete.
+
+The preferred way to declare authorization is to ship a `manifest.json` file in the bundle's `files[]` (shown above). The platform reads it, validates it against the migration SQL, applies it, and **strips it from `files[]` before the site deploys** so it's never publicly reachable on your subdomain. The deploy response includes `manifest_applied: true` on success. If the manifest references a table your migration doesn't create, the deploy is rejected with HTTP 400 and a structured `errors` array listing **every** violation.
+
+Built-in policies (one per table):
+
+- `user_owns_rows` — owner column matches `auth.uid()`. Requires `owner_column`. With `force_owner_on_insert: true`, a `BEFORE INSERT` trigger sets `owner_column := auth.uid()` automatically. Best for user-scoped data (todos, workouts, messages). `uuid` owner columns get index-friendly policies; other types fall back to a `::text` cast with a warning; a btree index is auto-created.
 - `public_read_authenticated_write` — anyone reads; **any authenticated user can INSERT/UPDATE/DELETE any row** (not just their own). For collaborative content (shared boards, announcements).
 - `public_read_write_UNRESTRICTED` — ⚠ fully open; `anon_key` can read AND write any row. For intentionally public tables only (guestbooks, waitlists, feedback forms). **Requires** `"i_understand_this_is_unrestricted": true` on the table entry.
 - `custom` — escape hatch. Provide `custom_sql` containing `CREATE POLICY` statements; they run inside the apply transaction after RLS is enabled + forced.
 
-| Template | anon_key reads | anon_key writes | authenticated reads | authenticated writes |
-|----------|---------------|-----------------|---------------------|----------------------|
-| `user_owns_rows` | no | no | own rows only | own rows only |
-| `public_read_authenticated_write` | all rows | no | all rows | all rows (any row) |
-| `public_read_write_UNRESTRICTED` | all rows | all rows | all rows | all rows |
+| Policy | anon SELECT | anon writes | auth SELECT | auth writes |
+|--------|:-----------:|:-----------:|:-----------:|:-----------:|
+| (omitted from manifest) | — | — | — | — |
+| `user_owns_rows` | — | — | own rows | own rows |
+| `public_read_authenticated_write` | all | — | all | all rows |
+| `public_read_write_UNRESTRICTED` | all | yes | all | yes |
 
-⚠️ **Dark by default (v1.31+)**: tables created via `run402 projects sql` are NOT readable by anon or authenticated until the expose manifest declares them with `expose: true`. Pre-v1.31 tables on Pod 01 are grandfathered and keep their existing grants until a manifest is applied.
+`—` = denied. `service_key` bypasses all policies. **Views** are always created with `security_invoker=true` — they inherit the underlying table's RLS. **RPCs** require an entry in `rpcs[*]` with `grant_to` to be callable as `/rest/v1/rpc/<fn>` (since v1.30, `CREATE FUNCTION` revokes PUBLIC EXECUTE automatically).
 
-**Migration from `rls` → `expose`**: the `rls` block below and `run402 projects rls` are deprecated (sunset **2026-05-23**). Bundle deploys containing an `rls` block are auto-translated to an expose manifest during the deprecation window. After the sunset date, the legacy endpoint returns `410 Gone`.
+**Imperative escape hatch:** for ad-hoc changes outside a deploy, use `run402 projects apply-expose <project_id> --file manifest.json`. Inspect current state with `run402 projects get-expose <project_id>` — `source: "applied"` means it came from a prior apply; `"introspected"` means it was reconstructed from live DB state.
 
-Equivalent manifest (use this going forward):
+The manifest is **convergent**: applying the same manifest twice is a no-op; items removed between applies have their policies revoked, grants revoked, triggers dropped, views dropped. Include everything you want exposed in every apply.
 
-```json
-{
-  "version": "1",
-  "tables": [
-    { "name": "items", "expose": true, "policy": "public_read_write_UNRESTRICTED", "i_understand_this_is_unrestricted": true }
-  ],
-  "views": [],
-  "rpcs": []
-}
-```
-
-Apply it with `run402 projects apply-expose <project_id> --file manifest.json` (or inline JSON). Inspect current state with `run402 projects get-expose <project_id>` — `source: "applied"` means it came from `internal.project_manifest`; `"introspected"` means the manifest was regenerated from live DB state (no manifest has ever been applied).
-
-The manifest is **convergent**: applying the same manifest twice is a no-op; items removed between applies have their policies revoked, grants revoked, triggers dropped, and views dropped. Include everything you want exposed in every apply.
+**Conflicting sources:** bundles that include both inline `expose` and a `manifest.json` file (or legacy `rls` + `manifest.json`) are rejected with 400 — the platform refuses to silently pick one source over another.
 
 Deploy:
 
@@ -291,7 +287,7 @@ Deploy:
 run402 deploy --manifest app.json
 ```
 
-This deploys to an existing project: runs migrations, applies RLS, sets secrets, deploys functions, deploys the site, and claims the subdomain. Provision the project first with `run402 projects provision`.
+This deploys to an existing project: runs migrations, applies the authorization manifest (from `manifest.json` in `files[]`), sets secrets, deploys functions, deploys the site, and claims the subdomain. Provision the project first with `run402 projects provision`.
 
 ### Step-by-Step Deploy
 
@@ -307,9 +303,8 @@ run402 projects sql <project_id> "CREATE TABLE items (id serial PRIMARY KEY, tit
 # 3. Insert seed data
 run402 projects sql <project_id> "INSERT INTO items (title) VALUES ('Buy groceries'), ('Read a book')"
 
-# 4. Declare the authorization manifest (supersedes `projects rls`, sunset 2026-05-23).
-#    Write the manifest to manifest.json first, then apply:
-#    {"version":"1","tables":[{"name":"items","expose":true,"policy":"public_read_authenticated_write"}],"views":[],"rpcs":[]}
+# 4. Declare authorization. Write manifest.json first:
+#    {"version":"1","tables":[{"name":"items","expose":true,"policy":"public_read_authenticated_write"}]}
 run402 projects apply-expose <project_id> --file manifest.json
 
 # 5. Deploy a static site (uses active project automatically)
@@ -355,11 +350,8 @@ run402 subdomains claim my-app
 - `run402 projects apply-expose <id> <manifest_json>` — apply a declarative authorization manifest
 - `run402 projects apply-expose <id> --file manifest.json` — apply from a JSON file
 - `run402 projects get-expose <id>` — print the current manifest (`source: applied | introspected`)
-- `run402 projects rls <id> <user_owns_rows|public_read_authenticated_write|public_read_write_UNRESTRICTED> '<tables_json>'` — ⚠ DEPRECATED (sunset 2026-05-23). Migrate to `apply-expose`. For UNRESTRICTED, `apply-expose` accepts `"i_understand_this_is_unrestricted": true` on the table entry.
 
 Provisioning automatically sets the new project as the **active project**. Other commands that take `<id>` default to the active project when omitted.
-
-RLS `tables_json` (legacy): `'[{"table":"posts"}]'` or `'[{"table":"notes","owner_column":"user_id"}]'` for user_owns_rows. Prefer the expose manifest for new work.
 
 SQL supports DDL + queries, returns JSON. REST uses PostgREST syntax (`select=`, `eq.`, `order=`, `limit=`).
 
@@ -372,7 +364,7 @@ User auth: password + Google OAuth. See "User Auth" section below.
 - `run402 deploy list [--project <id>] [--limit <n>]` — list recent deploy operations
 - `run402 deploy events <operation_id> [--project <id>]` — fetch the recorded event stream for an operation
 
-Requires active tier and a provisioned project. Deploys to an existing project: runs migrations, applies RLS, sets secrets, deploys functions, deploys static site, and claims subdomain. The manifest must include `project_id` (or use `--project` flag, or omit both to use the active project).
+Requires active tier and a provisioned project. Deploys to an existing project: runs migrations, applies the authorization manifest (from a `manifest.json` entry in `files[]`), sets secrets, deploys functions, deploys static site, and claims subdomain. The manifest must include `project_id` (or use `--project` flag, or omit both to use the active project).
 
 ### functions
 Node 22 runtime. Must export `default async (req: Request) => Response`.
@@ -1024,7 +1016,7 @@ const refreshed = await fetch(API + '/auth/v1/token?grant_type=refresh_token', {
 9. **Workout Log** -- Track exercises, sets, reps, weight with progress over time.
 10. **Flash Cards** -- Spaced-repetition study app. Pre-load 50 phrases.
 
-Provision first so you have the `anon_key` to embed in your frontend HTML. The manifest should include `project_id` (from provision), `migrations` (CREATE TABLE + INSERT seed data), `rls` (for browser-writable apps: `public_read_write_UNRESTRICTED` + `"i_understand_this_is_unrestricted": true`; for user-scoped apps use `user_owns_rows`), `files` (array of files), and `subdomain`. Your human gets a live URL they can use immediately.
+Provision first so you have the `anon_key` to embed in your frontend HTML. The manifest should include `project_id` (from provision), `migrations` (CREATE TABLE + INSERT seed data), `files` (array of files — including a `manifest.json` entry to declare authorization: `public_read_write_UNRESTRICTED` + `"i_understand_this_is_unrestricted": true` for browser-writable apps; `user_owns_rows` for user-scoped apps), and `subdomain`. Your human gets a live URL they can use immediately.
 
 ## Make It Great
 

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -31,11 +31,11 @@ Agent allowance persists at `~/.config/run402/allowance.json`. Faucet gives 0.25
 {
   "name": "my-app",
   "migrations": "CREATE TABLE items (id serial PRIMARY KEY, title text NOT NULL, done boolean DEFAULT false, user_id uuid, created_at timestamptz DEFAULT now());",
-  "rls": {
-    "template": "user_owns_rows",
-    "tables": [{ "table": "items", "owner_column": "user_id" }]
-  },
-  "site": [
+  "files": [
+    {
+      "file": "manifest.json",
+      "data": "{\"$schema\":\"https://run402.com/schemas/manifest.v1.json\",\"version\":\"1\",\"tables\":[{\"name\":\"items\",\"expose\":true,\"policy\":\"user_owns_rows\",\"owner_column\":\"user_id\",\"force_owner_on_insert\":true}]}"
+    },
     { "file": "index.html", "data": "<!DOCTYPE html>..." },
     { "file": "style.css", "data": "body { ... }" }
   ],
@@ -43,7 +43,7 @@ Agent allowance persists at `~/.config/run402/allowance.json`. Faucet gives 0.25
 }
 ```
 
-All fields except `name` are optional. Can also include `secrets`, `functions`.
+All fields except `name` are optional. Can also include `secrets`, `functions`. The `manifest.json` entry in `files[]` declares the project's authorization surface (which tables/views/RPCs are reachable via PostgREST) — see "Authorization Manifest" below. The platform reads it, validates it against the migrations, applies it, and **strips it from `files[]` before deploying the site**, so it's never publicly reachable on your subdomain.
 
 ### Step 3: Deploy
 
@@ -82,7 +82,7 @@ node <skill_dir>/scripts/projects.mjs list
 5. **Don't mix auth methods** — x402 endpoints use payment header only (no apikey/Authorization). REST/auth/storage use apikey only (no payment header).
 6. **`POST /subdomains/v1` is idempotent** — upserts. Safe to call every deploy.
 7. **Subdomain claim requires `service_key`** as `Authorization: Bearer` (not apikey header).
-8. **Don't GRANT/REVOKE** — permissions managed automatically. Use RLS templates for access control.
+8. **Don't GRANT/REVOKE** — permissions managed automatically. Declare what's reachable via a `manifest.json` entry in your bundle's `files[]` (see "Authorization Manifest").
 9. **Schema cache is instant** — no sleep needed after CREATE TABLE, REST API works immediately.
 
 ---
@@ -130,13 +130,18 @@ Once funded, x402 payments settle from allowance automatically. No code changes.
 {
   "name": "my-saas-app",
   "migrations": "CREATE TABLE ...; CREATE TABLE ...;",
-  "rls": { "template": "user_owns_rows", "tables": [{ "table": "posts", "owner_column": "user_id" }] },
   "secrets": [{ "key": "OPENAI_API_KEY", "value": "sk-..." }],
   "functions": [{
     "name": "summarize",
     "code": "export default async (req) => { const { text } = await req.json(); return new Response(JSON.stringify({ result: text.slice(0, 100) })); }"
   }],
-  "site": [{ "file": "index.html", "data": "<!DOCTYPE html>..." }],
+  "files": [
+    {
+      "file": "manifest.json",
+      "data": "{\"version\":\"1\",\"tables\":[{\"name\":\"posts\",\"expose\":true,\"policy\":\"user_owns_rows\",\"owner_column\":\"user_id\",\"force_owner_on_insert\":true}]}"
+    },
+    { "file": "index.html", "data": "<!DOCTYPE html>..." }
+  ],
   "subdomain": "my-saas"
 }
 ```
@@ -145,10 +150,9 @@ Once funded, x402 payments settle from allowance automatically. No code changes.
 |-------|----------|-------------|
 | `name` | Yes | App/project name |
 | `migrations` | No | SQL string (CREATE TABLE, etc.) |
-| `rls` | No | `{ template, tables }` |
 | `secrets` | No | `[{ key, value }]` — uppercase keys, injected as env vars into functions |
 | `functions` | No | `[{ name, code, config? }]` — serverless functions (Lambda). Limits: prototype=5, hobby=25, team=100 |
-| `site` | No | `[{ file, data, encoding? }]` — `base64` for binary. 50MB max |
+| `files` | No | `[{ file, data, encoding? }]` — site files; `base64` for binary; 50MB max. Include a `manifest.json` entry to declare authorization (see "Authorization Manifest"). |
 | `subdomain` | No | Custom subdomain → `name.run402.com` |
 
 Site deployment is free with active tier. If any step fails, the project is rolled into the soft-delete grace window (no half-deployed apps).
@@ -185,14 +189,21 @@ Returns: `{ "status": "ok", "schema": "p0001", "rows": [], "rowCount": 0 }`
 
 Both `SERIAL` and `BIGINT GENERATED ALWAYS AS IDENTITY` work. Sequence permissions granted automatically.
 
-### 3. Apply RLS (Optional)
+### 3. Declare Authorization (Optional)
+
+Tables you create are dark by default — invisible to PostgREST's `anon` role until a manifest declares them. Apply a manifest with `POST /projects/v1/admin/:id/expose`:
 
 ```bash
-curl -X POST https://api.run402.com/projects/v1/admin/$PROJECT_ID/rls \
+curl -X POST https://api.run402.com/projects/v1/admin/$PROJECT_ID/expose \
   -H "Authorization: Bearer $SERVICE_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"template": "user_owns_rows", "tables": [{"table": "todos", "owner_column": "user_id"}]}'
+  -d '{
+    "version": "1",
+    "tables": [{ "name": "todos", "expose": true, "policy": "user_owns_rows", "owner_column": "user_id", "force_owner_on_insert": true }]
+  }'
 ```
+
+Or include a `manifest.json` entry in your bundle's `files[]` on the next `POST /deployments/v1` — same shape, gateway applies it before the site deploys. See "Authorization Manifest" for the full schema.
 
 ### 4. Deploy Site
 
@@ -370,31 +381,71 @@ Public blobs are CDN-served at `https://pr-<public_id>.run402.com/_blob/<key>` (
 
 ---
 
-## Row-Level Security (RLS)
+## Authorization Manifest
 
-Three templates. Applied via `POST /projects/v1/admin/:id/rls` with `service_key`. **Prefer `user_owns_rows` for anything user-scoped.**
+The manifest is the single source of truth for which tables, views, and RPCs in your project are reachable through PostgREST (`/rest/v1/*`). **Tables you create are dark by default** — `anon` and `authenticated` can't read them until the manifest says so. Closes the "agent created a table, forgot to set RLS, data leaked" footgun.
 
-### `user_owns_rows`
-Users access only rows where the owner column matches `auth.uid()`. Best for user-scoped data (todos, workouts, messages). `uuid` owner columns get an index-friendly policy; other types fall back to a `::text` cast with a warning. The endpoint auto-creates a btree index on the owner column.
-```json
-{ "template": "user_owns_rows", "tables": [{ "table": "todos", "owner_column": "user_id" }] }
-```
+JSON Schema: `https://run402.com/schemas/manifest.v1.json` — point your editor's `$schema` at it for autocomplete.
 
-### `public_read_authenticated_write`
-Anyone can read (including `anon_key`). **Any authenticated user can INSERT/UPDATE/DELETE any row** (not just their own). Appropriate for collaborative content like shared boards or announcements; do not use where users should only edit their own rows.
-```json
-{ "template": "public_read_authenticated_write", "tables": [{ "table": "announcements" }] }
-```
+### Preferred: `manifest.json` in the bundle's `files[]`
 
-### `public_read_write_UNRESTRICTED`
-⚠ Fully open. Anyone (including `anon_key`) can read, insert, update, or delete any row. Only appropriate for intentionally public tables (guestbooks, waitlists, feedback forms). **Requires** `"i_understand_this_is_unrestricted": true` in the request body and logs an audit line on the gateway.
+Authorization travels with your code. Include a file named `manifest.json` in `files[]` and the platform reads it, validates it against the migration SQL, applies it, and **strips it from `files[]` before the site deploys** (so it's never publicly reachable on your subdomain). The deploy response includes `manifest_applied: true` on success.
+
 ```json
 {
-  "template": "public_read_write_UNRESTRICTED",
-  "tables": [{ "table": "guestbook" }],
-  "i_understand_this_is_unrestricted": true
+  "$schema": "https://run402.com/schemas/manifest.v1.json",
+  "version": "1",
+  "tables": [
+    { "name": "workouts", "expose": true, "policy": "user_owns_rows", "owner_column": "user_id", "force_owner_on_insert": true },
+    { "name": "internal_metrics", "expose": false }
+  ],
+  "views": [
+    { "name": "public_leaderboard", "base": "workouts", "select": ["user_id", "score"], "expose": true }
+  ],
+  "rpcs": [
+    { "name": "compute_streak", "signature": "(user_id uuid)", "grant_to": ["authenticated"] }
+  ]
 }
 ```
+
+If the manifest references a table your migration doesn't create, the deploy is rejected with HTTP 400 and a structured `errors` array listing **every** violation (not just the first).
+
+### Imperative escape hatch: `POST /admin/v1/projects/:id/expose`
+
+Same JSON shape, no bundle. Useful for ad-hoc changes outside a deploy.
+
+```bash
+curl -X POST https://api.run402.com/projects/v1/admin/$PROJECT_ID/expose \
+  -H "Authorization: Bearer $SERVICE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "version": "1", "tables": [ ... ], "views": [ ... ], "rpcs": [ ... ] }'
+```
+
+Bundles that include both inline `expose` and `manifest.json` (or legacy `rls` + `manifest.json`) are rejected with 400 — the platform refuses to silently pick one source over another.
+
+### Convergence
+
+Applying the same manifest twice is a no-op. Removing a table (or flipping `expose` to `false`) drops policies, revokes anon SELECT, drops owner triggers, drops views. The manifest is the contract; DB state follows.
+
+### Built-in policies
+
+- **`user_owns_rows`** — owner column matches `auth.uid()`. Requires `owner_column`. With `force_owner_on_insert: true`, a `BEFORE INSERT` trigger sets `owner_column := auth.uid()` when the agent forgets to pass it. Best for user-scoped data (todos, workouts, messages).
+- **`public_read_authenticated_write`** — anyone reads; **any authenticated user can INSERT/UPDATE/DELETE any row** (not just their own). For collaborative content (shared boards, announcements).
+- **`public_read_write_UNRESTRICTED`** — ⚠ fully open; `anon_key` can read AND write any row. Only for intentionally public tables (guestbooks, waitlists, feedback forms). **Requires** `"i_understand_this_is_unrestricted": true` on the table entry.
+- **`custom`** — escape hatch. Provide `custom_sql` containing `CREATE POLICY` statements; they run inside the apply transaction after RLS is enabled and forced.
+
+| Policy | anon SELECT | anon INSERT/UPDATE/DELETE | auth SELECT | auth INSERT/UPDATE/DELETE |
+|--------|:-----------:|:-------------------------:|:-----------:|:-------------------------:|
+| (omitted from manifest) | — | — | — | — |
+| `user_owns_rows` | — | — | own rows | own rows |
+| `public_read_authenticated_write` | all | — | all | all rows |
+| `public_read_write_UNRESTRICTED` | all | yes | all | yes |
+
+`—` = denied. `service_key` bypasses all policies.
+
+**Views** are always created with `security_invoker=true` — they inherit the underlying table's RLS.
+
+**RPCs** — `CREATE FUNCTION` revokes PUBLIC EXECUTE automatically; the manifest's `rpcs[*]` section is the explicit opt-in to make a function callable as `/rest/v1/rpc/<fn>`. List the roles in `grant_to` (one of `anon`, `authenticated`, `service_role`, `project_admin`).
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,7 @@ server.tool(
 
 server.tool(
   "bundle_deploy",
-  "Deploy to an existing project. Runs migrations, applies RLS, sets secrets, deploys functions, deploys a static site, and claims a subdomain. Requires a provisioned project_id. Free with active tier.",
+  "Deploy to an existing project. Runs migrations, applies the authorization manifest, sets secrets, deploys functions, deploys a static site, and claims a subdomain. Requires a provisioned project_id. Free with active tier. To declare authorization, include a `manifest.json` entry in `files[]` (preferred — the gateway reads it, validates against the migrations, applies it, and strips it before the site deploys). Schema: https://run402.com/schemas/manifest.v1.json. The legacy top-level `rls` field still works during the deprecation window (sunset 2026-05-23) but is not recommended for new code.",
   bundleDeploySchema,
   async (args) => handleBundleDeploy(args),
 );

--- a/src/tools/bundle-deploy.ts
+++ b/src/tools/bundle-deploy.ts
@@ -65,9 +65,10 @@ export const bundleDeploySchema = {
     })
     .optional()
     .describe(
-      "RLS configuration to apply after migrations. Prefer `user_owns_rows` for anything user-scoped. " +
-      "`public_read_authenticated_write`: anyone reads, any authenticated user writes any row. " +
-      "`public_read_write_UNRESTRICTED`: fully open (anon_key writes); requires i_understand_this_is_unrestricted: true.",
+      "⚠ DEPRECATED (sunset 2026-05-23) — prefer a `manifest.json` entry in `files[]`. " +
+      "The gateway auto-translates this block to a manifest during the deprecation window. " +
+      "Templates: user_owns_rows, public_read_authenticated_write, public_read_write_UNRESTRICTED " +
+      "(requires i_understand_this_is_unrestricted: true).",
     ),
   secrets: z
     .array(z.object({ key: z.string(), value: z.string() }))
@@ -101,7 +102,12 @@ export const bundleDeploySchema = {
       }),
     )
     .optional()
-    .describe("Static site files to deploy (must include index.html)"),
+    .describe(
+      "Static site files to deploy (must include index.html). May include a `manifest.json` entry " +
+      "to declare the authorization surface (tables/views/RPCs reachable via PostgREST). The gateway " +
+      "reads it, validates against the migrations, applies it, and strips it from `files[]` before " +
+      "the site deploys. Schema: https://run402.com/schemas/manifest.v1.json.",
+    ),
   subdomain: z
     .string()
     .optional()


### PR DESCRIPTION
## Summary

Migrates the agent-facing docs to the auth-as-sdlc file pattern: ship a `manifest.json` entry in your bundle's `files[]`, and the gateway reads it, validates it against the migration SQL, applies it, and **strips it from `files[]`** before the site deploys (so it's never publicly reachable on your subdomain). Schema: https://run402.com/schemas/manifest.v1.json.

Removes the legacy `rls` template documentation (the `/projects/v1/admin/:id/rls` endpoint, the `rls` field in bundle deploy bodies, and the three-template explanations). The endpoint, the `setup_rls` MCP tool, and the `run402 projects rls` CLI command **continue to work** until the 2026-05-23 sunset — only the docs lose them.

Closes #106 (docs scope). The `validate_manifest` MCP tool work is split out to #151.

## Files changed

- **`openclaw/SKILL.md`** — Step 2 manifest example uses `files[]` with `manifest.json`; Bundle Deploy section drops the `rls` field; Step 3 "Apply RLS" → "Declare Authorization" using `apply-expose` + the file pattern; full "Row-Level Security (RLS)" section replaced with "Authorization Manifest" mirroring the private repo's `site/llms.txt` Step 6.
- **`SKILL.md`** — Step 3 rewritten around `apply_expose` + the manifest schema, with a pointer at `bundle_deploy`/`deploy` for the file-pattern path.
- **`cli/llms-cli.txt`** — deploy example shows `manifest.json` in `files[]`; "Authorization policy templates" + "Migration from rls → expose" + "Equivalent manifest" sections collapsed into a single "Authorization (the manifest.json file pattern)" section; deprecated `run402 projects rls` listing removed; "applies RLS" wording updated.
- **`cli/lib/deploy.mjs`** — `--help` manifest format example uses `files[]` with `manifest.json`; RLS templates explanation rewritten as "Authorization (manifest.json file pattern)".
- **`src/tools/bundle-deploy.ts`** — `rls` field marked deprecated in its description with a sunset date; `files[]` description gains a note about the `manifest.json` entry.
- **`src/index.ts`** — `bundle_deploy` tool description swaps "applies RLS" for the manifest-aware copy.

## Test plan

- [x] `npm run test:skill` (SKILL.md frontmatter + body integrity) — 21/21 pass
- [x] `npm run test:sync` (MCP/CLI/OpenClaw/SDK surface alignment) — 39/41 pass (2 skipped: private llms.txt not present in this checkout)
- [x] `node --test cli-help.test.mjs` (CLI `--help` contract) — 152/152 pass after `npm run build:core`
- [x] Verified zero remaining `"rls":` field examples in `SKILL.md`, `openclaw/SKILL.md`, `cli/llms-cli.txt`, `cli/lib/deploy.mjs`
- [ ] Pre-existing on main, **not** introduced by this PR: `npm run build:functions` fails (`functions/src/auth.ts` can't find `jsonwebtoken`), and `src/tools/*.test.ts` fail with `mock.module is not a function` under Node 25.6 — both are environmental issues unaffected by these doc changes (verified by `git stash` round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)