### PR TITLE
feat(operator): operator (human/email) session — login, overview, whoami, logout

### DIFF
--- a/cli-help.test.mjs
+++ b/cli-help.test.mjs
@@ -119,6 +119,7 @@ const MATRIX = {
     ],
   },
   agent: { shared: [], specific: ["contact"] },
+  operator: { shared: ["login", "logout", "overview", "whoami"], specific: [] },
   service: { shared: [], specific: ["status", "health"] },
 };
 

--- a/cli/cli.mjs
+++ b/cli/cli.mjs
@@ -48,6 +48,7 @@ Commands:
   billing     Email billing accounts, Stripe tier checkout, email packs
   contracts   KMS contract wallets ($0.04/day rental + $0.000005/sign)
   agent       Manage agent identity (contact info)
+  operator    Operator (human/email) session — login, then overview across your wallets
   service     Run402 service health and availability (status, health)
   cache       Inspect and invalidate the SSR origin cache (inspect, invalidate)
   doctor      Health and config diagnostics (machine-readable with --json)
@@ -241,6 +242,11 @@ switch (cmd) {
   }
   case "agent": {
     const { run } = await import("./lib/agent.mjs");
+    await run(sub, rest);
+    break;
+  }
+  case "operator": {
+    const { run } = await import("./lib/operator.mjs");
     await run(sub, rest);
     break;
   }

