### PR TITLE
fix: sibling bugs from v1.54.3 triage (#231, #232, #233)

### DIFF
--- a/cli-e2e.test.mjs
+++ b/cli-e2e.test.mjs
@@ -1584,6 +1584,92 @@ describe("CLI e2e happy path", () => {
       `database.migrations manifest should be accepted, got: ${capturedStderr()}`);
   });
 
+  // ── GH-232: deploy apply (v2 unified primitive) must reject empty specs ──
+  // The legacy `deploy --manifest` path was hardened in GH-185, but the v2
+  // `deploy apply --manifest` / `--spec` path silently sent empty specs to
+  // the gateway. This block mirrors the GH-185 guard pattern for v2 keys.
+  async function deployApplyAndCapture(args) {
+    const { run } = await import("./cli/lib/deploy.mjs");
+    let deployCalled = false;
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = (input, init) => {
+      const url = typeof input === "string" ? input : (input instanceof Request ? input.url : String(input));
+      const method = (init?.method || (input instanceof Request ? input.method : "GET") || "GET").toUpperCase();
+      if (url.endsWith("/deploy/v2/plans") && method === "POST") deployCalled = true;
+      return prevFetch(input, init);
+    };
+    let threw = null;
+    captureStart();
+    try {
+      await run(["apply", ...args]);
+    } catch (e) {
+      threw = e;
+    } finally {
+      captureStop();
+      globalThis.fetch = prevFetch;
+    }
+    return { threw, stderr: capturedStderr(), stdout: capturedStdout(), deployCalled };
+  }
+
+  it("deploy apply rejects empty manifest file (GH-232)", async () => {
+    const { writeFileSync: wf } = await import("node:fs");
+    const manifestPath = join(tempDir, "gh232-empty-manifest.json");
+    wf(manifestPath, JSON.stringify({}));
+    const { threw, stderr, deployCalled } = await deployApplyAndCapture(
+      ["--manifest", manifestPath, "--project", "prj_test123"]);
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    assert.equal(deployCalled, false, "must not POST to /deploy/v2/plans on empty manifest");
+    const parsed = parseStderrEnvelope(stderr);
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "MANIFEST_EMPTY");
+    assert.ok(parsed.message && /no deployable sections/i.test(parsed.message),
+      `message should explain no deployable sections, got: ${parsed.message}`);
+    assert.ok(parsed.hint, `hint should be present, got: ${JSON.stringify(parsed)}`);
+  });
+
+  it("deploy apply rejects --spec '{}' (GH-232)", async () => {
+    const { threw, stderr, deployCalled } = await deployApplyAndCapture(
+      ["--spec", "{}", "--project", "prj_test123"]);
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    assert.equal(deployCalled, false, "must not POST to /deploy/v2/plans on empty --spec");
+    const parsed = parseStderrEnvelope(stderr);
+    assert.equal(parsed.code, "MANIFEST_EMPTY");
+  });
+
+  it("deploy apply rejects --spec with only project_id (GH-232)", async () => {
+    const { threw, stderr, deployCalled } = await deployApplyAndCapture(
+      ["--spec", JSON.stringify({ project_id: "prj_test123" })]);
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    assert.equal(deployCalled, false, "must not POST to /deploy/v2/plans on project-id-only spec");
+    const parsed = parseStderrEnvelope(stderr);
+    assert.equal(parsed.code, "MANIFEST_EMPTY");
+  });
+
+  it("deploy apply rejects --spec with empty site.replace (GH-232)", async () => {
+    const { threw, stderr, deployCalled } = await deployApplyAndCapture(
+      ["--spec", JSON.stringify({ site: { replace: {} } }), "--project", "prj_test123"]);
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    assert.equal(deployCalled, false, "must not POST to /deploy/v2/plans on empty site.replace spec");
+    const parsed = parseStderrEnvelope(stderr);
+    assert.equal(parsed.code, "MANIFEST_EMPTY");
+  });
+
+  it("deploy apply accepts --spec with non-empty site.replace (GH-232)", async () => {
+    const { threw, deployCalled } = await deployApplyAndCapture(
+      ["--spec", JSON.stringify({ site: { replace: { "index.html": { data: "x" } } } }),
+        "--project", "prj_test123"]);
+    // The validator must NOT block this spec; the SDK call may proceed
+    // (and against the mock /deploy/v2/plans + commit endpoints, succeed).
+    assert.ok(!threw || !/MANIFEST_EMPTY/.test(threw.message),
+      `non-empty site.replace must pass the empty-manifest guard, got: ${threw && threw.message}`);
+    assert.equal(deployCalled, true,
+      "non-empty site.replace must reach /deploy/v2/plans");
+  });
+
   // ── Functions ───────────────────────────────────────────────────────────
 
   it("functions deploy", async () => {

--- a/cli-e2e.test.mjs
+++ b/cli-e2e.test.mjs
@@ -884,6 +884,120 @@ describe("CLI e2e happy path", () => {
     assert.ok(captured().includes("test"), "should return query results from file");
   });
 
+  it("projects sql with missing --file path returns structured JSON error (GH-233)", async () => {
+    const { run } = await import("./cli/lib/projects.mjs");
+    const missingPath = join(tempDir, `definitely-not-a-real-sql-${Date.now()}.sql`);
+    let threw = null;
+    captureStart();
+    try {
+      await run("sql", ["prj_test123", "--file", missingPath]);
+    } catch (e) {
+      threw = e;
+    } finally {
+      captureStop();
+    }
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    const stderr = capturedStderr();
+    assert.ok(!/node:fs/.test(stderr), `must not leak raw node:fs path, got: ${stderr}`);
+    assert.ok(!/readFileUtf8/.test(stderr), `must not leak readFileUtf8 V8 source pointer, got: ${stderr}`);
+    assert.ok(!/ENOENT/.test(stderr), `must not leak raw ENOENT error, got: ${stderr}`);
+    assert.ok(!/EISDIR/.test(stderr), `must not leak raw EISDIR error, got: ${stderr}`);
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{") && s.endsWith("}"));
+    assert.ok(line, `should emit a JSON error line on stderr, got: ${stderr}`);
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "FILE_NOT_FOUND",
+      `code should be FILE_NOT_FOUND, got: ${parsed.code}`);
+    assert.ok(parsed.message && parsed.message.includes(missingPath),
+      `message should include missing path, got: ${parsed.message}`);
+  });
+
+  it("projects sql with directory --file path returns structured JSON error (GH-233)", async () => {
+    const { run } = await import("./cli/lib/projects.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("sql", ["prj_test123", "--file", tempDir]);
+    } catch (e) {
+      threw = e;
+    } finally {
+      captureStop();
+    }
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    const stderr = capturedStderr();
+    assert.ok(!/node:fs/.test(stderr), `must not leak raw node:fs path, got: ${stderr}`);
+    assert.ok(!/readFileUtf8/.test(stderr), `must not leak readFileUtf8 V8 source pointer, got: ${stderr}`);
+    assert.ok(!/ENOENT/.test(stderr), `must not leak raw ENOENT error, got: ${stderr}`);
+    assert.ok(!/EISDIR/.test(stderr), `must not leak raw EISDIR error, got: ${stderr}`);
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{") && s.endsWith("}"));
+    assert.ok(line, `should emit a JSON error line on stderr, got: ${stderr}`);
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "NOT_A_FILE",
+      `code should be NOT_A_FILE, got: ${parsed.code}`);
+    assert.ok(parsed.message && parsed.message.includes(tempDir),
+      `message should include directory path, got: ${parsed.message}`);
+  });
+
+  it("projects apply-expose with missing --file path returns structured JSON error (GH-233)", async () => {
+    const { run } = await import("./cli/lib/projects.mjs");
+    const missingPath = join(tempDir, `definitely-not-a-real-manifest-${Date.now()}.json`);
+    let threw = null;
+    captureStart();
+    try {
+      await run("apply-expose", ["prj_test123", "--file", missingPath]);
+    } catch (e) {
+      threw = e;
+    } finally {
+      captureStop();
+    }
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    const stderr = capturedStderr();
+    assert.ok(!/node:fs/.test(stderr), `must not leak raw node:fs path, got: ${stderr}`);
+    assert.ok(!/readFileUtf8/.test(stderr), `must not leak readFileUtf8 V8 source pointer, got: ${stderr}`);
+    assert.ok(!/ENOENT/.test(stderr), `must not leak raw ENOENT error, got: ${stderr}`);
+    assert.ok(!/EISDIR/.test(stderr), `must not leak raw EISDIR error, got: ${stderr}`);
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{") && s.endsWith("}"));
+    assert.ok(line, `should emit a JSON error line on stderr, got: ${stderr}`);
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "FILE_NOT_FOUND",
+      `code should be FILE_NOT_FOUND, got: ${parsed.code}`);
+    assert.ok(parsed.message && parsed.message.includes(missingPath),
+      `message should include missing path, got: ${parsed.message}`);
+  });
+
+  it("projects apply-expose with directory --file path returns structured JSON error (GH-233)", async () => {
+    const { run } = await import("./cli/lib/projects.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("apply-expose", ["prj_test123", "--file", tempDir]);
+    } catch (e) {
+      threw = e;
+    } finally {
+      captureStop();
+    }
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    const stderr = capturedStderr();
+    assert.ok(!/node:fs/.test(stderr), `must not leak raw node:fs path, got: ${stderr}`);
+    assert.ok(!/readFileUtf8/.test(stderr), `must not leak readFileUtf8 V8 source pointer, got: ${stderr}`);
+    assert.ok(!/ENOENT/.test(stderr), `must not leak raw ENOENT error, got: ${stderr}`);
+    assert.ok(!/EISDIR/.test(stderr), `must not leak raw EISDIR error, got: ${stderr}`);
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{") && s.endsWith("}"));
+    assert.ok(line, `should emit a JSON error line on stderr, got: ${stderr}`);
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "NOT_A_FILE",
+      `code should be NOT_A_FILE, got: ${parsed.code}`);
+    assert.ok(parsed.message && parsed.message.includes(tempDir),
+      `message should include directory path, got: ${parsed.message}`);
+  });
+
   it("projects sql exits non-zero on blocked SQL (GH-34)", async () => {
     const { run } = await import("./cli/lib/projects.mjs");
     // Swap in a fetch that returns a 400 with a blocked-SQL error body.
@@ -1705,6 +1819,63 @@ describe("CLI e2e happy path", () => {
     await run("set", ["prj_test123", "FILE_KEY", "--file", valPath]);
     captureStop();
     assert.ok(captured().includes("ok"), "should set secret from file");
+  });
+
+  it("secrets set with missing --file path returns structured JSON error (GH-233)", async () => {
+    const { run } = await import("./cli/lib/secrets.mjs");
+    const missingPath = join(tempDir, `definitely-not-a-real-secret-${Date.now()}.txt`);
+    let threw = null;
+    captureStart();
+    try {
+      await run("set", ["prj_test123", "TLS_CERT", "--file", missingPath]);
+    } catch (e) {
+      threw = e;
+    } finally {
+      captureStop();
+    }
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    const stderr = capturedStderr();
+    assert.ok(!/node:fs/.test(stderr), `must not leak raw node:fs path, got: ${stderr}`);
+    assert.ok(!/readFileUtf8/.test(stderr), `must not leak readFileUtf8 V8 source pointer, got: ${stderr}`);
+    assert.ok(!/ENOENT/.test(stderr), `must not leak raw ENOENT error, got: ${stderr}`);
+    assert.ok(!/EISDIR/.test(stderr), `must not leak raw EISDIR error, got: ${stderr}`);
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{") && s.endsWith("}"));
+    assert.ok(line, `should emit a JSON error line on stderr, got: ${stderr}`);
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "FILE_NOT_FOUND",
+      `code should be FILE_NOT_FOUND, got: ${parsed.code}`);
+    assert.ok(parsed.message && parsed.message.includes(missingPath),
+      `message should include missing path, got: ${parsed.message}`);
+  });
+
+  it("secrets set with directory --file path returns structured JSON error (GH-233)", async () => {
+    const { run } = await import("./cli/lib/secrets.mjs");
+    let threw = null;
+    captureStart();
+    try {
+      await run("set", ["prj_test123", "TLS_CERT", "--file", tempDir]);
+    } catch (e) {
+      threw = e;
+    } finally {
+      captureStop();
+    }
+    assert.ok(threw && /process\.exit\(1\)/.test(threw.message),
+      `should exit non-zero, got: ${threw && threw.message}`);
+    const stderr = capturedStderr();
+    assert.ok(!/node:fs/.test(stderr), `must not leak raw node:fs path, got: ${stderr}`);
+    assert.ok(!/readFileUtf8/.test(stderr), `must not leak readFileUtf8 V8 source pointer, got: ${stderr}`);
+    assert.ok(!/ENOENT/.test(stderr), `must not leak raw ENOENT error, got: ${stderr}`);
+    assert.ok(!/EISDIR/.test(stderr), `must not leak raw EISDIR error, got: ${stderr}`);
+    const line = stderr.split("\n").map(s => s.trim()).find(s => s.startsWith("{") && s.endsWith("}"));
+    assert.ok(line, `should emit a JSON error line on stderr, got: ${stderr}`);
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.status, "error");
+    assert.equal(parsed.code, "NOT_A_FILE",
+      `code should be NOT_A_FILE, got: ${parsed.code}`);
+    assert.ok(parsed.message && parsed.message.includes(tempDir),
+      `message should include directory path, got: ${parsed.message}`);
   });
 
   it("secrets list", async () => {

--- a/cli-e2e.test.mjs
+++ b/cli-e2e.test.mjs
@@ -3719,6 +3719,111 @@ describe("CLI domains list --project / positional parity (GH-209)", () => {
   });
 });
 
