### PR TITLE
fix(cli): add blob content-type override

### DIFF
--- a/cli-argv.test.mjs
+++ b/cli-argv.test.mjs
@@ -196,6 +196,74 @@ describe("numeric flag validation", () => {
     assert.equal(calls.length, 0, "bad --concurrency must not init an upload");
   });
 
+  it("blob put validates --content-type before upload init (GH-237)", async () => {
+    const { run } = await import("./cli/lib/blob.mjs");
+    const file = join(tempDir, "bad-mime.txt");
+    writeFileSync(file, "hello");
+    for (const value of ["", "image", "/svg", "image/"]) {
+      calls = [];
+      const argv = value === ""
+        ? [file, "--project", "prj_test123", "--content-type"]
+        : [file, "--project", "prj_test123", "--content-type", value];
+      const err = await expectExit1(() => run("put", argv));
+      assert.equal(err.code, "BAD_FLAG");
+      assert.match(err.message, /--content-type/);
+      assert.equal(calls.length, 0, `bad --content-type ${JSON.stringify(value)} must not init an upload`);
+    }
+  });
+
+  it("blob put sends explicit --content-type to upload init (GH-237)", async () => {
+    const { run } = await import("./cli/lib/blob.mjs");
+    const file = join(tempDir, "extensionless-asset");
+    writeFileSync(file, "<svg></svg>");
+    let initBody = null;
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = (input, init) => {
+      const info = requestInfo(input, init);
+      calls.push(info);
+      if (info.path === "/storage/v1/uploads" && info.method === "POST") {
+        initBody = JSON.parse(String(info.init.body));
+        return Promise.resolve(json({
+          upload_id: "upload_mime",
+          mode: "single",
+          part_count: 1,
+          parts: [{ part_number: 1, url: "https://s3.example.test/upload_mime/p1", byte_start: 0, byte_end: 10 }],
+        }, 201));
+      }
+      if (info.url === "https://s3.example.test/upload_mime/p1" && info.method === "PUT") {
+        return Promise.resolve(new Response("", { status: 200, headers: { etag: "\"etag-1\"" } }));
+      }
+      if (info.path === "/storage/v1/uploads/upload_mime/complete" && info.method === "POST") {
+        return Promise.resolve(json({
+          key: "assets/logo",
+          size_bytes: 11,
+          sha256: null,
+          visibility: "public",
+          content_type: "image/svg+xml",
+          url: "https://pr-test.run402.com/_blob/assets/logo",
+          immutable_url: null,
+        }));
+      }
+      return mockFetch(input, init);
+    };
+    captureStart();
+    try {
+      await run("put", [
+        file,
+        "--project", "prj_test123",
+        "--key", "assets/logo",
+        "--content-type", "image/svg+xml",
+        "--no-resume",
+      ]);
+    } finally {
+      captureStop();
+      globalThis.fetch = prevFetch;
+    }
+
+    assert.equal(initBody?.content_type, "image/svg+xml");
+    assert.equal(initBody?.key, "assets/logo");
+  });
+
   it("blob put surfaces upload-init gateway errors as structured JSON (GH-186)", async () => {
     const { run } = await import("./cli/lib/blob.mjs");
     const file = join(tempDir, "upload-init-fails.txt");

--- a/cli/README.md
+++ b/cli/README.md
@@ -97,11 +97,13 @@ CI deploys can ship `site`, `functions`, and `database` changes. Keep secrets, d
 
 ```bash
 run402 blob put ./logo.png        # → AssetRef with cdn_url, sri, etag
+run402 blob put ./asset --key assets/logo --content-type image/svg+xml
 run402 blob get <key> --output /tmp/logo.png
 run402 blob diagnose <url>        # exit 0 if fresh, 1 if stale
 ```
 
 The returned `cdn_url` is content-addressed (`pr-<public_id>.run402.com/_blob/<key>-<8hex>.<ext>`) — paste it straight into HTML. SRI is bundled in `sri`.
+`blob put` infers MIME type from the destination key; use `--content-type <mime>` when the key has no useful extension or needs an explicit override.
 
 ### Functions
 

--- a/cli/lib/blob.mjs
+++ b/cli/lib/blob.mjs
@@ -2,7 +2,7 @@
  * run402 blob — direct-to-S3 storage CLI.
  *
  * Usage:
- *   run402 blob put <file> [files...] [--project <id>] [--key <dest>] [--private] [--immutable] [--concurrency N] [--no-resume]
+ *   run402 blob put <file> [files...] [--project <id>] [--key <dest>] [--content-type <mime>] [--private] [--immutable] [--concurrency N] [--no-resume]
  *   run402 blob get <key> --output <file> [--project <id>]
  *   run402 blob ls [--project <id>] [--prefix <p>] [--limit <n>]
  *   run402 blob rm <key> [--project <id>]
@@ -52,6 +52,7 @@ Usage:
 Options:
   --project <id>      Project ID (defaults to active project from 'run402 projects use')
   --key <dest>        Destination key (put only; defaults to file basename)
+  --content-type <mime>  MIME override for blob put (defaults to extension inference)
   --private           Upload as private (not served by CDN; apikey required to read)
   --immutable         Adds a content-hash suffix to the URL so overwrites produce distinct URLs.
                       Requires computing SHA-256 over the file (CLI does this automatically).
@@ -84,6 +85,7 @@ Arguments:
 Options:
   --project <id>      Project ID (defaults to active project from 'run402 projects use')
   --key <dest>        Destination key; defaults to file basename. Use trailing '/' as prefix.
+  --content-type <mime>  MIME override; defaults to inferring from the destination key extension
   --private           Upload as private (not served by CDN; apikey required to read)
   --immutable         Append content-hash suffix so overwrites produce distinct URLs
   --concurrency N     Concurrent part PUTs for multipart uploads (default 4)
@@ -93,6 +95,7 @@ Options:
 Examples:
   run402 blob put ./artifact.tgz --project prj_abc123
   run402 blob put ./dist/**/*.png --project prj_abc123 --key assets/
+  run402 blob put ./asset --project prj_abc123 --key assets/logo --content-type image/svg+xml
   run402 blob put huge.bin --project prj_abc123 --immutable --concurrency 8
 `,
   get: `run402 blob get — Download a blob by key
@@ -202,10 +205,11 @@ function dieApiFailure(prefix, http, body) {
 
 function parseArgs(rawArgs) {
   const args = normalizeArgv(rawArgs);
-  const valueFlags = ["--project", "--key", "--concurrency", "--prefix", "--limit", "--output", "-o", "--ttl"];
+  const valueFlags = ["--project", "--key", "--content-type", "--concurrency", "--prefix", "--limit", "--output", "-o", "--ttl"];
   assertKnownFlags(args, [
     "--project",
     "--key",
+    "--content-type",
     "--private",
     "--immutable",
     "--concurrency",
@@ -221,11 +225,12 @@ function parseArgs(rawArgs) {
   ], valueFlags);
   const out = { positional: [], project: null, key: null, private: false, immutable: false,
                  concurrency: 4, resume: true, json: false, prefix: null, limit: null,
-                 output: null, ttl: null };
+                 output: null, ttl: null, contentType: null };
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--project") out.project = args[++i];
     else if (a === "--key") out.key = args[++i];
+    else if (a === "--content-type") out.contentType = parseContentTypeFlag("--content-type", args[++i]);
     else if (a === "--private") out.private = true;
     else if (a === "--immutable") out.immutable = true;
     else if (a === "--concurrency") out.concurrency = parseIntegerFlag("--concurrency", args[++i], { min: 1 });
@@ -238,6 +243,26 @@ function parseArgs(rawArgs) {
     else if (!a.startsWith("--")) out.positional.push(a);
   }
   return out;
+}
+
+function parseContentTypeFlag(name, value) {
+  if (value === undefined || value === null) {
+    fail({
+      code: "BAD_FLAG",
+      message: `${name} requires a MIME type value`,
+      details: { flag: name },
+    });
+  }
+  const raw = String(value).trim();
+  const base = raw.split(";", 1)[0].trim();
+  if (!/^[^\s/]+\/[^\s/]+$/.test(base)) {
+    fail({
+      code: "BAD_FLAG",
+      message: `${name} must be a non-empty type/subtype MIME value, got: ${String(value)}`,
+      details: { flag: name, value: String(value) },
+    });
+  }
+  return raw;
 }
 
 async function sha256File(filePath) {
@@ -311,7 +336,7 @@ async function putOne(project, filePath, opts) {
     const init = await apiFetch(`${API}/storage/v1/uploads`, "POST", project, {
       key: destKey,
       size_bytes: size,
-      content_type: guessContentType(destKey),
+      content_type: opts.contentType ?? guessContentType(destKey),
       visibility: opts.private ? "private" : "public",
       immutable: opts.immutable,
       sha256,

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -653,7 +653,7 @@ Injected as `process.env` in functions. Values are write-only — `list` returns
 
 Direct-to-S3 blob storage. Works for any size from 1 byte up to 5 TiB. No bucket concept — blobs live in a flat key namespace per project.
 
-- `run402 blob put <file> [files...] [--project <id>] [--key <dest>] [--private] [--immutable] [--concurrency N] [--no-resume] [--json]`
+- `run402 blob put <file> [files...] [--project <id>] [--key <dest>] [--content-type <mime>] [--private] [--immutable] [--concurrency N] [--no-resume] [--json]`
 - `run402 blob get <key> --output <file> [--project <id>]`
 - `run402 blob ls [--project <id>] [--prefix <p>] [--limit <n>]`
 - `run402 blob rm <key> [--project <id>]`
@@ -666,6 +666,7 @@ Examples:
 ```
 run402 blob put ./artifact.tgz --project prj_abc123
 run402 blob put ./dist/**/*.png --project prj_abc123 --key assets/
+run402 blob put ./asset --project prj_abc123 --key assets/logo --content-type image/svg+xml
 run402 blob put huge.bin --project prj_abc123 --immutable
 run402 blob get images/logo.png --output /tmp/logo.png --project prj_abc123
 run402 blob ls --project prj_abc123 --prefix images/
@@ -699,6 +700,8 @@ Other AssetRef fields for advanced use:
 Resume: state is persisted to `~/.run402/uploads/<upload_id>.json`. Ctrl-C mid-upload and re-run the same `blob put` command — it picks up where it left off. Pass `--no-resume` to start fresh.
 
 Private blobs (`--private`): no CDN URL returned; read via authenticated gateway path `GET /storage/v1/blob/<key>` with apikey, or via `run402 blob sign` for time-boxed external sharing.
+
+Content-Type: `blob put` infers MIME from the destination key extension. Use `--content-type <mime>` for extensionless assets, uncommon file types, or deliberate overrides; the value applies to every file in the invocation.
 
 `diagnose` exit codes are shell-loop-friendly: `0` when the CDN serves the gateway's expected SHA, `1` otherwise. So `until run402 blob diagnose <url>; do sleep 1; done` blocks until the CDN catches up. Vantage: probes are single-region (us-east-1); the `# probed once from gateway-us-east-1; not a global view` line on stderr is the explicit caveat.
 

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -250,6 +250,7 @@ Views always run with `security_invoker=true` — they inherit the underlying ta
 run402 blob put ./logo.png    --json
 run402 blob put ./app.js      --json
 run402 blob put ./styles.css  --json
+run402 blob put ./asset       --key assets/logo --content-type image/svg+xml --json
 ```
 
 Each response includes:
@@ -262,6 +263,8 @@ Each response includes:
 | `cache_kind` | `immutable` / `mutable` / `private` |
 
 Immutable upload is the default since v1.45 — the SDK computes the SHA-256 client-side and pairs the URL with SRI. The browser refuses execution on byte mismatch. No invalidation choreography.
+
+`blob put` infers MIME type from the destination key. Use `--content-type <mime>` for extensionless assets, unusual file types, or deliberate overrides.
 
 ### List, fetch, remove, sign
 


### PR DESCRIPTION
## Summary
- add `run402 blob put --content-type <mime>`
- pass explicit MIME values to upload init, falling back to key-extension inference when omitted
- document the flag for CLI and OpenClaw agents

## Tests
- node --test cli-argv.test.mjs
- npm run test:help
- npm run test:skill

Closes #237