### PR TITLE
CLI error envelope cleanup (4 fixes)

### DIFF
--- a/cli-e2e.test.mjs
+++ b/cli-e2e.test.mjs
@@ -1104,10 +1104,10 @@ describe("CLI e2e happy path", () => {
     assert.equal(parsed.status, "error");
     assert.ok(parsed.message && parsed.message.includes(missingName),
       `message should mention missing filename, got: ${parsed.message}`);
-    assert.equal(parsed.field, "files[0].path",
-      `field should identify the offending manifest field, got: ${parsed.field}`);
-    assert.ok(parsed.path && parsed.path.endsWith(missingName),
-      `path should be the absolute missing path, got: ${parsed.path}`);
+    assert.equal(parsed.details?.field, "files[0].path",
+      `details.field should identify the offending manifest field, got: ${parsed.details?.field}`);
+    assert.ok(parsed.details?.path && parsed.details.path.endsWith(missingName),
+      `details.path should be the absolute missing path, got: ${parsed.details?.path}`);
     assert.ok(parsed.hint && /relative to the manifest/i.test(parsed.hint),
       `hint should explain relative-path resolution, got: ${parsed.hint}`);
     // No raw `stack` field should be leaked.
@@ -1145,10 +1145,10 @@ describe("CLI e2e happy path", () => {
     assert.equal(parsed.status, "error");
     assert.ok(parsed.message && parsed.message.includes(missingName),
       `message should mention missing SQL filename, got: ${parsed.message}`);
-    assert.equal(parsed.field, "migrations_file",
-      `field should be migrations_file, got: ${parsed.field}`);
-    assert.ok(parsed.path && parsed.path.endsWith(missingName),
-      `path should be the absolute missing path, got: ${parsed.path}`);
+    assert.equal(parsed.details?.field, "migrations_file",
+      `details.field should be migrations_file, got: ${parsed.details?.field}`);
+    assert.ok(parsed.details?.path && parsed.details.path.endsWith(missingName),
+      `details.path should be the absolute missing path, got: ${parsed.details?.path}`);
     assert.ok(parsed.hint && /relative to the manifest/i.test(parsed.hint),
       `hint should explain relative-path resolution, got: ${parsed.hint}`);
   });
@@ -1176,10 +1176,10 @@ describe("CLI e2e happy path", () => {
     assert.ok(line, `should emit a JSON error line on stderr, got: ${stderr}`);
     const parsed = JSON.parse(line);
     assert.equal(parsed.status, "error");
-    assert.equal(parsed.field, "manifest",
-      `field should be manifest, got: ${parsed.field}`);
-    assert.ok(parsed.path && parsed.path.endsWith("definitely-not-a-real-manifest.json"),
-      `path should be the absolute missing manifest path, got: ${parsed.path}`);
+    assert.equal(parsed.details?.field, "manifest",
+      `details.field should be manifest, got: ${parsed.details?.field}`);
+    assert.ok(parsed.details?.path && parsed.details.path.endsWith("definitely-not-a-real-manifest.json"),
+      `details.path should be the absolute missing manifest path, got: ${parsed.details?.path}`);
     assert.ok(parsed.hint, `hint should be present, got: ${parsed.hint}`);
   });
 
@@ -2843,5 +2843,202 @@ describe("CLI init rail-switch guard (GH-210)", () => {
     assert.equal(parsed.details?.requested_rail, "x402");
     const after = JSON.parse(readFileSync(ALLOWANCE_FILE, "utf8"));
     assert.equal(after.rail, before.rail, "allowance.rail must NOT change without --switch-rail");
+  });
+});
+
+// ── Canonical error envelope migration (GH-215, GH-174, GH-191, GH-177) ────
+// Every client-side validation failure emits the same shape:
+// {status:"error", code, message, retryable, safe_to_retry, hint?, details?,
+//  next_actions, trace_id}. Exits with code 1 (status === "ok" ? 0 : 1).
+
+describe("CLI canonical error envelope (GH-215, GH-174)", () => {
+  function parseStderrJson() {
+    const stderr = capturedStderr();
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{"));
+    assert.ok(line, `expected JSON envelope on stderr, got: ${stderr}`);
+    return JSON.parse(line);
+  }
+
+  it("subdomains claim with empty name emits BAD_USAGE envelope", async () => {
+    const { run } = await import("./cli/lib/subdomains.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("claim", [""]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+    }
+    assert.equal(threw?.message, "process.exit(1)");
+    const parsed = parseStderrJson();
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "BAD_USAGE");
+    assert.ok(/run402 subdomains claim/.test(parsed.hint || ""), `hint should retain usage, got: ${parsed.hint}`);
+  });
+
+  it("subdomains claim without deployment emits NO_DEPLOYMENT envelope", async () => {
+    const { setActiveProjectId, saveProject } = await import("./cli/lib/config.mjs");
+    saveProject("prj_no_deploy_test", { anon_key: "a", service_key: "s" });
+    setActiveProjectId("prj_no_deploy_test");
+
+    const { run } = await import("./cli/lib/subdomains.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("claim", ["foo"]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+      const { removeProject } = await import("./cli/lib/config.mjs");
+      removeProject("prj_no_deploy_test");
+      setActiveProjectId("prj_test123");
+    }
+    assert.equal(threw?.message, "process.exit(1)");
+    const parsed = parseStderrJson();
+    assert.equal(parsed.code, "NO_DEPLOYMENT");
+    assert.ok(Array.isArray(parsed.next_actions), "next_actions should be an array");
+    assert.deepEqual(parsed.next_actions, [{ action: "deploy_site_first" }],
+      `next_actions should populate with deploy_site_first, got: ${JSON.stringify(parsed.next_actions)}`);
+  });
+
+  it("domains add with no args emits BAD_USAGE envelope with usage hint", async () => {
+    const { run } = await import("./cli/lib/domains.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("add", []);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+    }
+    assert.equal(threw?.message, "process.exit(1)");
+    const parsed = parseStderrJson();
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "BAD_USAGE");
+    assert.ok(/run402 domains add/.test(parsed.hint || ""), `hint should mention usage, got: ${parsed.hint}`);
+  });
+
+  it("blob put with unknown local project emits PROJECT_NOT_FOUND with details.source: local_registry", async () => {
+    const { run } = await import("./cli/lib/blob.mjs");
+    const tmpFile = join(tempDir, "blob-put-canary.bin");
+    const { writeFileSync: wf } = await import("node:fs");
+    wf(tmpFile, "x");
+    let threw = null;
+    captureStart();
+    try {
+      await run("put", [tmpFile, "--project", "prj_xxx_unknown"]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+    }
+    assert.equal(threw?.message, "process.exit(1)");
+    const parsed = parseStderrJson();
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "PROJECT_NOT_FOUND");
+    assert.equal(parsed.details?.project_id, "prj_xxx_unknown");
+    assert.equal(parsed.details?.source, "local_registry",
+      `must distinguish local-registry miss from gateway 404, got: ${JSON.stringify(parsed.details)}`);
+  });
+});
+
+describe("CLI status exit codes (GH-191)", () => {
+  it("status with no allowance exits 1 with status: no_allowance", async () => {
+    const { ALLOWANCE_FILE } = await import("./cli/lib/config.mjs");
+    try { rmSync(ALLOWANCE_FILE, { force: true }); } catch {}
+    const { run } = await import("./cli/lib/status.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run([]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+    }
+    assert.equal(threw?.message, "process.exit(1)",
+      "status with no allowance must exit 1 (status !== 'ok' rule), got: " + (threw?.message || "no exit"));
+    const stdout = capturedStdout();
+    const line = stdout.split("\n").find(s => s.trim().startsWith("{"));
+    assert.ok(line, `should emit status payload on stdout, got: ${stdout}`);
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.status, "no_allowance",
+      `payload status should remain 'no_allowance' for shell sentinels, got: ${parsed.status}`);
+  });
+
+  it("allowance status with no allowance exits 1 with status: no_wallet", async () => {
+    const { ALLOWANCE_FILE } = await import("./cli/lib/config.mjs");
+    try { rmSync(ALLOWANCE_FILE, { force: true }); } catch {}
+    const { run } = await import("./cli/lib/allowance.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("status", []);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+      // Restore the allowance for any following test that expects it set.
+      const { saveAllowance } = await import("./cli/lib/config.mjs");
+      saveAllowance({
+        address: "0x1234567890123456789012345678901234567890",
+        privateKey: "0x" + "11".repeat(32),
+        created: "2026-01-01T00:00:00.000Z",
+        funded: true,
+        rail: "x402",
+      });
+    }
+    assert.equal(threw?.message, "process.exit(1)",
+      "allowance status with no wallet must exit 1, got: " + (threw?.message || "no exit"));
+  });
+});
+
+describe("CLI contracts JSON-flag parse errors (GH-177)", () => {
+  function parseStderrJson() {
+    const stderr = capturedStderr();
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{"));
+    assert.ok(line, `expected JSON envelope on stderr, got: ${stderr}`);
+    return JSON.parse(line);
+  }
+
+  it("contracts call --abi 'not json' names the offending flag", async () => {
+    const { saveProject } = await import("./cli/lib/config.mjs");
+    saveProject("prj_contracts_test", { anon_key: "a", service_key: "s" });
+    const { run } = await import("./cli/lib/contracts.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("call", [
+        "prj_contracts_test", "cwlt_xyz",
+        "--to", "0xabc",
+        "--abi", "not json",
+        "--fn", "ping",
+        "--args", "[]",
+      ]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+      const { removeProject } = await import("./cli/lib/config.mjs");
+      removeProject("prj_contracts_test");
+    }
+    assert.equal(threw?.message, "process.exit(1)");
+    const parsed = parseStderrJson();
+    assert.equal(parsed.code, "BAD_JSON_FLAG");
+    assert.equal(parsed.details?.flag, "--abi",
+      `must name the offending flag, got: ${JSON.stringify(parsed.details)}`);
+    assert.ok(parsed.details?.value_preview, "must include value_preview");
+    assert.ok(parsed.details?.parse_error, "must include parse_error");
+  });
+
+  it("contracts read --abi '{garbage' names --abi (first bad flag wins)", async () => {
+    const { run } = await import("./cli/lib/contracts.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("read", [
+        "--chain", "base-sepolia",
+        "--to", "0xabc",
+        "--abi", "{garbage",
+        "--fn", "ping",
+        "--args", "[]",
+      ]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+    }
+    assert.equal(threw?.message, "process.exit(1)");
+    const parsed = parseStderrJson();
+    assert.equal(parsed.code, "BAD_JSON_FLAG");
+    assert.equal(parsed.details?.flag, "--abi",
+      `with both --abi and --args potentially bad, --abi parses first and wins; got: ${JSON.stringify(parsed.details)}`);
   });
 });