+// ── subdomains list flag/positional parity (GH-231) ─────────────────────────
+// Same shape as GH-209 but for `subdomains list`. `subdomains claim` and
+// `subdomains delete` accept `--project <id>`, but `subdomains list`
+// previously only accepted a positional [<id>] arg. Running
+// `run402 subdomains list --project prj_xxx` parsed `--project` as the
+// positional id and emitted 'Project --project not found' — same misleading
+// PROJECT_NOT_FOUND that GH-209 fixed for `domains list`. The fix mirrors
+// GH-209 (option #1: pure extension) — the legacy positional form keeps
+// working, and `--project` now resolves correctly.
+
+describe("CLI subdomains list --project / positional parity (GH-231)", () => {
+  async function seedActiveProject() {
+    const { saveProject, setActiveProjectId } = await import("./cli/lib/config.mjs");
+    saveProject(TEST_PROJECT.project_id, {
+      anon_key: TEST_PROJECT.anon_key,
+      service_key: TEST_PROJECT.service_key,
+    });
+    setActiveProjectId(TEST_PROJECT.project_id);
+  }
+
+  function buildListSpyFetch(calls) {
+    const apiOrigin = new URL(API).origin;
+    return async (input, init) => {
+      const url = typeof input === "string" ? input : (input instanceof Request ? input.url : String(input));
+      const method = (init?.method || (input instanceof Request ? input.method : "GET") || "GET").toUpperCase();
+      let path = url;
+      try {
+        const parsed = new URL(url);
+        if (parsed.origin === apiOrigin) path = parsed.pathname + parsed.search;
+      } catch {
+        // non-URL input — leave as raw
+      }
+      calls.push({ method, path, url });
+      if (method === "GET" && path === "/subdomains/v1") {
+        return Promise.resolve(json({ subdomains: [] }));
+      }
+      return Promise.resolve(new Response("Not Found", { status: 404 }));
+    };
+  }
+
+  it("subdomains list --project <id> resolves the project (does not parse '--project' as the id)", async () => {
+    await seedActiveProject();
+    const { run } = await import("./cli/lib/subdomains.mjs");
+    const calls = [];
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = buildListSpyFetch(calls);
+    let threw = null;
+    captureStart();
+    try {
+      await run("list", ["--project", TEST_PROJECT.project_id]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+      globalThis.fetch = prevFetch;
+    }
+    assert.equal(threw, null,
+      `subdomains list --project <id> must not exit; got: ${threw?.message || ""} / stderr: ${capturedStderr()}`);
+    assert.ok(
+      !/Project\s+--project\s+not found/.test(capturedStderr()),
+      `must not parse '--project' as the positional id, got stderr: ${capturedStderr()}`,
+    );
+    const get = calls.find(c => c.method === "GET" && c.path === "/subdomains/v1");
+    assert.ok(get, `must issue GET /subdomains/v1, calls: ${JSON.stringify(calls)}`);
+  });
+
+  it("subdomains list <id> (legacy positional) still works", async () => {
+    await seedActiveProject();
+    const { run } = await import("./cli/lib/subdomains.mjs");
+    const calls = [];
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = buildListSpyFetch(calls);
+    let threw = null;
+    captureStart();
+    try {
+      await run("list", [TEST_PROJECT.project_id]);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+      globalThis.fetch = prevFetch;
+    }
+    assert.equal(threw, null,
+      `legacy 'subdomains list <id>' must keep working, got: ${threw?.message || ""} / stderr: ${capturedStderr()}`);
+    const get = calls.find(c => c.method === "GET" && c.path === "/subdomains/v1");
+    assert.ok(get, `legacy positional must still issue GET /subdomains/v1, calls: ${JSON.stringify(calls)}`);
+  });
+
+  it("subdomains list (no args) falls back to active project", async () => {
+    await seedActiveProject();
+    const { run } = await import("./cli/lib/subdomains.mjs");
+    const calls = [];
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = buildListSpyFetch(calls);
+    let threw = null;
+    captureStart();
+    try {
+      await run("list", []);
+    } catch (e) { threw = e; } finally {
+      captureStop();
+      globalThis.fetch = prevFetch;
+    }
+    assert.equal(threw, null,
+      `'subdomains list' (no args) should resolve via active project, got: ${threw?.message || ""} / stderr: ${capturedStderr()}`);
+    const get = calls.find(c => c.method === "GET" && c.path === "/subdomains/v1");
+    assert.ok(get, `must still issue GET /subdomains/v1, calls: ${JSON.stringify(calls)}`);
+  });
+});
+
 // ── Message size cap (GH-175) ──────────────────────────────────────────────
 // `run402 message send <text>` previously had no client-side cap, so a
 // 200 KB single message was happily POSTed to /message/v1 and stored in the

--- a/cli/lib/argparse.mjs
+++ b/cli/lib/argparse.mjs
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from "node:fs";
 import { fail } from "./sdk-errors.mjs";
 import { resolveProjectId } from "./config.mjs";
 
@@ -139,6 +140,46 @@ export function validateWebhookUrl(url, fieldName = "--url") {
       field: fieldName,
       hint: "Webhook URLs must be https:// for transport security.",
       details: { flag: fieldName, value: url, scheme: parsed.protocol },
+    });
+  }
+}
+
+/**
+ * Validate that a CLI flag pointing at a filesystem path resolves to an
+ * existing regular file. Replaces the GH-195 inline pattern that was
+ * duplicated across `functions deploy`, `secrets set`, `projects sql`,
+ * and `projects apply-expose` (GH-233).
+ *
+ * Without this guard, `readFileSync` against a missing path leaks a raw
+ * `node:fs` ENOENT/EISDIR stack to stderr (with the V8 source pointer),
+ * which violates the CLI's structured-error contract.
+ *
+ * No-op: this helper is meant to be called only when the flag is set.
+ * Callers handle the optional/required dichotomy themselves.
+ *
+ * On failure: `fail()` writes a `FILE_NOT_FOUND` or `NOT_A_FILE` envelope
+ * to stderr and exits 1.
+ *
+ * @param {string} path - The filesystem path captured from the flag.
+ * @param {string} fieldName - The flag name for the envelope (default "--file").
+ */
+export function validateRegularFile(path, fieldName = "--file") {
+  if (!existsSync(path)) {
+    fail({
+      code: "FILE_NOT_FOUND",
+      message: `File not found: ${path}`,
+      field: fieldName,
+      path,
+      hint: `Check that ${fieldName} points to an existing file.`,
+    });
+  }
+  const stat = statSync(path);
+  if (!stat.isFile()) {
+    fail({
+      code: "NOT_A_FILE",
+      message: `${fieldName} points to a ${stat.isDirectory() ? "directory" : "non-regular file"}: ${path}`,
+      field: fieldName,
+      path,
     });
   }
 }

