### PR TITLE
fix(admin): mirror gateway lease-perpetual route rename (SDK + MCP)

### DIFF
--- a/cli-e2e.test.mjs
+++ b/cli-e2e.test.mjs
@@ -190,7 +190,7 @@ async function mockFetch(input, init) {
   if (path.match(/^\/projects\/v1\/[^/]+$/) && method === "DELETE") {
     return Promise.resolve(noContent());
   }
-  if (path.match(/^\/billing-accounts\/v1\/admin\/[^/]+\/lease-perpetual$/) && method === "POST") {
+  if (path.match(/^\/billing\/v1\/admin\/accounts\/[^/]+\/lease-perpetual$/) && method === "POST") {
     const accountId = path.split("/").at(-2);
     const desired = Boolean(body?.lease_perpetual);
     return Promise.resolve(json({
@@ -1880,7 +1880,7 @@ describe("CLI e2e happy path", () => {
     const prevFetch = globalThis.fetch;
     globalThis.fetch = (input, init) => {
       const url = typeof input === "string" ? input : (input instanceof Request ? input.url : String(input));
-      if (url.includes("/billing-accounts/v1/admin/ba_external/lease-perpetual")) {
+      if (url.includes("/billing/v1/admin/accounts/ba_external/lease-perpetual")) {
         seenUrl = url;
         if (input instanceof Request) {
           seenMethod = input.method;
@@ -1905,7 +1905,7 @@ describe("CLI e2e happy path", () => {
       globalThis.fetch = prevFetch;
     }
     assert.ok(
-      seenUrl && seenUrl.includes("/billing-accounts/v1/admin/ba_external/lease-perpetual"),
+      seenUrl && seenUrl.includes("/billing/v1/admin/accounts/ba_external/lease-perpetual"),
       `lease-perpetual should hit the admin endpoint; got: ${seenUrl}`,
     );
     assert.equal(seenMethod, "POST");

--- a/sdk/src/namespaces/admin.test.ts
+++ b/sdk/src/namespaces/admin.test.ts
@@ -211,7 +211,7 @@ describe("admin.getProjectFinance", () => {
 });
 
 describe("admin.setLeasePerpetual (v1.57)", () => {
-  it("POSTs to /billing-accounts/v1/admin/:id/lease-perpetual with admin headers", async () => {
+  it("POSTs to /billing/v1/admin/accounts/:account_id/lease-perpetual with admin headers", async () => {
     const { fetch, calls } = mockFetch(() =>
       json({
         status: "ok",
@@ -226,7 +226,7 @@ describe("admin.setLeasePerpetual (v1.57)", () => {
     assert.equal(calls[0]!.method, "POST");
     assert.equal(
       calls[0]!.url,
-      "https://api.test/billing-accounts/v1/admin/ba_known/lease-perpetual",
+      "https://api.test/billing/v1/admin/accounts/ba_known/lease-perpetual",
     );
     assert.equal(calls[0]!.headers["X-Admin-Mode"], "1");
     assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "t");
@@ -253,7 +253,7 @@ describe("admin.setLeasePerpetual (v1.57)", () => {
     await sdk(fetch).admin.setLeasePerpetual("ba/has space", true);
     assert.equal(
       calls[0]!.url,
-      "https://api.test/billing-accounts/v1/admin/ba%2Fhas%20space/lease-perpetual",
+      "https://api.test/billing/v1/admin/accounts/ba%2Fhas%20space/lease-perpetual",
     );
   });
 });

--- a/sdk/src/namespaces/admin.ts
+++ b/sdk/src/namespaces/admin.ts
@@ -432,14 +432,14 @@ export class Admin {
    * `reactivated: true`.
    *
    * Platform-admin only. Calls
-   * `POST /billing-accounts/v1/admin/:id/lease-perpetual`.
+   * `POST /billing/v1/admin/accounts/:account_id/lease-perpetual`.
    */
   async setLeasePerpetual(
     billingAccountId: string,
     perpetual: boolean,
   ): Promise<SetLeasePerpetualResult> {
     return this.client.request<SetLeasePerpetualResult>(
-      `/billing-accounts/v1/admin/${encodeURIComponent(billingAccountId)}/lease-perpetual`,
+      `/billing/v1/admin/accounts/${encodeURIComponent(billingAccountId)}/lease-perpetual`,
       {
         method: "POST",
         headers: { "X-Admin-Mode": "1" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -687,7 +687,7 @@ server.tool(
 
 server.tool(
   "admin_set_lease_perpetual",
-  "Toggle a billing account's `lease_perpetual` escape hatch (v1.57+). When `lease_perpetual: true`, the account never advances past `active` regardless of lease expiry; every project on the account inherits the pinned state. Enabling on a grace-state account (past_due / frozen / dormant) reactivates inline and returns `reactivated: true`. Platform-admin only — uses the configured allowance wallet for admin auth. Replaces the v1.56 `pin_project` (gateway endpoint /projects/v1/admin/:id/pin was removed in v1.57). Calls POST /billing-accounts/v1/admin/:id/lease-perpetual.",
+  "Toggle a billing account's `lease_perpetual` escape hatch (v1.57+). When `lease_perpetual: true`, the account never advances past `active` regardless of lease expiry; every project on the account inherits the pinned state. Enabling on a grace-state account (past_due / frozen / dormant) reactivates inline and returns `reactivated: true`. Platform-admin only — uses the configured allowance wallet for admin auth. Replaces the v1.56 `pin_project` (gateway endpoint /projects/v1/admin/:id/pin was removed in v1.57). Calls POST /billing/v1/admin/accounts/:account_id/lease-perpetual.",
   adminSetLeasePerpetualSchema,
   async (args) => handleAdminSetLeasePerpetual(args),
 );

--- a/sync.test.ts
+++ b/sync.test.ts
@@ -371,7 +371,7 @@ const SURFACE: Capability[] = [
   // v1.57: pin/unpin endpoints removed. Per-project pin is superseded by the
   // account-level escape hatch (admin_set_lease_perpetual). archive and
   // reactivate are operator moderation actions, scoped to a single project.
-  { id: "admin_set_lease_perpetual", endpoint: "POST /billing-accounts/v1/admin/:id/lease-perpetual", mcp: "admin_set_lease_perpetual", cli: "admin:lease-perpetual", openclaw: "admin:lease-perpetual" },
+  { id: "admin_set_lease_perpetual", endpoint: "POST /billing/v1/admin/accounts/:account_id/lease-perpetual", mcp: "admin_set_lease_perpetual", cli: "admin:lease-perpetual", openclaw: "admin:lease-perpetual" },
   { id: "admin_archive_project",     endpoint: "POST /projects/v1/admin/:id/archive",                 mcp: "admin_archive_project",     cli: "admin:archive",          openclaw: "admin:archive" },
   { id: "admin_reactivate_project",  endpoint: "POST /projects/v1/admin/:id/reactivate",              mcp: "admin_reactivate_project",  cli: "admin:reactivate",       openclaw: "admin:reactivate" },
   { id: "promote_user",    endpoint: "POST /projects/v1/admin/:id/promote-user", mcp: "promote_user", cli: "projects:promote-user", openclaw: "projects:promote-user" },


### PR DESCRIPTION
Batch 1 / piece 1 of the pre-launch API-consistency cleanup (#430).

The one-route `/billing-accounts/v1/*` namespace is retired; the `lease-perpetual` toggle joins the `/billing/v1/admin/accounts/*` family next to credit/debit/set-tier:

| Old | New |
|---|---|
| `POST /billing-accounts/v1/admin/:id/lease-perpetual` | `POST /billing/v1/admin/accounts/:account_id/lease-perpetual` |

### What changed
- `sdk/src/namespaces/admin.ts` — `setLeasePerpetual()` request path (the only place that builds the URL) + doc comment
- `src/index.ts` — MCP `admin_set_lease_perpetual` tool description ("Calls POST …")
- `sdk/src/namespaces/admin.test.ts`, `cli-e2e.test.mjs`, `sync.test.ts` — cross-surface URL/registry assertions (registry param adopts the new `:account_id` convention)

The CLI and OpenClaw commands are thin shims over the SDK and reference only the command name (`run402 admin lease-perpetual`, unchanged), so they needed no edits.

### Out of scope
Piece 2 (admin `credit`/`debit`/`set-tier` keyed by `:account_id`) has **no published-client surface in this repo** — those are gateway-internal admin routes, so there is nothing to mirror here. Pieces 3–5 are pending gateway design.

### Verification
Full suite green locally (`npm test`: 1277 + 619 tests, 0 failures; doc-snippet check 43 snippets). `git grep billing-accounts` is clean across source.

> ⚠️ Coordination: per #430, the gateway rename must not deploy until this is merged + published, else published clients calling the old path 404.

Refs #430