### PR TITLE
fix(sdk): drop misleading inherit deprecation warning from bundleDeploy

### DIFF
--- a/sdk/src/namespaces/apps.ts
+++ b/sdk/src/namespaces/apps.ts
@@ -156,7 +156,7 @@ export class Apps {
    * the only behavior change vs. v1's blind re-execution and is safe for
    * idempotent migrations (the documented agent norm).
    *
-   * `inherit: true` is silently ignored with a one-time deprecation warning;
+   * `inherit: true` is silently ignored;
    * patch semantics on `r.deploy.apply` replace it.
    */
   async bundleDeploy(
@@ -165,8 +165,6 @@ export class Apps {
   ): Promise<BundleDeployResult> {
     const project = await this.client.getProject(projectId);
     if (!project) throw new ProjectNotFound(projectId, "deploying bundle");
-
-    if (opts.inherit) warnInheritOnce();
 
     const spec = await translateBundleToReleaseSpec(projectId, opts);
     const deploy = new Deploy(this.client);
@@ -302,16 +300,6 @@ export class Apps {
 }
 
 // ─── bundleDeploy compat shim helpers ────────────────────────────────────────
-
-let inheritWarned = false;
-function warnInheritOnce(): void {
-  if (inheritWarned) return;
-  inheritWarned = true;
-  // eslint-disable-next-line no-console
-  console.warn(
-    "[run402] bundleDeploy: `inherit: true` is deprecated. The v2 deploy primitive uses explicit replace/patch semantics; pass `r.deploy.apply({ ..., site: { patch: { put: {...} } } })` for partial updates. The flag will be ignored.",
-  );
-}
 
 async function translateBundleToReleaseSpec(
   projectId: string,


### PR DESCRIPTION
## Summary
- The `[run402] bundleDeploy: \`inherit: true\` is deprecated...` console warning in `sdk/src/namespaces/apps.ts` fired unconditionally before the deploy ran. When an unrelated error followed (e.g. the `expose.tables` shape mismatch tracked in #154), callers read the warning first and assumed removing `inherit: true` would fix the failure — it didn't.
- Removed `warnInheritOnce` and its call site. The deprecation is preserved in the `bundleDeploy` JSDoc; the flag continues to be silently ignored as before.

## Test plan
- [x] `npx tsc --noEmit` (root + core + sdk) — clean
- [x] `npm run build` — passes
- [x] `npm test` — 479 unit + 271 CLI-e2e, 0 fail, 2 skipped (matches pre-change baseline)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)