--- a/cli/lib/deploy-v2.mjs
+++ b/cli/lib/deploy-v2.mjs
@@ -166,6 +166,43 @@ async function applyCmd(args) {
     });
   }
 
+  // GH-232: Reject empty specs client-side. Without this guard,
+  // `run402 deploy apply --spec '{}'` (and `--manifest <empty>`) would silently
+  // send an empty ReleaseSpec to /deploy/v2/plans with no signal that nothing
+  // was deployed. This mirrors the GH-185 guard already in place for the
+  // legacy `run402 deploy --manifest` path.
+  //
+  // `deploy apply` is v2-only — only meaningful keys are the v2 ReleaseSpec
+  // shape (database, site, functions, secrets, subdomains, domains).
+  // For object-typed sections the "container is non-empty" check isn't enough
+  // — `site:{replace:{}}` has one key but ships nothing. We recurse one level
+  // so any object whose own values are all empty containers is still empty.
+  const meaningful = ["database", "site", "functions", "secrets", "subdomains", "domains"];
+  function hasContent(v) {
+    if (v == null) return false;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === "object") {
+      const keys = Object.keys(v);
+      if (keys.length === 0) return false;
+      return keys.some((k) => hasContent(v[k]));
+    }
+    if (typeof v === "string") return v.length > 0;
+    return true;
+  }
+  const hasMeaningfulContent = spec && typeof spec === "object" && !Array.isArray(spec) && meaningful.some((key) => hasContent(spec[key]));
+  if (!hasMeaningfulContent) {
+    fail({
+      code: "MANIFEST_EMPTY",
+      message: `Manifest contains no deployable sections. Expected at least one of: ${meaningful.join(", ")}`,
+      hint: "Did you mean to write a 'site.replace' or 'database.migrations' block? See https://run402.com/schemas/manifest.v1.json",
+      details: {
+        field: opts.manifest ? "manifest" : opts.spec ? "spec" : "stdin",
+        ...(opts.manifest ? { path: resolve(opts.manifest) } : {}),
+        meaningful_keys: meaningful,
+      },
+    });
+  }
+
   if (opts.manifest) resolveFileDataPaths(spec, dirname(resolve(opts.manifest)));
 
   if (opts.project && spec.project_id && spec.project_id !== opts.project) {

--- a/cli/lib/functions.mjs
+++ b/cli/lib/functions.mjs
@@ -1,8 +1,8 @@
-import { readFileSync, existsSync, statSync } from "fs";
+import { readFileSync } from "fs";
 import { findProject, API } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
 import { reportSdkError, fail } from "./sdk-errors.mjs";
-import { assertKnownFlags, hasHelp, normalizeArgv, parseIntegerFlag } from "./argparse.mjs";
+import { assertKnownFlags, hasHelp, normalizeArgv, parseIntegerFlag, validateRegularFile } from "./argparse.mjs";
 
 const HELP = `run402 functions — Manage serverless functions
 
@@ -181,24 +181,7 @@ async function deploy(projectId, name, args) {
   if (!opts.file) {
     fail({ code: "BAD_USAGE", message: "Missing --file <file>" });
   }
-  if (!existsSync(opts.file)) {
-    fail({
-      code: "FILE_NOT_FOUND",
-      message: `File not found: ${opts.file}`,
-      field: "--file",
-      path: opts.file,
-      hint: "Check that --file points to an existing source file.",
-    });
-  }
-  const stat = statSync(opts.file);
-  if (!stat.isFile()) {
-    fail({
-      code: "NOT_A_FILE",
-      message: `--file points to a ${stat.isDirectory() ? "directory" : "non-regular file"}: ${opts.file}`,
-      field: "--file",
-      path: opts.file,
-    });
-  }
+  validateRegularFile(opts.file, "--file");
   const code = readFileSync(opts.file, "utf-8");
 
   const deployOpts = { name, code };

--- a/cli/lib/projects.mjs
+++ b/cli/lib/projects.mjs
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { findProject, loadKeyStore, API, allowanceAuthHeaders, resolveProjectId, getActiveProjectId } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
 import { reportSdkError, fail, parseFlagJson } from "./sdk-errors.mjs";
-import { assertKnownFlags, failBadProjectId, hasHelp, normalizeArgv, positionalArgs, resolvePositionalProject } from "./argparse.mjs";
+import { assertKnownFlags, failBadProjectId, hasHelp, normalizeArgv, positionalArgs, resolvePositionalProject, validateRegularFile } from "./argparse.mjs";
 
 const HELP = `run402 projects — Manage your deployed Run402 projects
 
@@ -175,13 +175,14 @@ async function provision(args) {
 }
 
 async function applyExpose(projectId, args = []) {
-  const p = findProject(projectId);
   let file = null;
   let inline = null;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--file" && args[i + 1]) { file = args[++i]; }
     else if (!inline && !args[i].startsWith("--")) { inline = args[i]; }
   }
+  if (file) validateRegularFile(file, "--file");
+  const p = findProject(projectId);
   const raw = file ? readFileSync(file, "utf-8") : inline;
   if (!raw) {
     fail({
@@ -252,7 +253,6 @@ async function keys(projectId) {
 }
 
 async function sqlCmd(projectId, args = []) {
-  const p = findProject(projectId);
   let file = null;
   let query = null;
   let paramsRaw = null;
@@ -261,6 +261,8 @@ async function sqlCmd(projectId, args = []) {
     else if (args[i] === "--params" && args[i + 1]) { paramsRaw = args[++i]; }
     else if (!query && !args[i].startsWith("--")) { query = args[i]; }
   }
+  if (file) validateRegularFile(file, "--file");
+  const p = findProject(projectId);
   const sql = file ? readFileSync(file, "utf-8") : query;
   if (!sql) {
     fail({

--- a/cli/lib/secrets.mjs
+++ b/cli/lib/secrets.mjs
@@ -1,6 +1,7 @@
 import { readFileSync } from "fs";
 import { getSdk } from "./sdk.mjs";
 import { reportSdkError, fail } from "./sdk-errors.mjs";
+import { validateRegularFile } from "./argparse.mjs";
 
 const HELP = `run402 secrets — Manage project secrets
 
@@ -82,6 +83,7 @@ async function set(projectId, key, args = []) {
     if (args[i] === "--file" && args[i + 1]) { file = args[++i]; }
     else if (!value && !args[i].startsWith("--")) { value = args[i]; }
   }
+  if (file) validateRegularFile(file, "--file");
   const val = file ? readFileSync(file, "utf-8") : value;
   if (!val) {
     fail({

--- a/cli/lib/subdomains.mjs
+++ b/cli/lib/subdomains.mjs
@@ -10,7 +10,7 @@ Usage:
 Subcommands:
   claim  <name> [--project <id>] [--deployment <id>]   Claim a subdomain
   delete <name> --confirm [--project <id>]              Release a subdomain. Requires --confirm.
-  list   [<id>]                                         List subdomains for a project
+  list   [<id>] | list --project <id>                   List subdomains for a project
 
 Options default to the active project and its last deployment when omitted.
 Legacy syntax 'claim <deployment_id> <name>' is still supported.
@@ -151,8 +151,24 @@ async function deleteSubdomain(allArgs) {
   }
 }
 
-async function list(projectIdArg) {
-  const projectId = resolveProjectId(projectIdArg);
+function parseProjectFlag(args) {
+  let project = null;
+  const rest = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--project" && args[i + 1]) { project = args[++i]; }
+    else { rest.push(args[i]); }
+  }
+  return { project, rest };
+}
+
+async function list(args) {
+  const argList = Array.isArray(args) ? args : [];
+  const { project, rest } = parseProjectFlag(argList);
+  // Either --project <id> or a positional id is accepted; --project wins
+  // when both are supplied. Falls back to the active project when neither
+  // is given. Keeps backward-compat with the legacy `subdomains list <id>`
+  // form (GH-231; mirrors the GH-209 fix for `domains list`).
+  const projectId = resolveProjectId(project || rest[0]);
   try {
     const data = await getSdk().subdomains.list(projectId);
     console.log(JSON.stringify(data, null, 2));
@@ -177,7 +193,7 @@ export async function run(sub, args) {
       break;
     }
     case "delete": await deleteSubdomain(args); break;
-    case "list":   await list(args[0]); break;
+    case "list":   await list(args); break;
     default:
       console.error(`Unknown subcommand: ${sub}\n`);
       console.log(HELP);


### PR DESCRIPTION
## Summary

Sibling bugs surfaced during the v1.54.3 triage batch. All three were spotted by the agents that fixed the original bugs and noted in their commit messages as out-of-scope follow-ups.

| Issue | Title | Sibling of | Commit |
|---|---|---|---|
| #231 | `subdomains list` flag/positional bug | #209 | `e3c54e6` |
| #232 | `deploy apply` (v2 primitive) lacks empty-manifest guard | #185 | `1cedcc3` |
| #233 | `--file` flags share #195's crash class (`secrets set`, `projects sql`, `projects apply-expose`) | #195 | `bb09885` |

#233 also extracted `validateRegularFile()` into `cli/lib/argparse.mjs` and refactored `functions deploy --file` to call the shared helper — one place to update if the envelope shape evolves.

## Verification

- Each fix branch individually green (test + build + typecheck).
- Combined `npm test`: **714 unit + 375 e2e + 22 doc snippets**, 0 failures.
- All three merges into this branch were conflict-free.
- `npm run build`: clean.
- `npx tsc --noEmit` (root + core + sdk): clean.

## Test plan

- [ ] Review the per-issue commits
- [ ] CI passes on this branch
- [ ] Merge to `main`
- [ ] Run `/publish` for a `patch` bump (1.54.3 → 1.54.4) shipping all 3 fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