--- a/cli/lib/operator.mjs
+++ b/cli/lib/operator.mjs
@@ -1,0 +1,261 @@
+/**
+ * run402 operator — the operator (human / email) session.
+ *
+ * The operator is YOU, the human, identified by email — distinct from the
+ * AGENT (your wallet / SIWX identity). One browser login spans every wallet
+ * that verified your email, so `operator overview` returns the cross-wallet
+ * union. For a single wallet's account state, use `run402 status`.
+ *
+ * Auth: browser-delegated device-authorization grant (RFC 8628, the
+ * `aws sso login` model). The CLI never performs WebAuthn — the browser does,
+ * via the existing magic-link / passkey flows — and the CLI brokers the
+ * resulting operator-session token, cached at the BASE config dir (shared
+ * across named wallets, since the session is email-scoped).
+ *
+ * Agent-first: JSON to stdout. `login` additionally prints the verification URL
+ * + user code to stderr (human-in-the-loop) and degrades gracefully when not a
+ * TTY. Gated on the gateway device-auth bridge (kychee-com/run402-private#443).
+ */
+
+import { setTimeout as sleep } from "node:timers/promises";
+import { spawn } from "node:child_process";
+import { fail, reportSdkError } from "./sdk-errors.mjs";
+import { getSdk } from "./sdk.mjs";
+import { normalizeArgv, hasHelp, assertKnownFlags } from "./argparse.mjs";
+import {
+  saveOperatorSession,
+  clearOperatorSession,
+  loadLiveOperatorSession,
+  readOperatorSession,
+  isOperatorSessionExpired,
+  operatorSessionFromTokenResponse,
+} from "../core-dist/operator-session.js";
+
+const CLIENT_NAME = "run402 CLI";
+
+const HELP = `run402 operator — operator (human / email) session
+
+The operator is YOU, the human, identified by email — distinct from the agent
+(your wallet). One browser login spans every wallet that verified your email.
+For a single wallet's account state, use 'run402 status'.
+
+Usage:
+  run402 operator login [--no-open]
+  run402 operator overview
+  run402 operator whoami
+  run402 operator logout
+
+Subcommands:
+  login      Sign in via the browser (device-authorization, like 'aws sso login')
+  overview   Account view across ALL wallets controlling your email (requires login)
+  whoami     Show the cached session (email, wallets, expiry) — local, no network
+  logout     Revoke the session server-side and clear the local cache
+
+Options:
+  --no-open  (login) Do not auto-open the browser; just print the URL + code.
+
+Notes:
+  - The session is cached at the base config dir, shared across named wallets.
+  - 'overview' requires 'login' and never falls back to a single wallet.
+  - JSON to stdout; 'login' prints the URL + code to stderr (human-in-the-loop).
+`;
+
+/** Shared output shape for `whoami` and the `login` success result. */
+function sessionView(session, nowMs = Date.now()) {
+  return {
+    logged_in: true,
+    email: session.email,
+    wallets: session.wallets,
+    wallet_count: session.wallets.length,
+    expires_at: new Date(session.expires_at).toISOString(),
+    absolute_expires_at: session.absolute_expires_at || null,
+    expires_in_seconds: Math.max(0, Math.round((session.expires_at - nowMs) / 1000)),
+  };
+}
+
+/** Best-effort, cross-platform browser open. Never throws. */
+function openBrowser(url) {
+  try {
+    let cmd;
+    let cmdArgs;
+    if (process.platform === "darwin") {
+      cmd = "open";
+      cmdArgs = [url];
+    } else if (process.platform === "win32") {
+      cmd = "cmd";
+      cmdArgs = ["/c", "start", "", url];
+    } else {
+      cmd = "xdg-open";
+      cmdArgs = [url];
+    }
+    const child = spawn(cmd, cmdArgs, { stdio: "ignore", detached: true });
+    child.on("error", () => {}); // ignore: the URL is also printed to stderr
+    child.unref();
+  } catch {
+    // Best-effort only — the human can always copy the printed URL.
+  }
+}
+
+async function login(args) {
+  assertKnownFlags(args, ["--help", "-h", "--no-open"]);
+  const noOpen = args.includes("--no-open");
+  const sdk = getSdk();
+
+  let start;
+  try {
+    start = await sdk.operator.deviceStart({ clientName: CLIENT_NAME });
+  } catch (err) {
+    return reportSdkError(err);
+  }
+
+  // Human-in-the-loop prompt → stderr, so stdout stays clean for the final JSON.
+  const target = start.verification_uri_complete || start.verification_uri;
+  process.stderr.write(
+    `\nTo authorize the ${CLIENT_NAME}, open:\n  ${start.verification_uri}\n` +
+      `and enter the code:  ${start.user_code}\n\n`,
+  );
+  if (!noOpen && process.stderr.isTTY) {
+    openBrowser(target);
+    process.stderr.write("(opening your browser…)\n\n");
+  }
+  process.stderr.write("Waiting for approval…\n");
+
+  // Poll loop — honor the server interval, back off on slow_down, and stop at
+  // the device-code deadline. if/else (not switch) so the sync scanner doesn't
+  // mistake the poll states for CLI subcommands.
+  let intervalMs = Math.max(1, Number(start.interval) || 5) * 1000;
+  const deadline = Date.now() + Math.max(1, Number(start.expires_in) || 600) * 1000;
+
+  while (Date.now() < deadline) {
+    await sleep(intervalMs);
+    let result;
+    try {
+      result = await sdk.operator.devicePoll(start.device_code);
+    } catch (err) {
+      return reportSdkError(err);
+    }
+    if (result.kind === "approved") {
+      const session = operatorSessionFromTokenResponse(result.session);
+      saveOperatorSession(session);
+      process.stderr.write(`\nSigned in as ${session.email}.\n`);
+      console.log(JSON.stringify(sessionView(session)));
+      return;
+    }
+    if (result.kind === "authorization_pending") continue;
+    if (result.kind === "slow_down") {
+      intervalMs += 5000;
+      continue;
+    }
+    if (result.kind === "access_denied") {
+      fail({
+        code: "OPERATOR_LOGIN_DENIED",
+        message: "Authorization was denied in the browser.",
+        hint: "Run 'run402 operator login' to try again.",
+      });
+    }
+    if (result.kind === "expired_token") {
+      fail({
+        code: "OPERATOR_LOGIN_EXPIRED",
+        message: "The device code expired before approval.",
+        hint: "Run 'run402 operator login' to get a fresh code.",
+      });
+    }
+    fail({ code: "OPERATOR_LOGIN_FAILED", message: `Unexpected device poll result: ${result.kind}` });
+  }
+  fail({
+    code: "OPERATOR_LOGIN_TIMEOUT",
+    message: "Timed out waiting for browser approval.",
+    hint: "Run 'run402 operator login' to try again.",
+  });
+}
+
+async function logout(args) {
+  assertKnownFlags(args, ["--help", "-h"]);
+  const session = loadLiveOperatorSession();
+  let revoked = false;
+  if (session) {
+    try {
+      await getSdk().operator.revoke({ token: session.operator_session_token });
+      revoked = true;
+    } catch {
+      // Best-effort: a failed server revoke (expired token, offline) must not
+      // block clearing the local cache. The local token is removed regardless.
+      revoked = false;
+    }
+  }
+  clearOperatorSession();
+  console.log(JSON.stringify({ revoked, cleared: true }));
+}
+
+async function overview(args) {
+  assertKnownFlags(args, ["--help", "-h"]);
+  const session = loadLiveOperatorSession();
+  if (!session) {
+    fail({
+      code: "OPERATOR_LOGIN_REQUIRED",
+      message: "No operator session. Run 'run402 operator login' to sign in.",
+      hint: "operator overview shows the union across all wallets controlling your email; for a single wallet use 'run402 status'.",
+    });
+  }
+  try {
+    const result = await getSdk().operator.overview({ token: session.operator_session_token });
+    console.log(JSON.stringify(result, null, 2));
+  } catch (err) {
+    // 401/403 means the session was revoked or expired server-side. Clear the
+    // stale cache and point at re-login instead of leaving a dead token behind.
+    if (err && (err.status === 401 || err.status === 403)) {
+      clearOperatorSession();
+      fail({
+        code: "OPERATOR_SESSION_INVALID",
+        message: "Operator session is no longer valid (revoked or expired).",
+        hint: "Run 'run402 operator login' to sign in again.",
+      });
+    }
+    reportSdkError(err);
+  }
+}
+
+async function whoami(args) {
+  assertKnownFlags(args, ["--help", "-h"]);
+  const now = Date.now();
+  const session = readOperatorSession();
+  if (!session) {
+    console.log(JSON.stringify({ logged_in: false, reason: "no_session", hint: "Run 'run402 operator login' to sign in." }));
+    process.exitCode = 1;
+    return;
+  }
+  if (isOperatorSessionExpired(session, now)) {
+    console.log(JSON.stringify({ logged_in: false, reason: "expired", email: session.email, hint: "Run 'run402 operator login' to sign in again." }));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(JSON.stringify(sessionView(session, now)));
+}
+
+export async function run(sub, args = []) {
+  args = normalizeArgv(args);
+  if (!sub || sub === "--help" || sub === "-h" || hasHelp(args)) {
+    console.log(HELP);
+    process.exit(0);
+  }
+  switch (sub) {
+    case "login":
+      await login(args);
+      break;
+    case "logout":
+      await logout(args);
+      break;
+    case "overview":
+      await overview(args);
+      break;
+    case "whoami":
+      await whoami(args);
+      break;
+    default:
+      fail({
+        code: "BAD_USAGE",
+        message: `Unknown subcommand: operator ${sub}`,
+        hint: "Run 'run402 operator --help' for usage.",
+      });
+  }
+}

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -1345,6 +1345,16 @@ KMS contract wallets — provision AWS KMS-backed Ethereum wallets per project f
 
 `contact` returns `email_verification_status`, `passkey_binding_status`, and `assurance_level`. New or changed emails start a reply challenge and stay `email_pending` until the mailbox owner replies. `passkey enroll` requires `email_verified` and emails the enrollment link to the verified contact email; the token is not printed.
 
+### operator
+The **operator** is YOU, the human, identified by email — distinct from the **agent** (your wallet / SIWX identity). One browser login spans every wallet that verified your email, so `operator overview` returns the cross-wallet union. For a single wallet's account state, use `run402 status` (that IS the wallet's view; there is no `operator status`).
+
+- `run402 operator login [--no-open]` — browser-delegated sign-in (device-authorization, RFC 8628, the `aws sso login` model). Prints a verification URL + short user code to stderr and (on a TTY) opens the browser; you approve via the existing magic-link OR passkey web flow. Polls until approved, then caches the session at `{base}/operator-session.json` (0600, base config dir — shared across named wallets). Stdout JSON on success: `{ logged_in, email, wallets, wallet_count, expires_at, absolute_expires_at, expires_in_seconds }`.
+- `run402 operator overview` — account view across ALL wallets controlling your email. Sends the cached operator-session bearer to `GET /agent/v1/operator/overview`. **Requires login** — returns `OPERATOR_LOGIN_REQUIRED` (no SIWX fallback) when there is no live session, and clears the cache + returns `OPERATOR_SESSION_INVALID` on a 401/403 (revoked or expired).
+- `run402 operator whoami` — local, no network. Prints the cached session (`logged_in`, email, wallets, expiry) or `{ logged_in: false, reason: "no_session" | "expired" }` with a non-zero exit.
+- `run402 operator logout` — revokes the session server-side (`POST /agent/v1/operator/session/revoke`) then clears the local cache. Idempotent; best-effort revoke (always clears locally). Stdout: `{ revoked, cleared }`.
+
+The session is email-scoped (~30m access TTL, ~12h absolute cap), so it is cached once at the base dir and reused regardless of the active `--wallet`. Login/overview/logout require the gateway device-authorization bridge (kychee-com/run402-private#443); `whoami` is local and works today. Not exposed as MCP tools by design — MCP authenticates as the agent (wallet), and the human session must not be handed to the agent.
+
 ### service
 Public service-level status. No allowance, no auth, no keystore required — works on a fresh install. Reports on the Run402 service (uptime, capabilities, operator); for your account state use `run402 status`.
 - `run402 service status` — public availability report (24h/7d/30d uptime per capability, operator, deployment, schema `run402-status-v1`)

--- a/core/src/operator-session.test.ts
+++ b/core/src/operator-session.test.ts
@@ -1,0 +1,258 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, statSync, existsSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readOperatorSession,
+  saveOperatorSession,
+  clearOperatorSession,
+  isOperatorSessionExpired,
+  loadLiveOperatorSession,
+  operatorSessionFromTokenResponse,
+  getOperatorSessionPath,
+  type OperatorSession,
+} from "./operator-session.js";
+
+function tmp() {
+  const dir = mkdtempSync(join(tmpdir(), "r402-opsess-"));
+  return {
+    dir,
+    path: join(dir, "operator-session.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function sample(over: Partial<OperatorSession> = {}): OperatorSession {
+  return {
+    operator_session_token: "ops_abc.def.ghi",
+    token_type: "Bearer",
+    email: "tal@kychee.com",
+    wallets: ["0x1111111111111111111111111111111111111111", "0x2222222222222222222222222222222222222222"],
+    expires_at: 9_999_999_999_000,
+    absolute_expires_at: "2099-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+test("readOperatorSession returns null when the file is absent", () => {
+  const { path, cleanup } = tmp();
+  try {
+    assert.equal(readOperatorSession(path), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("save then read round-trips", () => {
+  const { path, cleanup } = tmp();
+  try {
+    const s = sample();
+    saveOperatorSession(s, path);
+    assert.deepEqual(readOperatorSession(path), s);
+  } finally {
+    cleanup();
+  }
+});
+
+test("save writes mode 0600", { skip: process.platform === "win32" }, () => {
+  const { path, cleanup } = tmp();
+  try {
+    saveOperatorSession(sample(), path);
+    assert.equal(statSync(path).mode & 0o777, 0o600);
+  } finally {
+    cleanup();
+  }
+});
+
+test("unparseable JSON reads as null (not logged in)", () => {
+  const { path, cleanup } = tmp();
+  try {
+    writeFileSync(path, "{not json", { mode: 0o600 });
+    assert.equal(readOperatorSession(path), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a JSON array (not object) throws a structured error", () => {
+  const { path, cleanup } = tmp();
+  try {
+    writeFileSync(path, "[]", { mode: 0o600 });
+    assert.throws(() => readOperatorSession(path), /must contain a JSON object/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("missing token throws", () => {
+  const { path, cleanup } = tmp();
+  try {
+    const { operator_session_token: _drop, ...rest } = sample();
+    writeFileSync(path, JSON.stringify(rest), { mode: 0o600 });
+    assert.throws(() => readOperatorSession(path), /operator_session_token/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("missing email throws", () => {
+  const { path, cleanup } = tmp();
+  try {
+    writeFileSync(path, JSON.stringify(sample({ email: "" })), { mode: 0o600 });
+    assert.throws(() => readOperatorSession(path), /'email'/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("invalid wallets list throws", () => {
+  const { path, cleanup } = tmp();
+  try {
+    writeFileSync(path, JSON.stringify({ ...sample(), wallets: [1, 2] }), { mode: 0o600 });
+    assert.throws(() => readOperatorSession(path), /'wallets'/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("non-finite expires_at throws", () => {
+  const { path, cleanup } = tmp();
+  try {
+    writeFileSync(path, JSON.stringify({ ...sample(), expires_at: "soon" }), { mode: 0o600 });
+    assert.throws(() => readOperatorSession(path), /'expires_at'/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("clear removes the file and is idempotent", () => {
+  const { path, cleanup } = tmp();
+  try {
+    saveOperatorSession(sample(), path);
+    assert.ok(existsSync(path));
+    clearOperatorSession(path);
+    assert.ok(!existsSync(path));
+    // Second clear on an absent file is a no-op (no throw).
+    clearOperatorSession(path);
+    assert.ok(!existsSync(path));
+  } finally {
+    cleanup();
+  }
+});
+
+test("isOperatorSessionExpired: future is live, past is expired", () => {
+  const now = 1_000_000_000_000;
+  assert.equal(isOperatorSessionExpired(sample({ expires_at: now + 60_000 }), now), false);
+  assert.equal(isOperatorSessionExpired(sample({ expires_at: now - 1 }), now), true);
+});
+
+test("isOperatorSessionExpired: skew buffer treats near-expiry as expired", () => {
+  const now = 1_000_000_000_000;
+  // Expires in 5s, but the 10s skew buffer should consider it already expired.
+  assert.equal(isOperatorSessionExpired(sample({ expires_at: now + 5_000 }), now), true);
+});
+
+test("isOperatorSessionExpired: absolute cap in the past forces expiry", () => {
+  const now = 1_000_000_000_000;
+  assert.equal(
+    isOperatorSessionExpired(
+      sample({ expires_at: now + 3_600_000, absolute_expires_at: "1990-01-01T00:00:00.000Z" }),
+      now,
+    ),
+    true,
+  );
+});
+
+test("loadLiveOperatorSession returns the session when live, null when expired/absent", () => {
+  const { path, cleanup } = tmp();
+  try {
+    const now = 1_000_000_000_000;
+    assert.equal(loadLiveOperatorSession(path, now), null); // absent
+
+    saveOperatorSession(sample({ expires_at: now + 600_000 }), path);
+    assert.ok(loadLiveOperatorSession(path, now)); // live
+
+    saveOperatorSession(sample({ expires_at: now - 1 }), path);
+    assert.equal(loadLiveOperatorSession(path, now), null); // expired
+  } finally {
+    cleanup();
+  }
+});
+
+test("operatorSessionFromTokenResponse maps expires_in to an absolute expires_at", () => {
+  const now = 1_700_000_000_000;
+  const mapped = operatorSessionFromTokenResponse(
+    {
+      operator_session_token: "ops_xyz",
+      token_type: "Bearer",
+      expires_in: 1800,
+      absolute_expires_at: "2099-01-01T00:00:00.000Z",
+      email: "tal@kychee.com",
+      wallets: ["0xabc"],
+    },
+    now,
+  );
+  assert.equal(mapped.expires_at, now + 1800 * 1000);
+  assert.equal(mapped.email, "tal@kychee.com");
+  assert.deepEqual(mapped.wallets, ["0xabc"]);
+});
+
+test("operatorSessionFromTokenResponse defaults token_type to Bearer and tolerates missing fields", () => {
+  const now = 0;
+  const mapped = operatorSessionFromTokenResponse({ operator_session_token: "ops_only" }, now);
+  assert.equal(mapped.token_type, "Bearer");
+  assert.equal(mapped.expires_at, 0);
+  assert.deepEqual(mapped.wallets, []);
+  assert.equal(mapped.absolute_expires_at, "");
+});
+
+test("self-heal tightens a world-readable file to 0600 on read", { skip: process.platform === "win32" }, () => {
+  const { path, cleanup } = tmp();
+  try {
+    writeFileSync(path, JSON.stringify(sample()), { mode: 0o644 });
+    chmodSync(path, 0o644); // ensure the loose mode survived umask
+    readOperatorSession(path);
+    assert.equal(statSync(path).mode & 0o777, 0o600);
+  } finally {
+    cleanup();
+  }
+});
+
+test("getOperatorSessionPath honors RUN402_OPERATOR_SESSION_PATH then the base config dir", () => {
+  const savedOverride = process.env.RUN402_OPERATOR_SESSION_PATH;
+  const savedBase = process.env.RUN402_CONFIG_DIR;
+  try {
+    process.env.RUN402_OPERATOR_SESSION_PATH = "/custom/op.json";
+    assert.equal(getOperatorSessionPath(), "/custom/op.json");
+
+    delete process.env.RUN402_OPERATOR_SESSION_PATH;
+    process.env.RUN402_CONFIG_DIR = "/tmp/r402-base";
+    // Lives at the BASE dir directly, never under profiles/<name>/.
+    assert.equal(getOperatorSessionPath(), join("/tmp/r402-base", "operator-session.json"));
+  } finally {
+    if (savedOverride === undefined) delete process.env.RUN402_OPERATOR_SESSION_PATH;
+    else process.env.RUN402_OPERATOR_SESSION_PATH = savedOverride;
+    if (savedBase === undefined) delete process.env.RUN402_CONFIG_DIR;
+    else process.env.RUN402_CONFIG_DIR = savedBase;
+  }
+});
+
+test("operator session path stays at base even when a named wallet is active", () => {
+  const savedOverride = process.env.RUN402_OPERATOR_SESSION_PATH;
+  const savedBase = process.env.RUN402_CONFIG_DIR;
+  const savedWallet = process.env.RUN402_WALLET;
+  try {
+    delete process.env.RUN402_OPERATOR_SESSION_PATH;
+    process.env.RUN402_CONFIG_DIR = "/tmp/r402-base";
+    process.env.RUN402_WALLET = "work"; // a named profile must NOT move the session
+    assert.equal(getOperatorSessionPath(), join("/tmp/r402-base", "operator-session.json"));
+  } finally {
+    if (savedOverride === undefined) delete process.env.RUN402_OPERATOR_SESSION_PATH;
+    else process.env.RUN402_OPERATOR_SESSION_PATH = savedOverride;
+    if (savedBase === undefined) delete process.env.RUN402_CONFIG_DIR;
+    else process.env.RUN402_CONFIG_DIR = savedBase;
+    if (savedWallet === undefined) delete process.env.RUN402_WALLET;
+    else process.env.RUN402_WALLET = savedWallet;
+  }
+});

--- a/core/src/operator-session.ts
+++ b/core/src/operator-session.ts
@@ -1,0 +1,211 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync, renameSync, statSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getConfigBaseDir } from "./config.js";
+
+/**
+ * A cached operator session — the *human* (email) principal, distinct from the
+ * agent's per-wallet SIWX identity. Minted in the browser via the device-
+ * authorization flow (`run402 operator login`) and cached at the BASE config
+ * dir (not per-wallet) because it is email-scoped: one login spans every local
+ * named wallet that the email controls.
+ *
+ * Stored shape vs the gateway token payload: the gateway returns a relative
+ * `expires_in` (seconds); we persist the absolute `expires_at` (epoch ms,
+ * computed at write time) so a cached session can be checked for expiry without
+ * knowing when it was written. `absolute_expires_at` (the gateway's ~12h hard
+ * cap) is stored verbatim, for display and a defensive secondary expiry check.
+ */
+export interface OperatorSession {
+  operator_session_token: string;
+  token_type: string;
+  email: string;
+  wallets: string[];
+  /** Epoch ms when the access token expires (issued_at + expires_in). */
+  expires_at: number;
+  /** ISO 8601 absolute cap from the gateway; the session cannot outlive it. */
+  absolute_expires_at: string;
+}
+
+/**
+ * The token payload returned by the device/token poll (and the underlying
+ * email/passkey mints). Relative `expires_in`; mapped to an absolute
+ * `expires_at` by {@link operatorSessionFromTokenResponse} before caching.
+ */
+export interface OperatorSessionTokenResponse {
+  operator_session_token: string;
+  token_type?: string;
+  expires_in?: number;
+  absolute_expires_at?: string;
+  email?: string;
+  wallets?: string[];
+}
+
+/**
+ * Path to the cached operator session: `{base}/operator-session.json`, at the
+ * BASE config dir — NOT the per-profile dir, because the session is email-
+ * scoped and shared across all local named wallets. `RUN402_OPERATOR_SESSION_PATH`
+ * overrides for testing, mirroring `RUN402_ALLOWANCE_PATH`.
+ */
+export function getOperatorSessionPath(): string {
+  return process.env.RUN402_OPERATOR_SESSION_PATH || join(getConfigBaseDir(), "operator-session.json");
+}
+
+/**
+ * If the session file is readable by group or other (any low 0o077 bit set),
+ * tighten it to 0600 and warn once on stderr — the bearer token is as sensitive
+ * as the allowance private key. Best-effort: POSIX-only, silent elsewhere.
+ * Mirrors the self-heal in `allowance.ts`.
+ */
+function selfHealPermissions(p: string): void {
+  if (process.platform === "win32") return;
+  try {
+    const mode = statSync(p).mode & 0o777;
+    if ((mode & 0o077) !== 0) {
+      chmodSync(p, 0o600);
+      process.stderr.write(
+        `warning: tightened permissions on ${p} from ${mode.toString(8)} to 600 (was readable by other users).\n`,
+      );
+    }
+  } catch {
+    // Best-effort; never block a read on a chmod/stat failure.
+  }
+}
+
+/**
+ * Load the cached operator session from disk.
+ *
+ * Returns `null` for the "no session cached" cases (file absent, unreadable, or
+ * unparseable JSON) — callers treat that as "not logged in" and point at
+ * `run402 operator login`. Throws a structured `Error` when the file parses as
+ * JSON but the shape is wrong, so a corrupted cache surfaces a clear fix-it
+ * instead of a downstream `TypeError`.
+ */
+export function readOperatorSession(path?: string): OperatorSession | null {
+  const p = path ?? getOperatorSessionPath();
+  if (!existsSync(p)) return null;
+  selfHealPermissions(p);
+  let raw: string;
+  try {
+    raw = readFileSync(p, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Unparseable input reads as "no session" rather than an error — consumers
+    // already handle null with a friendly "run 'run402 operator login'".
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `operator-session.json must contain a JSON object (got ${
+        Array.isArray(parsed) ? "array" : parsed === null ? "null" : typeof parsed
+      }). Delete the file and run 'run402 operator login' to recreate it.`,
+    );
+  }
+  const data = parsed as Partial<OperatorSession>;
+  if (typeof data.operator_session_token !== "string" || data.operator_session_token.length === 0) {
+    throw new Error(
+      "operator-session.json missing valid 'operator_session_token'. Run 'run402 operator login' to refresh it.",
+    );
+  }
+  if (typeof data.email !== "string" || data.email.length === 0) {
+    throw new Error(
+      "operator-session.json missing valid 'email'. Run 'run402 operator login' to refresh it.",
+    );
+  }
+  if (typeof data.expires_at !== "number" || !Number.isFinite(data.expires_at)) {
+    throw new Error(
+      "operator-session.json missing valid 'expires_at'. Run 'run402 operator login' to refresh it.",
+    );
+  }
+  if (!Array.isArray(data.wallets) || data.wallets.some((w) => typeof w !== "string")) {
+    throw new Error(
+      "operator-session.json has an invalid 'wallets' list. Run 'run402 operator login' to refresh it.",
+    );
+  }
+  return {
+    operator_session_token: data.operator_session_token,
+    token_type: typeof data.token_type === "string" ? data.token_type : "Bearer",
+    email: data.email,
+    wallets: data.wallets as string[],
+    expires_at: data.expires_at,
+    absolute_expires_at: typeof data.absolute_expires_at === "string" ? data.absolute_expires_at : "",
+  };
+}
+
+/** Persist an operator session atomically (temp-file + rename), mode 0600. */
+export function saveOperatorSession(data: OperatorSession, path?: string): void {
+  const p = path ?? getOperatorSessionPath();
+  const dir = dirname(p);
+  mkdirSync(dir, { recursive: true });
+  const tmp = join(dir, `.operator-session.${randomBytes(4).toString("hex")}.tmp`);
+  writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  renameSync(tmp, p);
+  chmodSync(p, 0o600);
+}
+
+/**
+ * Delete the cached operator session — the local half of `operator logout`.
+ * Best-effort and idempotent: a missing file is a no-op.
+ */
+export function clearOperatorSession(path?: string): void {
+  const p = path ?? getOperatorSessionPath();
+  try {
+    rmSync(p, { force: true });
+  } catch {
+    // Best-effort: a failed unlink should never crash logout.
+  }
+}
+
+/**
+ * Whether a cached session is past its usable life. The access token
+ * (`expires_at`, ~30m) always expires before the absolute cap (~12h), so
+ * checking it is sufficient; the absolute cap is honored defensively. A small
+ * skew buffer treats a session expiring within `skewMs` as already expired, so
+ * we never send a token that dies mid-flight.
+ */
+export function isOperatorSessionExpired(
+  session: OperatorSession,
+  nowMs: number = Date.now(),
+  skewMs = 10_000,
+): boolean {
+  if (nowMs + skewMs >= session.expires_at) return true;
+  if (session.absolute_expires_at) {
+    const cap = Date.parse(session.absolute_expires_at);
+    if (Number.isFinite(cap) && nowMs + skewMs >= cap) return true;
+  }
+  return false;
+}
+
+/**
+ * Read the cached session and return it only if still usable; `null` if absent
+ * or expired. The bearer fetch path and `operator overview` use this so an
+ * expired cache surfaces as "not logged in" instead of a server 401.
+ */
+export function loadLiveOperatorSession(path?: string, nowMs: number = Date.now()): OperatorSession | null {
+  const s = readOperatorSession(path);
+  if (!s) return null;
+  return isOperatorSessionExpired(s, nowMs) ? null : s;
+}
+
+/**
+ * Map a gateway token payload (relative `expires_in`) into the cached shape
+ * (absolute `expires_at`). `nowMs` is injectable for deterministic tests.
+ */
+export function operatorSessionFromTokenResponse(
+  resp: OperatorSessionTokenResponse,
+  nowMs: number = Date.now(),
+): OperatorSession {
+  return {
+    operator_session_token: resp.operator_session_token,
+    token_type: resp.token_type ?? "Bearer",
+    email: resp.email ?? "",
+    wallets: Array.isArray(resp.wallets) ? resp.wallets.filter((w): w is string => typeof w === "string") : [],
+    expires_at: nowMs + (typeof resp.expires_in === "number" ? resp.expires_in : 0) * 1000,
+    absolute_expires_at: resp.absolute_expires_at ?? "",
+  };
+}

--- a/openclaw/scripts/operator.mjs
+++ b/openclaw/scripts/operator.mjs
@@ -1,0 +1,1 @@
+export { run } from "../../cli/lib/operator.mjs";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -31,6 +31,7 @@ import { Admin } from "./namespaces/admin.js";
 import { Deploy } from "./namespaces/deploy.js";
 import { Ci } from "./namespaces/ci.js";
 import { Jobs } from "./namespaces/jobs.js";
+import { Operator } from "./namespaces/operator.js";
 import type { ContentSource, FileSet } from "./namespaces/deploy.types.js";
 import { ScopedRun402 } from "./scoped.js";
 import { LocalError } from "./errors.js";
@@ -80,6 +81,11 @@ export class Run402 {
   readonly _applyEngine: Deploy;
   readonly ci: Ci;
   readonly jobs: Jobs;
+  /**
+   * The *human* (email) principal — browser-delegated operator session (RFC
+   * 8628 device flow), distinct from the agent's per-wallet SIWX identity.
+   */
+  readonly operator: Operator;
 
   readonly #client: Client;
 
@@ -145,6 +151,7 @@ export class Run402 {
     this._applyEngine = new Deploy(client);
     this.ci = new Ci(client);
     this.jobs = new Jobs(client);
+    this.operator = new Operator(client);
   }
 
   /**
@@ -358,6 +365,7 @@ export type * from "./namespaces/domains.js";
 export type * from "./namespaces/email.js";
 export type * from "./namespaces/functions.types.js";
 export type * from "./namespaces/jobs.js";
+export type * from "./namespaces/operator.js";
 export type * from "./namespaces/projects.types.js";
 export type * from "./namespaces/secrets.js";
 export type * from "./namespaces/sender-domain.js";

--- a/sdk/src/namespaces/operator.test.ts
+++ b/sdk/src/namespaces/operator.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the `operator` namespace. Contract-first: the device + revoke
+ * endpoints (kychee-com/run402-private#443) 404 against the live gateway until
+ * that ships, so these exercise the client against mocked fetch — URL, method,
+ * auth header selection (bearer vs SIWX vs none), and the RFC 8628 poll state
+ * machine (pending/slow_down are data, not exceptions).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { Run402 } from "../index.js";
+import type { CredentialsProvider } from "../credentials.js";
+
+interface FetchCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function mockFetch(
+  handler: (call: FetchCall) => Response | Promise<Response>,
+): { fetch: typeof globalThis.fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchImpl: typeof globalThis.fetch = async (input, init) => {
+    const call: FetchCall = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body ?? null,
+    };
+    calls.push(call);
+    return handler(call);
+  };
+  return { fetch: fetchImpl, calls };
+}
+
+function makeCreds(overrides: Partial<CredentialsProvider> = {}): CredentialsProvider {
+  return {
+    async getAuth() {
+      return { "SIGN-IN-WITH-X": "test-siwx" };
+    },
+    async getProject() {
+      return null;
+    },
+    ...overrides,
+  };
+}
+
+function makeSdk(fetchImpl: typeof globalThis.fetch): Run402 {
+  return new Run402({
+    apiBase: "https://api.example.test",
+    credentials: makeCreds(),
+    fetch: fetchImpl,
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const TOKEN_PAYLOAD = {
+  operator_session_token: "ops_tok.abc.def",
+  token_type: "Bearer",
+  expires_in: 1800,
+  absolute_expires_at: "2099-01-01T00:00:00.000Z",
+  email: "tal@kychee.com",
+  wallets: ["0xabc"],
+};
+
+describe("operator.deviceStart", () => {
+  it("POSTs the device endpoint unauthenticated (no SIWX header)", async () => {
+    const start = {
+      device_code: "dc_secret",
+      user_code: "WXYZ-1234",
+      verification_uri: "https://api.example.test/operator",
+      verification_uri_complete: "https://api.example.test/operator?code=WXYZ-1234",
+      expires_in: 600,
+      interval: 5,
+    };
+    const { fetch, calls } = mockFetch(() => jsonResponse(start));
+    const sdk = makeSdk(fetch);
+    const result = await sdk.operator.deviceStart();
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.url, "https://api.example.test/agent/v1/operator/session/device");
+    assert.equal(calls[0]!.method, "POST");
+    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], undefined);
+    assert.equal(result.user_code, "WXYZ-1234");
+    assert.equal(result.interval, 5);
+  });
+});
+
+describe("operator.devicePoll", () => {
+  it("returns {kind:'approved'} with the session on 200 + token", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse(TOKEN_PAYLOAD));
+    const sdk = makeSdk(fetch);
+    const result = await sdk.operator.devicePoll("dc_secret");
+
+    assert.equal(calls[0]!.url, "https://api.example.test/agent/v1/operator/session/device/token");
+    assert.equal(calls[0]!.method, "POST");
+    assert.deepEqual(JSON.parse(String(calls[0]!.body)), { device_code: "dc_secret" });
+    assert.equal(result.kind, "approved");
+    if (result.kind === "approved") {
+      assert.equal(result.session.operator_session_token, "ops_tok.abc.def");
+      assert.equal(result.session.email, "tal@kychee.com");
+    }
+  });
+
+  it("maps authorization_pending (HTTP 400 + {error}) to a non-throwing result", async () => {
+    const { fetch } = mockFetch(() => jsonResponse({ error: "authorization_pending" }, 400));
+    const sdk = makeSdk(fetch);
+    assert.deepEqual(await sdk.operator.devicePoll("dc"), { kind: "authorization_pending" });
+  });
+
+  it("maps slow_down, access_denied, expired_token", async () => {
+    for (const code of ["slow_down", "access_denied", "expired_token"] as const) {
+      const { fetch } = mockFetch(() => jsonResponse({ error: code }, 400));
+      const sdk = makeSdk(fetch);
+      assert.deepEqual(await sdk.operator.devicePoll("dc"), { kind: code });
+    }
+  });
+
+  it("tolerates an error envelope returned with HTTP 200", async () => {
+    const { fetch } = mockFetch(() => jsonResponse({ error: "authorization_pending" }, 200));
+    const sdk = makeSdk(fetch);
+    assert.deepEqual(await sdk.operator.devicePoll("dc"), { kind: "authorization_pending" });
+  });
+
+  it("throws on an unexpected response shape (so callers don't loop forever)", async () => {
+    const { fetch } = mockFetch(() => jsonResponse({ unexpected: true }, 500));
+    const sdk = makeSdk(fetch);
+    await assert.rejects(() => sdk.operator.devicePoll("dc"), /Unexpected operator device-token response/);
+  });
+});
+
+describe("operator.overview", () => {
+  it("with a token: sends the bearer and NOT the SIWX header (email-union)", async () => {
+    const overview = { scope: { kind: "email", principal: "tal@kychee.com" }, wallets: [{}, {}] };
+    const { fetch, calls } = mockFetch(() => jsonResponse(overview));
+    const sdk = makeSdk(fetch);
+    const result = await sdk.operator.overview({ token: "ops_tok" });
+
+    assert.equal(calls[0]!.url, "https://api.example.test/agent/v1/operator/overview");
+    assert.equal(calls[0]!.method, "GET");
+    assert.equal(calls[0]!.headers["Authorization"], "Bearer ops_tok");
+    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], undefined);
+    assert.equal(result.scope?.kind, "email");
+  });
+
+  it("without a token: falls back to SIWX (wallet slice)", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse({ scope: { kind: "wallet" } }));
+    const sdk = makeSdk(fetch);
+    await sdk.operator.overview();
+
+    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");
+    assert.equal(calls[0]!.headers["Authorization"], undefined);
+  });
+});
+
+describe("operator.revoke", () => {
+  it("POSTs the revoke endpoint with the bearer and resolves on 204", async () => {
+    const { fetch, calls } = mockFetch(() => new Response(null, { status: 204 }));
+    const sdk = makeSdk(fetch);
+    await sdk.operator.revoke({ token: "ops_tok" });
+
+    assert.equal(calls[0]!.url, "https://api.example.test/agent/v1/operator/session/revoke");
+    assert.equal(calls[0]!.method, "POST");
+    assert.equal(calls[0]!.headers["Authorization"], "Bearer ops_tok");
+  });
+});

--- a/sdk/src/namespaces/operator.ts
+++ b/sdk/src/namespaces/operator.ts
@@ -1,0 +1,168 @@
+/**
+ * `operator` namespace — the *human* (email) principal, distinct from the
+ * agent's per-wallet SIWX identity.
+ *
+ * The human authenticates in the browser via an OAuth 2.0 device-authorization
+ * grant (RFC 8628, the `aws sso login` model): `deviceStart` returns a
+ * user-facing code + URL, the human approves it via the existing magic-link or
+ * passkey web flow, and `devicePoll` brokers the resulting operator-session
+ * token. `overview` reads the email-union account view with that token, and
+ * `revoke` ends the session server-side.
+ *
+ * Bearer auth is passed explicitly (`opts.token`) rather than sourced from a
+ * credential provider, because the operator session is a Node-only on-disk
+ * cache (`core/operator-session.ts`) and this namespace stays isomorphic. The
+ * `device*` endpoints are unauthenticated (the `device_code` in the body is the
+ * credential), so they send no auth headers.
+ *
+ * Gateway contract: kychee-com/run402-private#443 (RFC 8628 device-auth bridge).
+ */
+
+import type { Client } from "../kernel.js";
+import { ApiError, NetworkError } from "../errors.js";
+
+/** RFC 8628 device-authorization start response. */
+export interface DeviceAuthStart {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  /** Pre-fills the user_code so the human can click straight through. */
+  verification_uri_complete?: string;
+  expires_in: number;
+  /** Minimum seconds between `devicePoll` calls. */
+  interval: number;
+}
+
+/** The operator-session token payload (wire shape; relative `expires_in`). */
+export interface OperatorSessionToken {
+  operator_session_token: string;
+  token_type: string;
+  expires_in: number;
+  absolute_expires_at: string;
+  email: string;
+  wallets: string[];
+}
+
+/**
+ * Result of one `devicePoll`. The non-approved states are the RFC 8628 token
+ * error codes — they are expected polling states, NOT thrown errors, so callers
+ * can run the poll loop without try/catch.
+ */
+export type DevicePollResult =
+  | { kind: "approved"; session: OperatorSessionToken }
+  | { kind: "authorization_pending" }
+  | { kind: "slow_down" }
+  | { kind: "access_denied" }
+  | { kind: "expired_token" };
+
+/**
+ * Account overview. Forward-compatible: the gateway owns the exact shape and
+ * may add fields, so unknown keys are preserved via the index signature.
+ * `scope.kind` is `"email"` for the operator-session (email-union) and
+ * `"wallet"` for a SIWX slice.
+ */
+export interface OperatorOverview {
+  scope?: { kind?: "email" | "wallet" | string; principal?: string };
+  rollup?: Record<string, unknown>;
+  billing_accounts?: unknown[];
+  wallets?: unknown[];
+  advisories?: unknown[];
+  [key: string]: unknown;
+}
+
+const POLL_ERROR_CODES = new Set([
+  "authorization_pending",
+  "slow_down",
+  "access_denied",
+  "expired_token",
+]);
+
+export class Operator {
+  constructor(private readonly client: Client) {}
+
+  /**
+   * Begin the device-authorization flow. Unauthenticated. Returns the codes the
+   * CLI prints (`user_code` + `verification_uri`) plus the poll `interval` and
+   * `expires_in`.
+   */
+  async deviceStart(opts: { clientName?: string } = {}): Promise<DeviceAuthStart> {
+    return this.client.request<DeviceAuthStart>("/agent/v1/operator/session/device", {
+      method: "POST",
+      body: opts.clientName ? { client_name: opts.clientName } : {},
+      withAuth: false,
+      context: "starting operator device authorization",
+    });
+  }
+
+  /**
+   * Poll once for approval. Bypasses the kernel's error mapping on purpose: the
+   * RFC 8628 error codes (`authorization_pending`, `slow_down`, ...) are normal
+   * polling states returned as data, not exceptions. Only an unexpected
+   * response shape throws.
+   */
+  async devicePoll(deviceCode: string): Promise<DevicePollResult> {
+    const url = `${this.client.apiBase}/agent/v1/operator/session/device/token`;
+    let res: Response;
+    try {
+      res = await this.client.fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ device_code: deviceCode }),
+      });
+    } catch (err) {
+      throw new NetworkError(
+        `Network error while polling operator device token: ${(err as Error).message}`,
+        err,
+        "polling operator device token",
+      );
+    }
+    const body = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && body && typeof body.operator_session_token === "string") {
+      return { kind: "approved", session: body as unknown as OperatorSessionToken };
+    }
+    const error = body && typeof body.error === "string" ? body.error : null;
+    if (error && POLL_ERROR_CODES.has(error)) {
+      return { kind: error as Exclude<DevicePollResult["kind"], "approved"> };
+    }
+    throw new ApiError(
+      `Unexpected operator device-token response (HTTP ${res.status})`,
+      res.status,
+      body,
+      "polling operator device token",
+    );
+  }
+
+  /**
+   * Fetch the account overview. With `opts.token` the request carries the
+   * operator-session bearer and returns the email-union; without it the request
+   * falls back to the credential provider's default auth (SIWX) and returns
+   * that wallet's slice. The CLI always passes a token (human-only surface); the
+   * SDK supports both because the gateway endpoint accepts both principals.
+   */
+  async overview(opts: { token?: string } = {}): Promise<OperatorOverview> {
+    if (opts.token) {
+      return this.client.request<OperatorOverview>("/agent/v1/operator/overview", {
+        headers: { Authorization: `Bearer ${opts.token}` },
+        withAuth: false,
+        context: "fetching operator overview",
+      });
+    }
+    return this.client.request<OperatorOverview>("/agent/v1/operator/overview", {
+      context: "fetching operator overview",
+    });
+  }
+
+  /**
+   * Revoke the operator session server-side (the server half of
+   * `operator logout`). Idempotent on the gateway; returns 204. The local cache
+   * is cleared separately by the CLI.
+   */
+  async revoke(opts: { token: string }): Promise<void> {
+    await this.client.request<unknown>("/agent/v1/operator/session/revoke", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${opts.token}` },
+      withAuth: false,
+      context: "revoking operator session",
+    });
+  }
+}

--- a/sync.test.ts
+++ b/sync.test.ts
@@ -61,7 +61,7 @@ function parseSubcommands(filePath: string): string[] {
 /** Parse CLI commands as "module:subcommand" pairs */
 function parseCliCommands(): string[] {
   const cmds: string[] = [];
-  for (const mod of ["admin", "allowance", "wallets", "tier", "projects", "image", "storage", "assets", "cache", "cdn", "functions", "secrets", "jobs", "sites", "subdomains", "domains", "apps", "email", "message", "agent", "ai", "auth", "sender-domain", "billing", "contracts", "webhooks", "service", "deploy", "ci", "transfer", "notifications", "webhook-secret"]) {
+  for (const mod of ["admin", "allowance", "wallets", "tier", "projects", "image", "storage", "assets", "cache", "cdn", "functions", "secrets", "jobs", "sites", "subdomains", "domains", "apps", "email", "message", "agent", "operator", "ai", "auth", "sender-domain", "billing", "contracts", "webhooks", "service", "deploy", "ci", "transfer", "notifications", "webhook-secret"]) {
     for (const sub of parseSubcommands(join(__dirname, "cli/lib", `${mod}.mjs`))) {
       cmds.push(`${mod}:${sub}`);
     }
@@ -80,7 +80,7 @@ function parseCliCommands(): string[] {
 /** Parse OpenClaw commands as "module:subcommand" pairs */
 function parseOpenClawCommands(): string[] {
   const cmds: string[] = [];
-  for (const mod of ["admin", "allowance", "wallets", "tier", "projects", "image", "storage", "assets", "cache", "cdn", "functions", "secrets", "jobs", "sites", "subdomains", "domains", "apps", "email", "message", "agent", "ai", "auth", "sender-domain", "billing", "contracts", "webhooks", "service", "deploy", "ci", "transfer", "notifications", "webhook-secret"]) {
+  for (const mod of ["admin", "allowance", "wallets", "tier", "projects", "image", "storage", "assets", "cache", "cdn", "functions", "secrets", "jobs", "sites", "subdomains", "domains", "apps", "email", "message", "agent", "operator", "ai", "auth", "sender-domain", "billing", "contracts", "webhooks", "service", "deploy", "ci", "transfer", "notifications", "webhook-secret"]) {
     for (const sub of parseSubcommands(join(__dirname, "openclaw/scripts", `${mod}.mjs`))) {
       cmds.push(`${mod}:${sub}`);
     }
@@ -325,6 +325,16 @@ const SURFACE: Capability[] = [
   { id: "set_notification_preferences", endpoint: "PATCH /agent/v1/notifications/preferences",     mcp: "set_notification_preferences", cli: null,                            openclaw: null },
   { id: "test_notification",            endpoint: "POST /agent/v1/notifications/test",             mcp: "test_notification",            cli: "notifications:test",            openclaw: "notifications:test" },
   { id: "rotate_webhook_secret",        endpoint: "POST /agent/v1/webhook-secret/rotate",          mcp: "rotate_webhook_secret",        cli: "webhook-secret:rotate",         openclaw: "webhook-secret:rotate" },
+
+  // ── Operator session (human/email principal, RFC 8628 device-auth) ──────
+  // The operator is the human (email), distinct from the agent (wallet/SIWX).
+  // Human-only surface → MCP null by design (MCP authenticates as the agent;
+  // the human device-login must not hand the email-union session to the agent).
+  // The wallet's own account view is `run402 status`, not an operator command.
+  { id: "operator_login",    endpoint: "POST /agent/v1/operator/session/device (+ /device/token)", mcp: null, cli: "operator:login",    openclaw: "operator:login" },
+  { id: "operator_overview", endpoint: "GET /agent/v1/operator/overview (operator-session bearer)", mcp: null, cli: "operator:overview", openclaw: "operator:overview" },
+  { id: "operator_logout",   endpoint: "POST /agent/v1/operator/session/revoke",                   mcp: null, cli: "operator:logout",   openclaw: "operator:logout" },
+  { id: "operator_whoami",   endpoint: "(local)",                                                  mcp: null, cli: "operator:whoami",   openclaw: "operator:whoami" },
 
   // ── Additional billing ─────────────────────────────────────────────────
   { id: "create_checkout",   endpoint: "POST /billing/v1/checkouts",        mcp: "create_checkout",     cli: "allowance:checkout",  openclaw: "allowance:checkout" },
@@ -587,6 +597,14 @@ const SDK_BY_CAPABILITY: Record<string, string | null> = {
   test_notification: "admin.testNotification",
   rotate_webhook_secret: "admin.rotateWebhookSecret",
   start_operator_passkey_enrollment: "admin.startOperatorPasskeyEnrollment",
+
+  // Operator session (human/email, RFC 8628 device-auth). `operator login`
+  // brokers deviceStart + devicePoll; devicePoll has no dedicated capability
+  // (it shares the `login` verb) and is listed in SDK_ONLY_METHODS below.
+  operator_login: "operator.deviceStart",
+  operator_overview: "operator.overview",
+  operator_logout: "operator.revoke",
+  operator_whoami: null, // local-only cache read (core/operator-session.ts)
 
   // Admin (v1.57)
   admin_set_lease_perpetual: "admin.setLeasePerpetual",
@@ -910,6 +928,11 @@ describe("SDK surface alignment", () => {
       // shares the `run402 functions rebuild --all` CLI verb (and the
       // name-less `functions_rebuild` MCP tool), so it has no dedicated leaf command.
       "functions.rebuildAll",
+      // ─── operator session (human/email, RFC 8628) ────────────────────────
+      // `operator login` brokers the device flow via deviceStart + devicePoll;
+      // devicePoll shares the `login` verb (no dedicated capability), like the
+      // cache.invalidate* variants above.
+      "operator.devicePoll",
     ]);
 
     const sdkMethods = await listSdkMethods();


### PR DESCRIPTION
## Summary

Adds the **operator** noun — the human / email principal, distinct from the agent (wallet / SIWX). Browser-delegated device-authorization (RFC 8628, the `aws sso login` model) brokers an operator session that spans every wallet verifying the email, so `operator overview` returns the cross-wallet union. The wallet's own account view stays `run402 status`.

Implements the client side of kychee-com/run402#417.

## Surface

- **core** `operator-session.ts` — email-scoped session cache at the base config dir (0600, atomic writes, self-heal perms, structured validation) + 19 tests.
- **sdk** `r.operator` — `deviceStart` / `devicePoll` / `overview({token})` / `revoke({token})` + 9 tests. `devicePoll` returns the RFC 8628 states as data (not exceptions); `overview` sends the bearer with a SIWX fallback when no token.
- **cli** `operator login | logout | overview | whoami` + dispatch + help.
- **openclaw** re-export (CLI↔OpenClaw parity); **sync** SURFACE rows (MCP-null) + SDK mapping + `devicePoll` orphan exemption; **docs** `cli/llms-cli.txt`.

## Gating

The network paths (`login` / `overview` / `logout`) require the gateway device-auth bridge (**kychee-com/run402-private#443**) and will 404 until it ships; `whoami` works locally today. No MCP tools by design — MCP authenticates as the agent, and the human session must not be handed to it.

## Tests

Full suite green: unit 1266/1267 (1 gated skip — private `llms.txt` absent locally), CLI e2e 610/610.

Refs: kychee-com/run402#417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