--- a/cli/lib/agent.mjs
+++ b/cli/lib/agent.mjs
@@ -1,6 +1,6 @@
 import { allowanceAuthHeaders } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 agent — Manage agent identity
 
@@ -24,7 +24,9 @@ async function contact(args) {
     if (args[i] === "--email" && args[i + 1]) email = args[++i];
     if (args[i] === "--webhook" && args[i + 1]) webhook = args[++i];
   }
-  if (!name) { console.error(JSON.stringify({ status: "error", message: "Missing --name <name>" })); process.exit(1); }
+  if (!name) {
+    fail({ code: "BAD_USAGE", message: "Missing --name <name>" });
+  }
   // Preserve the aggressive early exit when no allowance is configured.
   allowanceAuthHeaders("/agent/v1/contact");
 

--- a/cli/lib/ai.mjs
+++ b/cli/lib/ai.mjs
@@ -1,6 +1,6 @@
 import { resolveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 ai — AI translation and moderation tools
 
@@ -76,8 +76,16 @@ async function translate(args) {
   const from = parseFlag(args, "--from");
   const context = parseFlag(args, "--context");
 
-  if (!text) { console.error(JSON.stringify({ status: "error", message: "Text required. Usage: run402 ai translate <project_id> <text> --to <lang>" })); process.exit(1); }
-  if (!to) { console.error(JSON.stringify({ status: "error", message: "--to <lang> is required" })); process.exit(1); }
+  if (!text) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Text required.",
+      hint: "run402 ai translate <project_id> <text> --to <lang>",
+    });
+  }
+  if (!to) {
+    fail({ code: "BAD_USAGE", message: "--to <lang> is required" });
+  }
 
   try {
     const data = await getSdk().ai.translate(projectId, { text, to, from: from ?? undefined, context: context ?? undefined });
@@ -101,7 +109,13 @@ async function moderate(args) {
   const projectId = resolveProjectId(projectOpt || positional[0]);
   text = positional[1] || null;
 
-  if (!text) { console.error(JSON.stringify({ status: "error", message: "Text required. Usage: run402 ai moderate <project_id> <text>" })); process.exit(1); }
+  if (!text) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Text required.",
+      hint: "run402 ai moderate <project_id> <text>",
+    });
+  }
 
   try {
     const data = await getSdk().ai.moderate(projectId, text);

--- a/cli/lib/allowance.mjs
+++ b/cli/lib/allowance.mjs
@@ -1,6 +1,6 @@
 import { readAllowance, saveAllowance, ALLOWANCE_FILE, API } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 allowance — Manage your agent allowance
 
@@ -82,7 +82,7 @@ async function status() {
     const data = await getSdk().allowance.status();
     if (!data.configured) {
       console.log(JSON.stringify({ status: "no_wallet", message: "No agent allowance found. Run: run402 allowance create" }));
-      return;
+      process.exit(1);
     }
     // Preserve CLI's rail field (SDK doesn't surface it; read from local allowance).
     const w = readAllowance();
@@ -115,8 +115,11 @@ async function create() {
   } catch (err) {
     const msg = (err instanceof Error) ? err.message : String(err);
     if (/already exists/i.test(msg)) {
-      console.log(JSON.stringify({ status: "error", message: "Agent allowance already exists. Use 'status' to check it." }));
-      process.exit(1);
+      fail({
+        code: "ALLOWANCE_EXISTS",
+        message: "Agent allowance already exists.",
+        hint: "Use 'status' to check it.",
+      });
     }
     reportSdkError(err);
   }
@@ -124,7 +127,13 @@ async function create() {
 
 async function fund() {
   const w = readAllowance();
-  if (!w) { console.log(JSON.stringify({ status: "error", message: "No agent allowance. Run: run402 allowance create" })); process.exit(1); }
+  if (!w) {
+    fail({
+      code: "NO_ALLOWANCE",
+      message: "No agent allowance.",
+      hint: "Run: run402 allowance create",
+    });
+  }
 
   if (w.rail === "mpp") {
     // Tempo Moderato faucet — instant, no polling needed
@@ -139,8 +148,11 @@ async function fund() {
     });
     const data = await res.json();
     if (data.error) {
-      console.log(JSON.stringify({ status: "error", message: data.error.message || "Tempo faucet failed" }));
-      process.exit(1);
+      fail({
+        code: "FAUCET_FAILED",
+        message: data.error.message || "Tempo faucet failed",
+        details: { rail: "mpp" },
+      });
     }
 
     // Re-read balance once (instant confirmation)
@@ -164,8 +176,11 @@ async function fund() {
   const res = await fetch(`${API}/faucet/v1`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ address: w.address }) });
   const data = await res.json();
   if (!res.ok) {
-    console.log(JSON.stringify({ status: "error", ...data }));
-    process.exit(1);
+    fail({
+      code: data?.code || "FAUCET_FAILED",
+      message: data?.message || "Faucet request failed",
+      details: { http: res.status, ...data },
+    });
   }
 
   const MAX_WAIT = 30;
@@ -196,7 +211,13 @@ async function readUsdcBalance(client, usdc, address) {
 
 async function balance() {
   const w = readAllowance();
-  if (!w) { console.log(JSON.stringify({ status: "error", message: "No agent allowance. Run: run402 allowance create" })); process.exit(1); }
+  if (!w) {
+    fail({
+      code: "NO_ALLOWANCE",
+      message: "No agent allowance.",
+      hint: "Run: run402 allowance create",
+    });
+  }
 
   const { createPublicClient, http, base, baseSepolia, tempoModerato } = await loadDeps();
   const mainnetClient = createPublicClient({ chain: base, transport: http() });
@@ -229,19 +250,30 @@ async function exportAddr() {
     const address = await getSdk().allowance.export();
     console.log(address);
   } catch {
-    console.log(JSON.stringify({ status: "error", message: "No agent allowance." }));
-    process.exit(1);
+    fail({ code: "NO_ALLOWANCE", message: "No agent allowance." });
   }
 }
 
 async function checkout(args) {
   const w = readAllowance();
-  if (!w) { console.log(JSON.stringify({ status: "error", message: "No agent allowance. Run: run402 allowance create" })); process.exit(1); }
+  if (!w) {
+    fail({
+      code: "NO_ALLOWANCE",
+      message: "No agent allowance.",
+      hint: "Run: run402 allowance create",
+    });
+  }
   let amount = null;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--amount" && args[i + 1]) amount = parseInt(args[++i], 10);
   }
-  if (!amount) { console.error(JSON.stringify({ status: "error", message: "Missing --amount <usd_micros> (e.g. --amount 5000000 for $5)" })); process.exit(1); }
+  if (!amount) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing --amount <usd_micros>",
+      hint: "e.g. --amount 5000000 for $5",
+    });
+  }
   const res = await fetch(`${API}/billing/v1/checkouts`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -254,7 +286,13 @@ async function checkout(args) {
 
 async function history(args) {
   const w = readAllowance();
-  if (!w) { console.log(JSON.stringify({ status: "error", message: "No agent allowance. Run: run402 allowance create" })); process.exit(1); }
+  if (!w) {
+    fail({
+      code: "NO_ALLOWANCE",
+      message: "No agent allowance.",
+      hint: "Run: run402 allowance create",
+    });
+  }
   let limit = 20;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--limit" && args[i + 1]) limit = parseInt(args[++i], 10);

--- a/cli/lib/apps.mjs
+++ b/cli/lib/apps.mjs
@@ -1,6 +1,6 @@
 import { allowanceAuthHeaders, saveProject } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 apps — Browse and manage the app marketplace
 
@@ -177,7 +177,9 @@ async function versions(projectId) {
 }
 
 async function inspect(versionId) {
-  if (!versionId) { console.error(JSON.stringify({ status: "error", message: "Missing version ID" })); process.exit(1); }
+  if (!versionId) {
+    fail({ code: "BAD_USAGE", message: "Missing version ID" });
+  }
   try {
     const data = await getSdk().apps.getApp(versionId);
     console.log(JSON.stringify(data, null, 2));

--- a/cli/lib/auth.mjs
+++ b/cli/lib/auth.mjs
@@ -1,6 +1,6 @@
 import { findProject, resolveProjectId, API } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 auth — Manage project user authentication
 
@@ -121,8 +121,12 @@ async function magicLink(args) {
   const redirect = parseFlag(args, "--redirect");
   const projectId = resolveProjectId(parseFlag(args, "--project"));
 
-  if (!email) { console.error(JSON.stringify({ status: "error", message: "Missing --email" })); process.exit(1); }
-  if (!redirect) { console.error(JSON.stringify({ status: "error", message: "Missing --redirect <url>" })); process.exit(1); }
+  if (!email) {
+    fail({ code: "BAD_USAGE", message: "Missing --email" });
+  }
+  if (!redirect) {
+    fail({ code: "BAD_USAGE", message: "Missing --redirect <url>" });
+  }
 
   try {
     await getSdk().auth.requestMagicLink(projectId, { email, redirectUrl: redirect });
@@ -136,7 +140,9 @@ async function verify(args) {
   const token = parseFlag(args, "--token");
   const projectId = resolveProjectId(parseFlag(args, "--project"));
 
-  if (!token) { console.error(JSON.stringify({ status: "error", message: "Missing --token" })); process.exit(1); }
+  if (!token) {
+    fail({ code: "BAD_USAGE", message: "Missing --token" });
+  }
 
   try {
     const data = await getSdk().auth.verifyMagicLink(projectId, token);
@@ -152,8 +158,12 @@ async function setPassword(args) {
   const currentPassword = parseFlag(args, "--current");
   const projectId = resolveProjectId(parseFlag(args, "--project"));
 
-  if (!accessToken) { console.error(JSON.stringify({ status: "error", message: "Missing --token <bearer_token>" })); process.exit(1); }
-  if (!newPassword) { console.error(JSON.stringify({ status: "error", message: "Missing --new <password>" })); process.exit(1); }
+  if (!accessToken) {
+    fail({ code: "BAD_USAGE", message: "Missing --token <bearer_token>" });
+  }
+  if (!newPassword) {
+    fail({ code: "BAD_USAGE", message: "Missing --new <password>" });
+  }
 
   try {
     await getSdk().auth.setUserPassword(projectId, {
@@ -171,7 +181,12 @@ async function settings(args) {
   const allowPasswordSet = parseFlag(args, "--allow-password-set");
   const projectId = resolveProjectId(parseFlag(args, "--project"));
 
-  if (allowPasswordSet === null) { console.error(JSON.stringify({ status: "error", message: "Missing --allow-password-set <true|false>" })); process.exit(1); }
+  if (allowPasswordSet === null) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing --allow-password-set <true|false>",
+    });
+  }
 
   try {
     await getSdk().auth.settings(projectId, { allow_password_set: allowPasswordSet === "true" });

--- a/cli/lib/billing.mjs
+++ b/cli/lib/billing.mjs
@@ -1,6 +1,6 @@
 import { API } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 billing — Email billing accounts, Stripe tier checkout, email packs
 
@@ -97,8 +97,11 @@ function parseFlag(args, flag) {
 async function createEmail(args) {
   const email = args[0];
   if (!email) {
-    console.error(JSON.stringify({ status: "error", message: "Missing email. Usage: run402 billing create-email <email>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing email.",
+      hint: "run402 billing create-email <email>",
+    });
   }
   try {
     const data = await getSdk().billing.createEmailAccount(email);
@@ -112,8 +115,11 @@ async function linkWallet(args) {
   const accountId = args[0];
   const wallet = args[1];
   if (!accountId || !wallet) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 billing link-wallet <account_id> <wallet>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <account_id> and/or <wallet>.",
+      hint: "run402 billing link-wallet <account_id> <wallet>",
+    });
   }
   try {
     await getSdk().billing.linkWallet(accountId, wallet);
@@ -126,14 +132,16 @@ async function linkWallet(args) {
 async function tierCheckout(args) {
   const tier = args[0];
   if (!tier) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 billing tier-checkout <tier> [--email <e> | --wallet <w>]" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <tier>.",
+      hint: "run402 billing tier-checkout <tier> [--email <e> | --wallet <w>]",
+    });
   }
   const email = parseFlag(args, "--email");
   const wallet = parseFlag(args, "--wallet");
   if (!email && !wallet) {
-    console.error(JSON.stringify({ status: "error", message: "Must provide --email or --wallet" }));
-    process.exit(1);
+    fail({ code: "BAD_USAGE", message: "Must provide --email or --wallet" });
   }
   try {
     const data = await getSdk().billing.tierCheckout(tier, { email: email ?? undefined, wallet: wallet ?? undefined });
@@ -147,8 +155,7 @@ async function buyPack(args) {
   const email = parseFlag(args, "--email");
   const wallet = parseFlag(args, "--wallet");
   if (!email && !wallet) {
-    console.error(JSON.stringify({ status: "error", message: "Must provide --email or --wallet" }));
-    process.exit(1);
+    fail({ code: "BAD_USAGE", message: "Must provide --email or --wallet" });
   }
   try {
     const data = await getSdk().billing.buyEmailPack({ email: email ?? undefined, wallet: wallet ?? undefined });
@@ -162,8 +169,11 @@ async function autoRecharge(args) {
   const accountId = args[0];
   const state = args[1];
   if (!accountId || !state || !["on", "off"].includes(state)) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 billing auto-recharge <account_id> <on|off> [--threshold <n>]" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <account_id> and/or <on|off>.",
+      hint: "run402 billing auto-recharge <account_id> <on|off> [--threshold <n>]",
+    });
   }
   const thresholdStr = parseFlag(args, "--threshold");
   try {
@@ -182,8 +192,11 @@ async function balance(args) {
   // Accepts email OR wallet — SDK only models wallet, so keep direct fetch.
   const id = args[0];
   if (!id) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 billing balance <email-or-wallet>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <email-or-wallet>.",
+      hint: "run402 billing balance <email-or-wallet>",
+    });
   }
   const res = await fetch(`${API}/billing/v1/accounts/${encodeURIComponent(id)}`);
   const data = await res.json();
@@ -194,8 +207,11 @@ async function balance(args) {
 async function history(args) {
   const id = args[0];
   if (!id) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 billing history <email-or-wallet> [--limit <n>]" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <email-or-wallet>.",
+      hint: "run402 billing history <email-or-wallet> [--limit <n>]",
+    });
   }
   const limit = parseFlag(args, "--limit") || "50";
   const res = await fetch(`${API}/billing/v1/accounts/${encodeURIComponent(id)}/history?limit=${encodeURIComponent(limit)}`);

--- a/cli/lib/blob.mjs
+++ b/cli/lib/blob.mjs
@@ -36,7 +36,7 @@ import { pipeline } from "node:stream/promises";
 
 import { resolveProject, resolveProjectId, API } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 blob — Direct-to-S3 blob storage
 
@@ -182,9 +182,8 @@ Examples:
 
 const UPLOAD_STATE_DIR = join(homedir(), ".run402", "uploads");
 
-function die(msg, code = 1) {
-  console.error(JSON.stringify({ status: "error", message: msg }));
-  process.exit(code);
+function die(msg, exit_code = 1) {
+  fail({ code: "BAD_USAGE", message: msg, exit_code });
 }
 
 function parseArgs(args) {

--- a/cli/lib/cdn.mjs
+++ b/cli/lib/cdn.mjs
@@ -15,7 +15,7 @@
 
 import { resolveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 cdn — CloudFront CDN diagnostics for public blob URLs
 
@@ -68,9 +68,8 @@ Examples:
 `,
 };
 
-function die(msg, code = 1) {
-  console.error(JSON.stringify({ status: "error", message: msg }));
-  process.exit(code);
+function die(msg, exit_code = 1) {
+  fail({ code: "BAD_USAGE", message: msg, exit_code });
 }
 
 function parseArgs(args) {

--- a/cli/lib/config.mjs
+++ b/cli/lib/config.mjs
@@ -7,6 +7,7 @@ import { getApiBase, getConfigDir, getKeystorePath, getAllowancePath } from "../
 import { readAllowance as coreReadAllowance, saveAllowance as coreSaveAllowance } from "../core-dist/allowance.js";
 import { loadKeyStore, getProject, saveProject, updateProject, removeProject, saveKeyStore, getActiveProjectId, setActiveProjectId } from "../core-dist/keystore.js";
 import { getAllowanceAuthHeaders as coreGetAllowanceAuthHeaders } from "../core-dist/allowance-auth.js";
+import { fail } from "./sdk-errors.mjs";
 
 export const CONFIG_DIR = getConfigDir();
 export const ALLOWANCE_FILE = getAllowancePath();
@@ -23,31 +24,54 @@ export function saveAllowance(data) {
 
 export function allowanceAuthHeaders(path) {
   const headers = coreGetAllowanceAuthHeaders(path);
-  if (!headers) { console.error(JSON.stringify({ status: "error", message: "No agent allowance found. Run: run402 allowance create" })); process.exit(1); }
+  if (!headers) {
+    fail({
+      code: "NO_ALLOWANCE",
+      message: "No agent allowance found.",
+      hint: "Run: run402 allowance create",
+    });
+  }
   return headers;
 }
 
 export function findProject(id) {
   const p = getProject(id);
   if (!p) {
-    const hint = id && !id.startsWith("prj_")
-      ? ` Hint: project IDs start with "prj_". Check that the argument order is <project_id> <name>.`
-      : "";
-    console.error(`Project ${id} not found in local registry.${hint}`);
-    process.exit(1);
+    const idStr = id ?? "";
+    const hint = idStr && !String(idStr).startsWith("prj_")
+      ? `project IDs start with "prj_". Check that the argument order is <project_id> <name>.`
+      : undefined;
+    fail({
+      code: "PROJECT_NOT_FOUND",
+      message: `Project ${idStr} not found in local registry.`,
+      hint,
+      details: { project_id: idStr, source: "local_registry" },
+    });
   }
   return p;
 }
 
 export function resolveProject(id) {
   const projectId = id || getActiveProjectId();
-  if (!projectId) { console.error("Error: no project specified and no active project set. Run: run402 projects provision"); process.exit(1); }
+  if (!projectId) {
+    fail({
+      code: "NO_ACTIVE_PROJECT",
+      message: "no project specified and no active project set.",
+      hint: "Run: run402 projects provision",
+    });
+  }
   return findProject(projectId);
 }
 
 export function resolveProjectId(id) {
   const projectId = id || getActiveProjectId();
-  if (!projectId) { console.error("Error: no project specified and no active project set. Run: run402 projects provision"); process.exit(1); }
+  if (!projectId) {
+    fail({
+      code: "NO_ACTIVE_PROJECT",
+      message: "no project specified and no active project set.",
+      hint: "Run: run402 projects provision",
+    });
+  }
   return projectId;
 }
 

--- a/cli/lib/contracts.mjs
+++ b/cli/lib/contracts.mjs
@@ -1,6 +1,6 @@
 import { findProject, API } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail, parseFlagJson } from "./sdk-errors.mjs";
 
 const HELP = `run402 contracts — KMS-backed Ethereum wallets for smart-contract calls
 
@@ -100,8 +100,10 @@ async function provisionWallet(projectId, args) {
   const p = findProject(projectId);
   const chain = parseFlag(args, "--chain");
   if (!chain) {
-    console.error(JSON.stringify({ status: "error", message: "Missing --chain (base-mainnet or base-sepolia)" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing --chain (base-mainnet or base-sepolia)",
+    });
   }
   const recovery = parseFlag(args, "--recovery");
   // Soft default of one wallet — confirm if project already has one. This
@@ -115,8 +117,11 @@ async function provisionWallet(projectId, args) {
       const list = await listRes.json();
       const active = (list.wallets || []).filter((w) => w.status === "active");
       if (active.length >= 1 && !hasFlag(args, "--yes")) {
-        console.error(`This project already has ${active.length} active wallet(s). Adding another costs $0.04/day each ($1.20/month). Re-run with --yes to confirm.`);
-        process.exit(1);
+        fail({
+          code: "CONFIRMATION_REQUIRED",
+          message: `This project already has ${active.length} active wallet(s). Adding another costs $0.04/day each ($1.20/month). Re-run with --yes to confirm.`,
+          details: { active_wallets: active.length },
+        });
       }
     }
   } catch { /* best-effort */ }
@@ -154,8 +159,10 @@ async function setRecovery(projectId, walletId, args) {
   const clear = hasFlag(args, "--clear");
   const address = parseFlag(args, "--address");
   if (!clear && !address) {
-    console.error(JSON.stringify({ status: "error", message: "Provide --address 0x... or --clear" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Provide --address 0x... or --clear",
+    });
   }
   try {
     await getSdk().contracts.setRecovery(projectId, walletId, clear ? null : address);
@@ -168,8 +175,7 @@ async function setRecovery(projectId, walletId, args) {
 async function setAlert(projectId, walletId, args) {
   const threshold = parseFlag(args, "--threshold-wei");
   if (!threshold) {
-    console.error(JSON.stringify({ status: "error", message: "Missing --threshold-wei <n>" }));
-    process.exit(1);
+    fail({ code: "BAD_USAGE", message: "Missing --threshold-wei <n>" });
   }
   try {
     await getSdk().contracts.setLowBalanceAlert(projectId, walletId, threshold);
@@ -188,17 +194,22 @@ async function call(projectId, walletId, args) {
   const chain = parseFlag(args, "--chain") || "base-mainnet";
   const idempotency = parseFlag(args, "--idempotency-key");
   if (!to || !abi || !fn || !argsJson) {
-    console.error(JSON.stringify({ status: "error", message: "Required flags: --to, --abi, --fn, --args. Cost: chain gas + $0.000005 KMS sign fee." }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Required flags: --to, --abi, --fn, --args.",
+      hint: "Cost: chain gas + $0.000005 KMS sign fee.",
+    });
   }
+  const abiFragment = parseFlagJson("--abi", abi);
+  const callArgs = parseFlagJson("--args", argsJson);
   try {
     const data = await getSdk().contracts.call(projectId, {
       walletId,
       chain,
       contractAddress: to,
-      abiFragment: JSON.parse(abi),
+      abiFragment,
       functionName: fn,
-      args: JSON.parse(argsJson),
+      args: callArgs,
       value: value ?? undefined,
       idempotencyKey: idempotency ?? undefined,
     });
@@ -215,16 +226,20 @@ async function read(args) {
   const fn = parseFlag(args, "--fn");
   const argsJson = parseFlag(args, "--args");
   if (!chain || !to || !abi || !fn || !argsJson) {
-    console.error(JSON.stringify({ status: "error", message: "Required flags: --chain, --to, --abi, --fn, --args" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Required flags: --chain, --to, --abi, --fn, --args",
+    });
   }
+  const abiFragment = parseFlagJson("--abi", abi);
+  const callArgs = parseFlagJson("--args", argsJson);
   try {
     const data = await getSdk().contracts.read({
       chain,
       contractAddress: to,
-      abiFragment: JSON.parse(abi),
+      abiFragment,
       functionName: fn,
-      args: JSON.parse(argsJson),
+      args: callArgs,
     });
     console.log(JSON.stringify(data, null, 2));
   } catch (err) {
@@ -244,8 +259,11 @@ async function status(projectId, callId) {
 async function drain(projectId, walletId, args) {
   const to = parseFlag(args, "--to");
   if (!to || !hasFlag(args, "--confirm")) {
-    console.error(JSON.stringify({ status: "error", message: "Required: --to 0x... and --confirm. Cost: chain gas + $0.000005 KMS sign fee." }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Required: --to 0x... and --confirm.",
+      hint: "Cost: chain gas + $0.000005 KMS sign fee.",
+    });
   }
   try {
     const data = await getSdk().contracts.drain(projectId, walletId, to);
@@ -257,8 +275,7 @@ async function drain(projectId, walletId, args) {
 
 async function deleteWallet(projectId, walletId, args) {
   if (!hasFlag(args, "--confirm")) {
-    console.error(JSON.stringify({ status: "error", message: "Required: --confirm" }));
-    process.exit(1);
+    fail({ code: "BAD_USAGE", message: "Required: --confirm" });
   }
   try {
     const data = await getSdk().contracts.deleteWallet(projectId, walletId);

--- a/cli/lib/deploy-v2.mjs
+++ b/cli/lib/deploy-v2.mjs
@@ -26,7 +26,7 @@
 import { readFileSync } from "node:fs";
 import { resolve, dirname, isAbsolute, join } from "node:path";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 import { allowanceAuthHeaders, resolveProjectId } from "./config.mjs";
 
 const APPLY_HELP = `run402 deploy apply — Unified deploy primitive (v1.34+)
@@ -107,8 +107,11 @@ export async function runDeployV2(sub, args) {
   if (sub === "resume") return await resumeCmd(args);
   if (sub === "list") return await listCmd(args);
   if (sub === "events") return await eventsCmd(args);
-  console.error(JSON.stringify({ status: "error", message: `Unknown deploy subcommand: ${sub}` }));
-  process.exit(1);
+  fail({
+    code: "BAD_USAGE",
+    message: `Unknown deploy subcommand: ${sub}`,
+    details: { subcommand: sub },
+  });
 }
 
 async function readStdin() {
@@ -142,8 +145,11 @@ async function applyCmd(args) {
       const manifestPath = isAbsolute(opts.manifest) ? opts.manifest : resolve(process.cwd(), opts.manifest);
       raw = readFileSync(manifestPath, "utf-8");
     } catch (err) {
-      console.error(JSON.stringify({ status: "error", message: `Failed to read manifest: ${err.message}` }));
-      process.exit(1);
+      fail({
+        code: "BAD_USAGE",
+        message: `Failed to read manifest: ${err.message}`,
+        details: { flag: "--manifest", path: opts.manifest },
+      });
     }
   } else {
     raw = await readStdin();
@@ -153,18 +159,21 @@ async function applyCmd(args) {
   try {
     spec = JSON.parse(raw);
   } catch (err) {
-    console.error(JSON.stringify({ status: "error", message: `Manifest is not valid JSON: ${err.message}` }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: `Manifest is not valid JSON: ${err.message}`,
+      details: { source: opts.manifest ? "manifest" : opts.spec ? "spec" : "stdin", parse_error: err.message },
+    });
   }
 
   if (opts.manifest) resolveFileDataPaths(spec, dirname(resolve(opts.manifest)));
 
   if (opts.project && spec.project_id && spec.project_id !== opts.project) {
-    console.error(JSON.stringify({
-      status: "error",
+    fail({
+      code: "BAD_USAGE",
       message: `project_id conflict: spec.project_id=${spec.project_id} but --project=${opts.project}`,
-    }));
-    process.exit(1);
+      details: { spec_project_id: spec.project_id, flag_project_id: opts.project },
+    });
   }
   if (opts.project) spec.project_id = opts.project;
   if (!spec.project_id) spec.project_id = resolveProjectId(null);
@@ -198,8 +207,11 @@ async function resumeCmd(args) {
     if (!args[i].startsWith("-") && !opts.operationId) opts.operationId = args[i];
   }
   if (!opts.operationId) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 deploy resume <operation_id>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <operation_id>.",
+      hint: "run402 deploy resume <operation_id>",
+    });
   }
 
   allowanceAuthHeaders("/deploy/v2/operations");
@@ -243,8 +255,11 @@ async function eventsCmd(args) {
     if (!args[i].startsWith("-") && !opts.operationId) opts.operationId = args[i];
   }
   if (!opts.operationId) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 deploy events <operation_id>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <operation_id>.",
+      hint: "run402 deploy events <operation_id>",
+    });
   }
 
   const project = resolveProjectId(opts.project);
@@ -383,11 +398,11 @@ function resolveFileDataPaths(spec, baseDir) {
           m.sql = readFileSync(p, "utf-8");
           delete m.sql_path;
         } catch (err) {
-          console.error(JSON.stringify({
-            status: "error",
+          fail({
+            code: "BAD_USAGE",
             message: `Failed to read migration sql_path '${m.sql_path}': ${err.message}`,
-          }));
-          process.exit(1);
+            details: { migration_id: m.id, sql_path: m.sql_path },
+          });
         }
       }
     }
@@ -421,10 +436,10 @@ function readFileEntry(entry, baseDir) {
     if (entry.contentType) out.contentType = entry.contentType;
     return out;
   } catch (err) {
-    console.error(JSON.stringify({
-      status: "error",
+    fail({
+      code: "BAD_USAGE",
       message: `Failed to read file '${entry.path}': ${err.message}`,
-    }));
-    process.exit(1);
+      details: { path: entry.path },
+    });
   }
 }

--- a/cli/lib/deploy.mjs
+++ b/cli/lib/deploy.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "path";
 import { resolveProjectId } from "./config.mjs";
 import { resolveFilePathsInManifest, resolveMigrationsFile } from "./manifest.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 deploy — Deploy to an existing project on Run402
 
@@ -111,8 +111,8 @@ async function readStdin() {
  * Load + parse the manifest from --manifest file or stdin, and resolve any
  * referenced files[].path / migrations_file against the manifest's directory.
  *
- * Returns { manifest } on success, or { error } with a structured error object
- * on any fs / parse failure. Never throws.
+ * Returns the parsed manifest on success. On any fs / parse failure, calls
+ * `fail()` (which writes the canonical error envelope to stderr and exits 1).
  */
 async function loadManifest(opts) {
   let raw;
@@ -125,21 +125,18 @@ async function loadManifest(opts) {
       raw = readFileSync(opts.manifest, "utf-8");
     } catch (err) {
       if (err && err.code === "ENOENT") {
-        return { error: {
-          status: "error",
+        fail({
+          code: "BAD_USAGE",
           message: `File not found: ${manifestAbs}`,
-          field: "manifest",
-          path: manifestAbs,
           hint: "Check that --manifest points to an existing JSON file.",
-        } };
+          details: { field: "manifest", path: manifestAbs },
+        });
       }
-      return { error: {
-        status: "error",
+      fail({
+        code: "BAD_USAGE",
         message: err && err.message ? err.message : String(err),
-        field: "manifest",
-        path: manifestAbs,
-        ...(err && err.code ? { code: err.code } : {}),
-      } };
+        details: { field: "manifest", path: manifestAbs, ...(err && err.code ? { syscall_code: err.code } : {}) },
+      });
     }
   } else {
     raw = await readStdin();
@@ -149,12 +146,15 @@ async function loadManifest(opts) {
   try {
     manifest = JSON.parse(raw);
   } catch (err) {
-    return { error: {
-      status: "error",
+    fail({
+      code: "BAD_USAGE",
       message: `Manifest is not valid JSON: ${err.message}`,
-      field: opts.manifest ? "manifest" : "stdin",
-      ...(opts.manifest ? { path: resolve(opts.manifest) } : {}),
-    } };
+      details: {
+        field: opts.manifest ? "manifest" : "stdin",
+        ...(opts.manifest ? { path: resolve(opts.manifest) } : {}),
+        parse_error: err.message,
+      },
+    });
   }
 
   if (opts.manifest) {
@@ -163,25 +163,29 @@ async function loadManifest(opts) {
       resolveFilePathsInManifest(manifest, baseDir);
     } catch (err) {
       if (err && err.code === "ENOENT") {
-        return { error: {
-          status: "error",
+        fail({
+          code: "BAD_USAGE",
           message: `File not found: ${err.absPath || err.path || "<unknown>"}`,
-          field: err.field || "manifest",
-          ...(err.absPath || err.path ? { path: err.absPath || err.path } : {}),
           hint: `Paths in manifest.${err.field || "files[].path"} are resolved relative to the manifest file's directory (${baseDir}).`,
-        } };
+          details: {
+            field: err.field || "manifest",
+            ...(err.absPath || err.path ? { path: err.absPath || err.path } : {}),
+          },
+        });
       }
-      return { error: {
-        status: "error",
+      fail({
+        code: "BAD_USAGE",
         message: err && err.message ? err.message : String(err),
-        ...(err && err.field ? { field: err.field } : {}),
-        ...(err && (err.absPath || err.path) ? { path: err.absPath || err.path } : {}),
-        ...(err && err.code ? { code: err.code } : {}),
-      } };
+        details: {
+          ...(err && err.field ? { field: err.field } : {}),
+          ...(err && (err.absPath || err.path) ? { path: err.absPath || err.path } : {}),
+          ...(err && err.code ? { syscall_code: err.code } : {}),
+        },
+      });
     }
   }
 
-  return { manifest };
+  return manifest;
 }
 
 export async function run(args) {
@@ -210,25 +214,20 @@ export async function run(args) {
     if (args[i] === "--project" && args[i + 1]) opts.project = args[++i];
   }
 
-  const manifestResult = await loadManifest(opts);
-  if (manifestResult.error) {
-    console.error(JSON.stringify(manifestResult.error));
-    process.exit(1);
-  }
-  const manifest = manifestResult.manifest;
+  const manifest = await loadManifest(opts);
 
   // If both sources set project_id and they disagree, refuse to deploy rather
   // than silently shipping to the wrong target.
   if (opts.project && manifest.project_id && opts.project !== manifest.project_id) {
-    const err = {
-      status: "error",
+    fail({
+      code: "BAD_USAGE",
       message: `project_id conflict: manifest.project_id=${manifest.project_id} but --project=${opts.project}`,
-      manifest_project_id: manifest.project_id,
-      flag_project_id: opts.project,
       hint: "Remove one of them or make them match. The --project flag and manifest.project_id must agree (or only one of them must be set).",
-    };
-    console.error(JSON.stringify(err));
-    process.exit(1);
+      details: {
+        manifest_project_id: manifest.project_id,
+        flag_project_id: opts.project,
+      },
+    });
   }
 
   if (opts.project) manifest.project_id = opts.project;

--- a/cli/lib/domains.mjs
+++ b/cli/lib/domains.mjs
@@ -1,6 +1,6 @@
 import { resolveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 domains — Manage custom domains
 
@@ -40,7 +40,13 @@ async function add(args) {
   const { project, rest } = parseProjectFlag(args);
   const domain = rest[0];
   const subdomainName = rest[1];
-  if (!domain || !subdomainName) { console.error("Usage: run402 domains add <domain> <subdomain_name> [--project <id>]"); process.exit(1); }
+  if (!domain || !subdomainName) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <domain> and/or <subdomain_name>.",
+      hint: "run402 domains add <domain> <subdomain_name> [--project <id>]",
+    });
+  }
   const projectId = resolveProjectId(project);
   try {
     const data = await getSdk().domains.add(projectId, domain, subdomainName);
@@ -63,7 +69,13 @@ async function list(projectIdArg) {
 async function status(args) {
   const { project, rest } = parseProjectFlag(args);
   const domain = rest[0];
-  if (!domain) { console.error("Usage: run402 domains status <domain> [--project <id>]"); process.exit(1); }
+  if (!domain) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <domain>.",
+      hint: "run402 domains status <domain> [--project <id>]",
+    });
+  }
   const projectId = resolveProjectId(project);
   try {
     const data = await getSdk().domains.status(projectId, domain);
@@ -76,15 +88,19 @@ async function status(args) {
 async function deleteDomain(args) {
   const { project, rest } = parseProjectFlag(args);
   const domain = rest.find((a) => !a.startsWith("--"));
-  if (!domain) { console.error("Usage: run402 domains delete <domain> --confirm [--project <id>]"); process.exit(1); }
+  if (!domain) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <domain>.",
+      hint: "run402 domains delete <domain> --confirm [--project <id>]",
+    });
+  }
   if (!Array.isArray(args) || !args.includes("--confirm")) {
-    console.error(JSON.stringify({
-      status: "error",
+    fail({
       code: "CONFIRMATION_REQUIRED",
       message: `Destructive: releasing custom domain '${domain}' detaches it from this project and clears its DNS/SSL configuration. This is irreversible. Re-run with --confirm to proceed.`,
       details: { domain },
-    }));
-    process.exit(1);
+    });
   }
   const projectId = resolveProjectId(project);
   try {

--- a/cli/lib/email.mjs
+++ b/cli/lib/email.mjs
@@ -1,6 +1,6 @@
 import { resolveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail, parseFlagJson } from "./sdk-errors.mjs";
 
 const HELP = `run402 email — Send emails from your project
 
@@ -130,14 +130,12 @@ function parseVars(args) {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--vars" && args[i + 1]) {
       const raw = args[++i];
-      let parsed;
-      try { parsed = JSON.parse(raw); } catch {
-        console.error(JSON.stringify({ status: "error", message: "Invalid JSON for --vars. Expected a JSON object, e.g. '{\"key\":\"value\"}'" }));
-        process.exit(1);
-      }
+      const parsed = parseFlagJson("--vars", raw);
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        console.error(JSON.stringify({ status: "error", message: "--vars must be a JSON object, e.g. '{\"key\":\"value\"}'" }));
-        process.exit(1);
+        fail({
+          code: "BAD_USAGE",
+          message: "--vars must be a JSON object, e.g. '{\"key\":\"value\"}'",
+        });
       }
       for (const [k, v] of Object.entries(parsed)) vars[k] = typeof v === "string" ? v : String(v);
     }
@@ -161,8 +159,11 @@ async function create(args) {
   }
   const projectId = resolveProjectId(projectOpt);
   if (!slug) {
-    console.error(JSON.stringify({ status: "error", message: "Missing slug. Usage: run402 email create <slug>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing slug.",
+      hint: "run402 email create <slug>",
+    });
   }
 
   try {
@@ -184,8 +185,7 @@ async function send(args) {
   const variables = parseVars(args);
 
   if (!to) {
-    console.error(JSON.stringify({ status: "error", message: "Missing --to <email>" }));
-    process.exit(1);
+    fail({ code: "BAD_USAGE", message: "Missing --to <email>" });
   }
 
   try {
@@ -228,8 +228,11 @@ async function get(args) {
   }
   const projectId = resolveProjectId(projectOpt);
   if (!messageId) {
-    console.error(JSON.stringify({ status: "error", message: "Missing message_id. Usage: run402 email get <message_id>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing message_id.",
+      hint: "run402 email get <message_id>",
+    });
   }
   try {
     const data = await getSdk().email.get(projectId, messageId);
@@ -250,8 +253,11 @@ async function getRaw(args) {
   }
   const projectId = resolveProjectId(projectOpt);
   if (!messageId) {
-    console.error(JSON.stringify({ status: "error", message: "Missing message_id. Usage: run402 email get-raw <message_id> [--output <file>]" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing message_id.",
+      hint: "run402 email get-raw <message_id> [--output <file>]",
+    });
   }
 
   try {
@@ -286,12 +292,17 @@ async function reply(args) {
   const projectId = resolveProjectId(projectOpt);
 
   if (!messageId) {
-    console.error(JSON.stringify({ status: "error", message: "Missing message_id. Usage: run402 email reply <message_id> --html \"...\"" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing message_id.",
+      hint: 'run402 email reply <message_id> --html "..."',
+    });
   }
   if (!html && !text) {
-    console.error(JSON.stringify({ status: "error", message: "Provide --html and/or --text for the reply body" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Provide --html and/or --text for the reply body",
+    });
   }
 
   try {
@@ -299,12 +310,11 @@ async function reply(args) {
     const original = await getSdk().email.get(projectId, messageId);
     const replyTo = original.from || original.from_address || original.sender || null;
     if (!replyTo) {
-      console.error(JSON.stringify({
-        status: "error",
+      fail({
+        code: "BAD_USAGE",
         message: "Original message has no from address to reply to",
-        original_keys: Object.keys(original),
-      }));
-      process.exit(1);
+        details: { original_keys: Object.keys(original) },
+      });
     }
     const origSubject = typeof original.subject === "string" ? original.subject : "";
     const defaultSubject = origSubject && origSubject.toLowerCase().startsWith("re:")
@@ -339,11 +349,10 @@ async function deleteMailbox(args) {
   const confirmed = args.includes("--confirm");
 
   if (!confirmed) {
-    console.error(JSON.stringify({
-      status: "error",
+    fail({
+      code: "CONFIRMATION_REQUIRED",
       message: "Destructive: deleting a mailbox is irreversible (drops all messages and webhook subscriptions). Re-run with --confirm to proceed.",
-    }));
-    process.exit(1);
+    });
   }
 
   try {

--- a/cli/lib/functions.mjs
+++ b/cli/lib/functions.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { findProject, API } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 functions — Manage serverless functions
 
@@ -152,7 +152,9 @@ async function deploy(projectId, name, args) {
     if (args[i] === "--deps" && args[i + 1]) opts.deps = args[++i].split(",");
     if (args[i] === "--schedule" && i + 1 < args.length) opts.schedule = args[++i];
   }
-  if (!opts.file) { console.error(JSON.stringify({ status: "error", message: "Missing --file <file>" })); process.exit(1); }
+  if (!opts.file) {
+    fail({ code: "BAD_USAGE", message: "Missing --file <file>" });
+  }
   const code = readFileSync(opts.file, "utf-8");
 
   const deployOpts = { name, code };
@@ -212,7 +214,13 @@ async function logs(projectId, name, args) {
   if (since !== undefined) {
     const parsed = Number(since);
     const ms = Number.isNaN(parsed) ? new Date(since).getTime() : parsed;
-    if (Number.isNaN(ms)) { console.error(JSON.stringify({ status: "error", message: `Invalid --since value: ${since}` })); process.exit(1); }
+    if (Number.isNaN(ms)) {
+      fail({
+        code: "BAD_USAGE",
+        message: `Invalid --since value: ${since}`,
+        details: { flag: "--since", value: since },
+      });
+    }
     sinceIso = new Date(ms).toISOString();
   }
 
@@ -282,8 +290,10 @@ async function update(projectId, name, args) {
   if (memory !== undefined) updateOpts.memory = memory;
 
   if (Object.keys(updateOpts).length === 0) {
-    console.error(JSON.stringify({ status: "error", message: "Provide at least one of: --schedule, --schedule-remove, --timeout, --memory" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Provide at least one of: --schedule, --schedule-remove, --timeout, --memory",
+    });
   }
 
   try {

--- a/cli/lib/image.mjs
+++ b/cli/lib/image.mjs
@@ -1,6 +1,6 @@
 import { writeFileSync } from "fs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 image — Generate AI images via x402 micropayments
 
@@ -49,7 +49,13 @@ export async function run(sub, args) {
     i++;
   }
 
-  if (!opts.prompt) { console.error(JSON.stringify({ status: "error", message: "Prompt required. Usage: run402 image generate \"your prompt\"" })); process.exit(1); }
+  if (!opts.prompt) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Prompt required.",
+      hint: 'run402 image generate "your prompt"',
+    });
+  }
 
   try {
     const data = await getSdk().ai.generateImage({ prompt: opts.prompt, aspect: opts.aspect });

--- a/cli/lib/message.mjs
+++ b/cli/lib/message.mjs
@@ -1,6 +1,6 @@
 import { allowanceAuthHeaders } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 message — Send messages to Run402 developers
 
@@ -16,7 +16,9 @@ Examples:
 `;
 
 async function send(text) {
-  if (!text) { console.error(JSON.stringify({ status: "error", message: "Missing message text" })); process.exit(1); }
+  if (!text) {
+    fail({ code: "BAD_USAGE", message: "Missing message text." });
+  }
   // Preserve the aggressive early exit when no allowance is configured.
   allowanceAuthHeaders("/message/v1");
 

--- a/cli/lib/projects.mjs
+++ b/cli/lib/projects.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { findProject, loadKeyStore, API, allowanceAuthHeaders, resolveProjectId, getActiveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail, parseFlagJson } from "./sdk-errors.mjs";
 
 const HELP = `run402 projects — Manage your deployed Run402 projects
 
@@ -153,12 +153,21 @@ async function applyExpose(projectId, args = []) {
   }
   const raw = file ? readFileSync(file, "utf-8") : inline;
   if (!raw) {
-    console.error(JSON.stringify({ status: "error", message: "Missing manifest. Provide inline JSON or use --file <path>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing manifest.",
+      hint: "Provide inline JSON or use --file <path>",
+    });
   }
   let manifest;
   try { manifest = JSON.parse(raw); }
-  catch { console.error(JSON.stringify({ status: "error", message: "Invalid JSON for manifest" })); process.exit(1); }
+  catch (err) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Invalid JSON for manifest",
+      details: { parse_error: err.message },
+    });
+  }
   const res = await fetch(`${API}/projects/v1/admin/${projectId}/expose`, {
     method: "POST",
     headers: { "Authorization": `Bearer ${p.service_key}`, "Content-Type": "application/json" },
@@ -222,11 +231,22 @@ async function sqlCmd(projectId, args = []) {
     else if (!query && !args[i].startsWith("--")) { query = args[i]; }
   }
   const sql = file ? readFileSync(file, "utf-8") : query;
-  if (!sql) { console.error(JSON.stringify({ status: "error", message: "Missing SQL query. Provide inline or use --file <path>" })); process.exit(1); }
+  if (!sql) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing SQL query.",
+      hint: "Provide inline or use --file <path>",
+    });
+  }
   let params;
   if (paramsRaw) {
-    try { params = JSON.parse(paramsRaw); } catch { console.error(JSON.stringify({ status: "error", message: "Invalid JSON for --params. Expected a JSON array, e.g. '[42, \"hello\"]'" })); process.exit(1); }
-    if (!Array.isArray(params)) { console.error(JSON.stringify({ status: "error", message: "--params must be a JSON array, e.g. '[42, \"hello\"]'" })); process.exit(1); }
+    params = parseFlagJson("--params", paramsRaw);
+    if (!Array.isArray(params)) {
+      fail({
+        code: "BAD_USAGE",
+        message: "--params must be a JSON array, e.g. '[42, \"hello\"]'",
+      });
+    }
   }
   const useParams = params && params.length > 0;
   const headers = { "Authorization": `Bearer ${p.service_key}`, "Content-Type": useParams ? "application/json" : "text/plain" };
@@ -264,7 +284,13 @@ async function schema(projectId) {
 }
 
 async function use(projectId) {
-  if (!projectId) { console.error("Usage: run402 projects use <project_id>"); process.exit(1); }
+  if (!projectId) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <project_id>.",
+      hint: "run402 projects use <project_id>",
+    });
+  }
   try {
     await getSdk().projects.use(projectId);
     console.log(JSON.stringify({ status: "ok", active_project_id: projectId }));
@@ -274,7 +300,13 @@ async function use(projectId) {
 }
 
 async function pin(projectId) {
-  if (!projectId) { console.error(JSON.stringify({ status: "error", message: "Usage: run402 projects pin <project_id>" })); process.exit(1); }
+  if (!projectId) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <project_id>.",
+      hint: "run402 projects pin <project_id>",
+    });
+  }
   try {
     const data = await getSdk().projects.pin(projectId);
     console.log(JSON.stringify(data, null, 2));
@@ -284,7 +316,13 @@ async function pin(projectId) {
 }
 
 async function promoteUser(projectId, email) {
-  if (!email) { console.error(JSON.stringify({ status: "error", message: "Usage: run402 projects promote-user <project_id> <email>" })); process.exit(1); }
+  if (!email) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <email>.",
+      hint: "run402 projects promote-user <project_id> <email>",
+    });
+  }
   const p = findProject(projectId);
   const res = await fetch(`${API}/projects/v1/admin/${projectId}/promote-user`, {
     method: "POST",
@@ -297,7 +335,13 @@ async function promoteUser(projectId, email) {
 }
 
 async function demoteUser(projectId, email) {
-  if (!email) { console.error(JSON.stringify({ status: "error", message: "Usage: run402 projects demote-user <project_id> <email>" })); process.exit(1); }
+  if (!email) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <email>.",
+      hint: "run402 projects demote-user <project_id> <email>",
+    });
+  }
   const p = findProject(projectId);
   const res = await fetch(`${API}/projects/v1/admin/${projectId}/demote-user`, {
     method: "POST",

--- a/cli/lib/sdk-errors.mjs
+++ b/cli/lib/sdk-errors.mjs
@@ -1,25 +1,81 @@
 /**
  * CLI-side SDK error translator.
  *
- * Maps SDK `Run402Error` subclasses into the CLI's existing error output
- * format: `{status: "error", http: ?, ...bodyFields}` on stderr, `process.exit(1)`.
- * Preserves specific behaviors:
- *   - `ProjectNotFound` → plain-text "Project <id> not found in local registry"
- *     with the "Hint: project IDs start with prj_" guidance when the id
- *     doesn't start with `prj_`.
+ * Maps SDK `Run402Error` subclasses into the CLI's canonical error envelope:
+ * `{status: "error", code, message, retryable, safe_to_retry, ...}` on stderr,
+ * `process.exit(1)`. Preserves specific behaviors:
+ *   - `ProjectNotFound` → canonical envelope with `code: "PROJECT_NOT_FOUND"`
+ *     and `details.source: "local_registry"` so callers can distinguish the
+ *     local-registry miss from a gateway 404.
  *   - HTML / non-JSON error bodies → `body_preview` field (first 500 chars),
  *     matching GH-84 behavior.
  *   - Network errors → `{status: "error", message: "..."}`.
+ *
+ * For client-side validation failures (missing flags, bad JSON, no-op
+ * environments), use `fail()` instead — `reportSdkError` is strictly for
+ * thrown `Run402Error` instances.
  */
+
+/**
+ * Canonical client-side failure emitter.
+ *
+ * Writes a single JSON envelope to stderr and exits with `exit_code` (default 1).
+ * The envelope shape matches the gateway's structured error contract so callers
+ * branching on `code` / `retryable` / `safe_to_retry` work uniformly across
+ * client-side validation errors and SDK-thrown errors.
+ *
+ * `code` defaults to "BAD_USAGE" so the helper is safe to call without one.
+ * `retryable: false` and `safe_to_retry: true` are sane defaults for client-side
+ * validation: the call wasn't sent, so retrying is safe and won't help unless
+ * the user fixes input.
+ */
+export function fail({ message, code, hint, details, next_actions, retryable = false, safe_to_retry = true, exit_code = 1 } = {}) {
+  const envelope = {
+    status: "error",
+    code: code ?? "BAD_USAGE",
+    message,
+    retryable,
+    safe_to_retry,
+  };
+  if (hint !== undefined) envelope.hint = hint;
+  if (details !== undefined) envelope.details = details;
+  envelope.next_actions = Array.isArray(next_actions) ? next_actions : [];
+  envelope.trace_id = null;
+  console.error(JSON.stringify(envelope));
+  process.exit(exit_code);
+}
+
+/**
+ * Parse a JSON-bearing CLI flag value, naming the flag in the failure envelope.
+ *
+ * Wraps `JSON.parse` so the failure says which flag was bad and includes a
+ * truncated value preview, instead of leaking a raw V8 `JSON.parse` message
+ * that doesn't tell the caller which flag failed.
+ */
+export function parseFlagJson(name, value) {
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    fail({
+      code: "BAD_JSON_FLAG",
+      message: `${name} value is not valid JSON`,
+      details: { flag: name, value_preview: String(value).slice(0, 32), parse_error: e.message },
+    });
+  }
+}
 
 export function reportSdkError(err) {
   if (err?.name === "ProjectNotFound") {
     const id = err.projectId || "";
     const hint = id && !String(id).startsWith("prj_")
-      ? ` Hint: project IDs start with "prj_". Check that the argument order is <project_id> <name>.`
-      : "";
-    console.error(`Project ${id} not found in local registry.${hint}`);
-    process.exit(1);
+      ? `project IDs start with "prj_". Check that the argument order is <project_id> <name>.`
+      : undefined;
+    fail({
+      code: "PROJECT_NOT_FOUND",
+      message: `Project ${id} not found in local registry.`,
+      hint,
+      details: { project_id: id, source: "local_registry" },
+    });
   }
 
   const payload = { status: "error" };

--- a/cli/lib/secrets.mjs
+++ b/cli/lib/secrets.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 secrets — Manage project secrets
 
@@ -56,7 +56,13 @@ async function set(projectId, key, args = []) {
     else if (!value && !args[i].startsWith("--")) { value = args[i]; }
   }
   const val = file ? readFileSync(file, "utf-8") : value;
-  if (!val) { console.error(JSON.stringify({ status: "error", message: "Missing secret value. Provide inline or use --file <path>" })); process.exit(1); }
+  if (!val) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing secret value.",
+      hint: "Provide inline or use --file <path>",
+    });
+  }
   try {
     await getSdk().secrets.set(projectId, key, val);
     console.log(JSON.stringify({ status: "ok", message: `Secret '${key}' set for project ${projectId}.` }));

--- a/cli/lib/sender-domain.mjs
+++ b/cli/lib/sender-domain.mjs
@@ -1,6 +1,6 @@
 import { resolveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 sender-domain — Manage custom email sender domain
 
@@ -39,8 +39,11 @@ async function register(args) {
   const projectId = resolveProjectId(projectOpt);
 
   if (!domain) {
-    console.error(JSON.stringify({ status: "error", message: "Missing domain. Usage: run402 sender-domain register <domain>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing domain.",
+      hint: "run402 sender-domain register <domain>",
+    });
   }
 
   try {
@@ -81,8 +84,11 @@ async function inboundToggle(action, args) {
   const projectId = resolveProjectId(projectOpt);
 
   if (!domain) {
-    console.error(JSON.stringify({ status: "error", message: `Missing domain. Usage: run402 sender-domain inbound-${action} <domain>` }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing domain.",
+      hint: `run402 sender-domain inbound-${action} <domain>`,
+    });
   }
 
   try {

--- a/cli/lib/sites.mjs
+++ b/cli/lib/sites.mjs
@@ -5,7 +5,7 @@ import { fileSetFromDir } from "#sdk/node";
 import { allowanceAuthHeaders, resolveProjectId, updateProject } from "./config.mjs";
 import { resolveFilePathsInManifest } from "./manifest.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const SMALL_DIR_THRESHOLD = 5;
 
@@ -244,17 +244,19 @@ async function deployDir(args) {
     if (args[i] === "--dry-run") { opts.dryRun = true; continue; }
     if (args[i] === "--confirm-prune") { opts.confirmPrune = true; continue; }
     if (args[i] === "--inherit") {
-      console.error(JSON.stringify({
-        status: "error",
+      fail({
+        code: "BAD_USAGE",
         message: "--inherit is removed; the SDK now uploads only changed files automatically.",
-      }));
-      process.exit(1);
+      });
     }
     if (!args[i].startsWith("-") && opts.dir === null) { opts.dir = args[i]; continue; }
   }
   if (!opts.dir) {
-    console.error(JSON.stringify({ status: "error", message: "Missing <path>. Usage: run402 sites deploy-dir <path> --project <id>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <path>.",
+      hint: "run402 sites deploy-dir <path> --project <id>",
+    });
   }
   const projectId = resolveProjectId(opts.project);
 

--- a/cli/lib/status.mjs
+++ b/cli/lib/status.mjs
@@ -79,7 +79,7 @@ export async function run(args = []) {
   const allowance = readAllowance();
   if (!allowance) {
     console.log(JSON.stringify({ status: "no_allowance", message: "No agent allowance found. Run: run402 init" }));
-    return;
+    process.exit(1);
   }
 
   const wallet = allowance.address.toLowerCase();

--- a/cli/lib/subdomains.mjs
+++ b/cli/lib/subdomains.mjs
@@ -1,6 +1,6 @@
 import { resolveProject, resolveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 subdomains — Manage custom subdomains
 
@@ -64,11 +64,25 @@ async function claim(positionalArgs, flagArgs) {
   } else if (positionalArgs.length === 1) {
     name = positionalArgs[0];
   }
-  if (!name) { console.error("Usage: run402 subdomains claim <name> [--project <id>] [--deployment <id>]"); process.exit(1); }
+  if (!name) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <name>.",
+      hint: "run402 subdomains claim <name> [--project <id>] [--deployment <id>]",
+    });
+  }
   const projectId = resolveProjectId(opts.project);
   const p = resolveProject(opts.project);
   deploymentId = opts.deployment || deploymentId || p.last_deployment_id;
-  if (!deploymentId) { console.error("Error: no deployment_id specified and no recent deployment found. Deploy a site first or pass --deployment <id>."); process.exit(1); }
+  if (!deploymentId) {
+    fail({
+      code: "NO_DEPLOYMENT",
+      message: "no deployment_id specified and no recent deployment found.",
+      hint: "Deploy a site first or pass --deployment <id>.",
+      details: { project_id: projectId },
+      next_actions: [{ action: "deploy_site_first" }],
+    });
+  }
   try {
     const data = await getSdk().subdomains.claim(name, deploymentId, { projectId });
     console.log(JSON.stringify(data, null, 2));
@@ -86,17 +100,18 @@ async function deleteSubdomain(allArgs) {
     else if (!argList[i].startsWith("--") && !name) { name = argList[i]; }
   }
   if (!name) {
-    console.error(JSON.stringify({ status: "error", message: "Usage: run402 subdomains delete <name> --confirm [--project <id>]" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <name>.",
+      hint: "run402 subdomains delete <name> --confirm [--project <id>]",
+    });
   }
   if (!argList.includes("--confirm")) {
-    console.error(JSON.stringify({
-      status: "error",
+    fail({
       code: "CONFIRMATION_REQUIRED",
       message: `Destructive: releasing subdomain '${name}' makes it available for any other project to claim. This is irreversible. Re-run with --confirm to proceed.`,
       details: { name },
-    }));
-    process.exit(1);
+    });
   }
   const projectId = resolveProjectId(opts.project);
   try {

--- a/cli/lib/tier.mjs
+++ b/cli/lib/tier.mjs
@@ -1,5 +1,5 @@
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 tier — Manage your Run402 tier subscription
 
@@ -34,7 +34,13 @@ async function status() {
 }
 
 async function set(tierName) {
-  if (!tierName) { console.error(JSON.stringify({ status: "error", message: "Usage: run402 tier set <prototype|hobby|team>" })); process.exit(1); }
+  if (!tierName) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing <tier>.",
+      hint: "run402 tier set <prototype|hobby|team>",
+    });
+  }
   try {
     const data = await getSdk().tier.set(tierName);
     console.log(JSON.stringify(data, null, 2));

--- a/cli/lib/webhooks.mjs
+++ b/cli/lib/webhooks.mjs
@@ -1,6 +1,6 @@
 import { resolveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 
 const HELP = `run402 email webhooks — Manage mailbox webhooks
 
@@ -62,8 +62,11 @@ async function get(args) {
   }
   const projectId = resolveProjectId(projectOpt);
   if (!webhookId) {
-    console.error(JSON.stringify({ status: "error", message: "Missing webhook_id. Usage: run402 email webhooks get <webhook_id>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing webhook_id.",
+      hint: "run402 email webhooks get <webhook_id>",
+    });
   }
   try {
     const data = await getSdk().email.webhooks.get(projectId, webhookId);
@@ -82,8 +85,11 @@ async function del(args) {
   }
   const projectId = resolveProjectId(projectOpt);
   if (!webhookId) {
-    console.error(JSON.stringify({ status: "error", message: "Missing webhook_id. Usage: run402 email webhooks delete <webhook_id>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing webhook_id.",
+      hint: "run402 email webhooks delete <webhook_id>",
+    });
   }
   try {
     await getSdk().email.webhooks.delete(projectId, webhookId);
@@ -106,12 +112,14 @@ async function update(args) {
   }
   const projectId = resolveProjectId(projectOpt);
   if (!webhookId) {
-    console.error(JSON.stringify({ status: "error", message: "Missing webhook_id. Usage: run402 email webhooks update <webhook_id> [--url <url>] [--events <e1,e2>]" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing webhook_id.",
+      hint: "run402 email webhooks update <webhook_id> [--url <url>] [--events <e1,e2>]",
+    });
   }
   if (!url && !eventsRaw) {
-    console.error(JSON.stringify({ status: "error", message: "Provide at least --url or --events" }));
-    process.exit(1);
+    fail({ code: "BAD_USAGE", message: "Provide at least --url or --events" });
   }
 
   try {
@@ -132,12 +140,18 @@ async function register(args) {
   const projectId = resolveProjectId(projectOpt);
 
   if (!url) {
-    console.error(JSON.stringify({ status: "error", message: "Missing --url. Usage: run402 email webhooks register --url <url> --events <e1,e2>" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing --url.",
+      hint: "run402 email webhooks register --url <url> --events <e1,e2>",
+    });
   }
   if (!eventsRaw) {
-    console.error(JSON.stringify({ status: "error", message: "Missing --events. Valid events: delivery, bounced, complained, reply_received" }));
-    process.exit(1);
+    fail({
+      code: "BAD_USAGE",
+      message: "Missing --events.",
+      hint: "Valid events: delivery, bounced, complained, reply_received",
+    });
   }
 
   const events = eventsRaw.split(",").map((e) => e.trim());

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -38,19 +38,22 @@ Provision first, then write your frontend code with the real `anon_key` embedded
 
 CLI errors are JSON on stderr with an outer `"status": "error"` sentinel. Run402-originated JSON bodies may be merged into that object with canonical fields. Branch on `code`, not English `message` or legacy `error` text.
 
+Exit codes follow the rule `status === "ok" ? 0 : 1` -- any payload whose `status` is not `"ok"` exits non-zero, including the `no_allowance` / `no_wallet` informational sentinels emitted by `run402 status` and `run402 allowance status` when no agent allowance is configured. Shell-driven workflows can therefore branch on `$?` without parsing JSON.
+
 Canonical fields:
-- `code`: stable machine-readable reason, e.g. `PROJECT_FROZEN`, `PAYMENT_REQUIRED`, `MIGRATION_FAILED`, `MIGRATE_GATE_ACTIVE`
+- `code`: stable machine-readable reason, e.g. `PROJECT_FROZEN`, `PAYMENT_REQUIRED`, `MIGRATION_FAILED`, `MIGRATE_GATE_ACTIVE`. Client-side validation failures (missing flag, malformed JSON, unknown local project) default to `BAD_USAGE`; specific client-side cases use richer codes such as `PROJECT_NOT_FOUND` (with `details.source: "local_registry"`), `NO_DEPLOYMENT`, `NO_ALLOWANCE`, `BAD_JSON_FLAG`, `CONFIRMATION_REQUIRED`.
 - `retryable`: the same request may succeed later
 - `safe_to_retry`: repeating the same request should not duplicate or corrupt a mutation
 - `mutation_state`: one of `none`, `not_started`, `committed`, `rolled_back`, `partial`, `unknown`
 - `trace_id`: include this when reporting the issue
 - `details`: structured route-specific context
-- `next_actions`: advisory suggestions such as `authenticate`, `submit_payment`, `renew_tier`, `check_usage`, `retry`, `resume_deploy`, `edit_request`, or `edit_migration`; do not execute route-like suggestions without validating method/path/auth/safety
+- `next_actions`: advisory suggestions such as `authenticate`, `submit_payment`, `renew_tier`, `check_usage`, `retry`, `resume_deploy`, `edit_request`, `edit_migration`, or `deploy_site_first`; do not execute route-like suggestions without validating method/path/auth/safety
 
 Retry policy:
 - If `retryable: true` and `safe_to_retry: true`, retry the same request; for mutating commands reuse the same idempotency key when available.
 - If a mutating command returns 5xx with `safe_to_retry: false`, or `mutation_state` is `committed`, `partial`, or `unknown`, inspect/poll/reconcile state before retrying. For deploys, prefer `run402 deploy events <operation_id>` or `run402 deploy resume <operation_id>` over starting a duplicate operation.
 - Lifecycle/payment errors usually need an action: `PROJECT_FROZEN`/`PROJECT_DORMANT`/`PROJECT_PAST_DUE` -> `run402 projects usage <id>` or `run402 tier set <tier>`; `PAYMENT_REQUIRED`/`INSUFFICIENT_FUNDS` -> submit payment or fund allowance.
+- Client-side `BAD_JSON_FLAG` errors include `details.flag` (the offending flag, e.g. `--abi`) and `details.value_preview` (truncated value) so callers know which flag value to fix.
 
 Examples:
 ```json


### PR DESCRIPTION
## Summary

Single coordinated cleanup of the run402 CLI's error-emitting layer. Four bugs converged on one diff because they all touched the same surface — splitting them would just have caused merge friction.

## Bugs fixed

- [#215](https://github.com/kychee-com/run402/issues/215) — three error envelope shapes (full-server / minimal `{status,message}` / deploy-only `{status,message,field,hint,path}`) collapsed to one canonical shape across every client-side fail path.
- [#174](https://github.com/kychee-com/run402/issues/174) — every `console.error("Usage:…")` / `console.error("Error:…")` plain-text path migrated to the canonical JSON envelope. Specific repros from the bug body covered: `subdomains claim ""` (BAD_USAGE), `subdomains claim "foo/bar"` no-deployment (NO_DEPLOYMENT + next_actions), `domains add` no-args (BAD_USAGE), `blob put --project prj_xxx` (PROJECT_NOT_FOUND + `details.source: "local_registry"`).
- [#191](https://github.com/kychee-com/run402/issues/191) — `status` and `allowance status` no-allowance paths now `process.exit(1)` so shell scripts can branch on `$?`.
- [#177](https://github.com/kychee-com/run402/issues/177) — JSON-flag parse errors now name the offending flag and include a value preview (`code: "BAD_JSON_FLAG"`, `details: {flag, value_preview, parse_error}`). Wired into `contracts call/read --abi/--args`, `email send --vars`, `projects ... --params`.

## What landed

**New helpers in `cli/lib/sdk-errors.mjs`:**
- `fail({code, message, hint?, details?, next_actions?, ...})` — writes the canonical envelope to stderr and exits. Default `code: "BAD_USAGE"`.
- `parseFlagJson(name, value)` — wraps `JSON.parse`, emits the named-flag error envelope on failure.

**`reportSdkError` `ProjectNotFound` branch** routes through `fail()` with `details.source: "local_registry"` so callers can distinguish from a gateway 404.

**Migrations across 26 files in `cli/lib/`** — see commit `8073154` for the full list. Plain-text `Usage:` / `Error:` and minimal `{status,message}` shapes all gone from the error paths.

**`cli/llms-cli.txt`** updated to document the canonical shape, the `status === "ok" ? 0 : 1` exit-code rule, the `BAD_USAGE` default, and the new client-side codes (`PROJECT_NOT_FOUND`, `NO_DEPLOYMENT`, `NO_ALLOWANCE`, `BAD_JSON_FLAG`, `CONFIRMATION_REQUIRED`).

## What was deliberately NOT changed

- `console.error("Unknown subcommand: …")` + `console.log(HELP)` + `process.exit(1)` pattern (21 files) — these are help-fallback paths, not error envelopes. Spec says "Help output is separate".
- Raw-fetch response sites in `billing.mjs`, `allowance.mjs`, `projects.mjs`, `auth.mjs` that merge gateway response data into the envelope — already match the canonical shape via the gateway's own structured errors.
- `reportSdkError` for SDK-thrown `Run402Error` instances — different code path, already canonical.

## Verification

- 688 unit + 293 CLI e2e + 22 doc snippets, all pass
- TypeCheck clean across root, core, sdk, functions
- Build clean
- 8 new e2e tests cover every repro from the bug bodies

## Test plan

- [x] `npm run build` clean
- [x] `npm test` passes (688 + 293 + 22)
- [ ] Reviewer: spot-check 2-3 migrated handlers (e.g. `subdomains.mjs`, `blob.mjs`, `domains.mjs`) — the diff is large but the pattern is uniform
- [ ] Reviewer: confirm the new `PROJECT_NOT_FOUND` envelope from local-registry misses includes `details.source: "local_registry"` — agents need to distinguish this from gateway 404
- [ ] After merge: cut release via `/publish` (recommend `patch` → 1.54.1 — pure CLI cleanup, no API surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)