### PR TITLE
fix(billing): address accounts by :account_id; harden /wallets/:address/projects auth

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -722,7 +722,7 @@ The MCP server manages a local agent allowance — a wallet key dedicated to pay
 - **`init`** — composes `allowance_create` + `request_faucet` + `tier_status` + `list_projects`. Use this on a fresh install.
 - **`allowance_create`** / **`allowance_status`** / **`allowance_export`** — granular allowance ops.
 - **`request_faucet`** — Base Sepolia testnet USDC.
-- **`check_balance`** — mainnet + testnet + billing balance for an address.
+- **`check_balance`** — run402 billing account balance (available + held) for the agent's wallet; resolves the wallet to its account over SIWX.
 
 Other allowance options:
 - **Coinbase AgentKit** — MPC wallet on Base with built-in x402.

--- a/cli-e2e.test.mjs
+++ b/cli-e2e.test.mjs
@@ -688,8 +688,22 @@ async function mockFetch(input, init) {
   }
 
   // Billing
+  // Account lookup: GET /billing/v1/accounts?wallet=|?email= → resolve to a
+  // billing_account_id (and return the same detail shape as the by-id read).
+  if (pathNoQuery === "/billing/v1/accounts" && method === "GET") {
+    return Promise.resolve(json({
+      billing_account_id: "00000000-0000-4000-8000-0000000000e2",
+      available_usd_micros: 150000,
+      held_usd_micros: 0,
+      email_credits_remaining: 0,
+      tier: null,
+      lease_expires_at: null,
+      auto_recharge_enabled: false,
+      auto_recharge_threshold: 0,
+    }));
+  }
   if (path.match(/^\/billing\/v1\/accounts\/[^/]+$/) && method === "GET") {
-    return Promise.resolve(json({ available_usd_micros: 150000, held_usd_micros: 0 }));
+    return Promise.resolve(json({ billing_account_id: "00000000-0000-4000-8000-0000000000e2", available_usd_micros: 150000, held_usd_micros: 0 }));
   }
   if (path.match(/\/history/) && method === "GET") {
     return Promise.resolve(json({ transactions: [{ id: "tx1", amount: -100000, description: "Tier subscription" }] }));

--- a/cli/lib/billing.mjs
+++ b/cli/lib/billing.mjs
@@ -13,8 +13,8 @@ Subcommands:
   tier-checkout <tier> [--email <e> | --wallet <w>]    Stripe tier checkout
   buy-email-pack [--email <e> | --wallet <w>]  Buy \$5 email pack (10,000 emails)
   auto-recharge <account_id> <on|off> [--threshold <n>]
-  balance <identifier>                     Balance by email or wallet (0x...)
-  history <identifier> [--limit <n>]       Ledger history by email or wallet
+  balance <identifier>                     Balance by account id (UUID), wallet (0x...), or email
+  history <identifier> [--limit <n>]       Ledger history by account id (UUID), wallet, or email
 
 Examples:
   run402 billing create-email user@example.com
@@ -70,32 +70,44 @@ Examples:
   run402 billing auto-recharge acct_abc on --threshold 2000
   run402 billing auto-recharge acct_abc off
 `,
-  history: `run402 billing history — Show ledger history for an email or wallet
+  history: `run402 billing history — Show ledger history for a billing account
 
 Usage:
   run402 billing history <identifier> [--limit <n>]
 
 Arguments:
-  <identifier>        Email address or wallet (0x...)
+  <identifier>        Billing account id (UUID), wallet (0x...), or email.
+                      Wallet/email are resolved to the account id first.
 
 Options:
   --limit <n>         Max entries to return (default: 50)
 
+Auth:
+  Requires SIWX from a wallet linked to the account (signed automatically from
+  the local allowance), or an admin key. Email lookups require an admin key.
+
 Examples:
   run402 billing history user@example.com
   run402 billing history 0x1234... --limit 100
+  run402 billing history 00000000-0000-4000-8000-000000000001
 `,
-  balance: `run402 billing balance — Show balance for an email or wallet
+  balance: `run402 billing balance — Show balance for a billing account
 
 Usage:
   run402 billing balance <identifier>
 
 Arguments:
-  <identifier>        Email address or wallet (0x...)
+  <identifier>        Billing account id (UUID), wallet (0x...), or email.
+                      Wallet/email are resolved via the accounts lookup.
+
+Auth:
+  Requires SIWX from a wallet linked to the account (signed automatically from
+  the local allowance), or an admin key. Email lookups require an admin key.
 
 Examples:
   run402 billing balance user@example.com
   run402 billing balance 0x1234abcd...
+  run402 billing balance 00000000-0000-4000-8000-000000000001
 `,
   "create-email": `run402 billing create-email — Create an email billing account
 
@@ -292,8 +304,8 @@ async function balance(args) {
   if (!id) {
     fail({
       code: "BAD_USAGE",
-      message: "Missing <email-or-wallet>.",
-      hint: "run402 billing balance <email-or-wallet>",
+      message: "Missing <identifier>.",
+      hint: "run402 billing balance <account-id | wallet | email>",
     });
   }
   try {
@@ -316,8 +328,8 @@ async function history(args) {
   if (!id) {
     fail({
       code: "BAD_USAGE",
-      message: "Missing <email-or-wallet>.",
-      hint: "run402 billing history <email-or-wallet> [--limit <n>]",
+      message: "Missing <identifier>.",
+      hint: "run402 billing history <account-id | wallet | email> [--limit <n>]",
     });
   }
   const limit = parsedArgs.includes("--limit")

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -1342,10 +1342,10 @@ Email-based billing accounts, Stripe tier checkout, and email packs. Pay run402 
 - `run402 billing tier-checkout <tier> [--email <e> | --wallet <w>]` — subscribe/renew/upgrade a tier (prototype $0.10 / hobby $5 / team $20) via Stripe. Returns a checkout URL.
 - `run402 billing buy-email-pack [--email <e> | --wallet <w>]` — buy a $5 email pack (10,000 emails, never expire). Returns a Stripe checkout URL.
 - `run402 billing auto-recharge <account_id> <on|off> [--threshold <n>]` — auto-repurchase $5 packs when credits drop below threshold. Requires saved Stripe payment method.
-- `run402 billing balance <email-or-wallet>` — balance + email_credits_remaining + tier + lease + auto_recharge state
-- `run402 billing history <email-or-wallet> [--limit <n>]` — ledger history (both identifier types supported)
+- `run402 billing balance <account-id | wallet | email>` — balance + email_credits_remaining + tier + lease + auto_recharge state (response includes `billing_account_id`). A wallet/email is resolved to its account via `GET /billing/v1/accounts?wallet=|?email=`; an account id (UUID) reads `GET /billing/v1/accounts/:account_id` directly.
+- `run402 billing history <account-id | wallet | email> [--limit <n>]` — ledger history. Keyed by account id: a wallet/email is resolved to its `billing_account_id` first, then `GET /billing/v1/accounts/:account_id/history`.
 
-Auth (v2.19.1+): `balance`, `history`, `link-wallet`, and `auto-recharge` require SIWX signed by the relevant wallet (the path wallet for reads, the body wallet for link, a linked wallet for auto-recharge). The CLI signs automatically from the local allowance, so these only work when the agent's allowance wallet is the one being queried/linked/billed. Email-identifier reads require an admin key. Checkout-creation commands (`create-email`, `tier-checkout`, `buy-email-pack`) remain unauthenticated.
+Auth: account reads (`balance`, `history`) require SIWX from a wallet **linked to** the account (membership), or an admin key; the wallet→account lookup requires SIWX matching the queried wallet (email lookups are admin-only). `link-wallet` requires the body wallet's SIWX (or admin); `auto-recharge` a linked wallet's SIWX. The CLI signs automatically from the local allowance, so these only work when the agent's allowance wallet is on the account being queried/linked/billed. A non-member (or someone guessing an account id) gets 403 with no existence leak. Checkout-creation commands (`create-email`, `tier-checkout`, `buy-email-pack`) remain unauthenticated.
 
 Email packs only activate when the tier daily limit is exhausted AND the project has a verified custom sender domain (spam protection for `mail.run402.com`).
 

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -846,8 +846,8 @@ run402 billing link-wallet <account_id> <wallet>   # response includes pool_impl
 run402 billing tier-checkout hobby --email user@example.com
 run402 billing buy-email-pack       --email user@example.com   # $5 / 10k emails (never expire)
 run402 billing auto-recharge <account_id> on --threshold 2000
-run402 billing balance <email-or-wallet>
-run402 billing history <email-or-wallet>
+run402 billing balance <account-id | wallet | email>   # wallet/email resolved to the account; SIWX must be linked to it (email lookups admin-only)
+run402 billing history <account-id | wallet | email>
 ```
 
 `run402 tier set` refetches `/tiers/v1/status` after the call and includes the refreshed account-pool snapshot as `status_after` in the JSON output, so the new pooled `api_calls` / `storage_bytes` totals come back in one step.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -75,7 +75,7 @@ The `CredentialsProvider` interface has two required methods (`getAuth`, `getPro
 | `auth` | `requestMagicLink`, `verifyMagicLink`, `createUser`, `inviteUser`, `setUserPassword`, `settings`, passkey registration/login/list/delete helpers, `providers`, `promote`, `demote` |
 | `apps` | `browse`, `getApp`, `fork`, `publish`, `listVersions`, `updateVersion`, `deleteVersion` |
 | `tier` | `set`, `status` (tier pricing lives on `r.projects.getQuote()`) |
-| `billing` | `createEmailAccount`, `linkWallet`, `tierCheckout`, `buyEmailPack`, `setAutoRecharge`, `checkBalance`, `getAccount`, `getHistory`, `balance`, `history`, `createCheckout` |
+| `billing` | `createEmailAccount`, `linkWallet`, `tierCheckout`, `buyEmailPack`, `setAutoRecharge`, `checkBalance`, `getAccount`, `lookupAccount`, `getHistory`, `balance`, `history`, `createCheckout` |
 | `contracts` | `provisionWallet`, `getWallet`, `listWallets`, `setRecovery`, `setLowBalanceAlert`, `call`, `read`, `callStatus`, `drain`, `deleteWallet` |
 | `ai` | `translate`, `moderate`, `usage`, `generateImage` |
 | `allowance` | `status`, `create`, `export`, `faucet` |

--- a/sdk/llms-sdk.txt
+++ b/sdk/llms-sdk.txt
@@ -632,7 +632,7 @@ demoteUser(id, email): Promise<void>
 - `lease_perpetual: boolean | null` — operator escape hatch flag. When `true`, the account never advances past `active` regardless of lease expiry.
 - `tier: "prototype" | "hobby" | "team" | null` — the account's active tier.
 
-`r.projects.list(wallet)` returns per-project facts only (`id`, `name`, `api_calls`, `storage_bytes`, `created_at`). The v1.56 `status` / `pinned` / `tier` mirrors and the v1.57 `effective_status` / `account_lifecycle_state` / `lease_perpetual` per-project mirrors were dropped. The v1.56 `projects.pin(id)` SDK method was removed alongside the endpoint — use `r.admin.setLeasePerpetual(ba_id, true)`.
+`r.projects.list(wallet)` returns per-project facts only (`id`, `name`, `api_calls`, `storage_bytes`, `created_at`). It now requires SIWX from the wallet itself (or an admin key) — `GET /wallets/v1/:wallet/projects` was hardened from public to owner-only, since project ids/names/usage are private; the kernel signs the header from the provider, and listing another wallet's projects returns 403. The v1.56 `status` / `pinned` / `tier` mirrors and the v1.57 `effective_status` / `account_lifecycle_state` / `lease_perpetual` per-project mirrors were dropped. The v1.56 `projects.pin(id)` SDK method was removed alongside the endpoint — use `r.admin.setLeasePerpetual(ba_id, true)`.
 
 `r.projects.getUsage(id)` still surfaces `effective_status` and `account_lifecycle_state` because that endpoint scopes to a single project and the derivation collapses per-project `archived_at` / `deleted_at` together with the account's lifecycle.
 
@@ -1159,13 +1159,14 @@ gateways.
 
 ```
 createEmailAccount(email): Promise<EmailBillingAccount>
-linkWallet(billingAccountId, wallet): Promise<LinkWalletResult>
+linkWallet(billingAccountId, wallet): Promise<LinkWalletResult>  // billingAccountId = UUID; POST /billing/v1/accounts/:account_id/link-wallet
 tierCheckout(tier, identifier: { email?: string, wallet?: string }): Promise<CreateCheckoutResult>
 buyEmailPack(identifier: { email?: string, wallet?: string }): Promise<CreateCheckoutResult>
 setAutoRecharge(opts: { billingAccountId: string, enabled: boolean, threshold? }): Promise<void>
-checkBalance(identifier): Promise<BillingBalance>
-getAccount(identifier): Promise<BillingBalance>
-balance(identifier): Promise<BillingBalance> // alias of checkBalance
+checkBalance(identifier): Promise<BillingAccountDetail>  // identifier = account id (UUID) | wallet | email
+getAccount(identifier): Promise<BillingAccountDetail>
+lookupAccount(identifier): Promise<BillingAccountDetail>  // resolve wallet/email → account (incl. billing_account_id)
+balance(identifier): Promise<BillingAccountDetail> // alias of checkBalance
 history(identifier, limit?: number): Promise<BillingHistoryResult>
 getHistory(identifier, limit?: number): Promise<BillingHistoryResult>
 createCheckout(wallet, amountUsdMicros: number): Promise<CreateCheckoutResult>
@@ -1174,6 +1175,17 @@ createCheckout(wallet, amountUsdMicros: number): Promise<CreateCheckoutResult>
 createEmail(email): Promise<EmailBillingAccount>
 autoRecharge(opts): Promise<void>
 ```
+
+Accounts are addressed by their canonical `billing_account_id` (UUID).
+`getAccount` / `checkBalance` / `history` accept an account id, wallet, or email:
+an account id reads `GET /billing/v1/accounts/:account_id` directly, while a
+wallet/email is resolved through the `GET /billing/v1/accounts?wallet=|?email=`
+lookup (also exposed as `lookupAccount`). The detail shape dropped
+`identifier_type` and added `billing_account_id`; `BillingBalance` is a
+deprecated alias of `BillingAccountDetail`. Account reads require SIWX from a
+wallet **linked to** the account (or matching the looked-up `?wallet`), or an
+admin key — email lookups are admin-only; `history` resolves to the account id
+first, then reads `GET /billing/v1/accounts/:account_id/history`.
 
 `linkWallet` merges a wallet into an existing billing account's pool. On v1.46+
 gateways the response includes a `pool_implications` block (`tier`,

--- a/sdk/src/namespaces/billing.test.ts
+++ b/sdk/src/namespaces/billing.test.ts
@@ -66,29 +66,47 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 const WALLET_UPPER = "0xABCDEF0123456789ABCDEF0123456789ABCDEF01";
 const WALLET_LOWER = "0xabcdef0123456789abcdef0123456789abcdef01";
+const ACCOUNT_ID = "00000000-0000-4000-8000-000000000001";
 
-describe("billing.checkBalance", () => {
-  it("GETs /billing/v1/accounts/:wallet without auth and returns the runtime shape", async () => {
-    const { fetch, calls } = mockFetch(() =>
-      jsonResponse({
-        available_usd_micros: 0,
-        email_credits_remaining: 0,
-        tier: "prototype",
-        lease_expires_at: "2026-05-07T14:49:10.884Z",
-        auto_recharge_enabled: false,
-        auto_recharge_threshold: 2000,
-        identifier_type: "wallet",
-      }),
-    );
+/** The canonical account-detail projection the gateway returns (accountDetailJson). */
+function accountDetail(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    billing_account_id: ACCOUNT_ID,
+    available_usd_micros: 0,
+    email_credits_remaining: 0,
+    tier: "prototype",
+    lease_expires_at: "2026-05-07T14:49:10.884Z",
+    auto_recharge_enabled: false,
+    auto_recharge_threshold: 2000,
+    ...overrides,
+  };
+}
+
+/**
+ * Mock for history flows: a wallet/email identifier first hits the
+ * `?wallet=`/`?email=` lookup (→ account detail), then `/history` (→ the
+ * ledger envelope). An account-id identifier skips straight to `/history`.
+ */
+function historyMock(entries: unknown[] = []) {
+  return mockFetch((call) =>
+    call.url.includes("/history")
+      ? jsonResponse({ billing_account_id: ACCOUNT_ID, entries })
+      : jsonResponse(accountDetail()),
+  );
+}
+
+describe("billing.checkBalance / getAccount", () => {
+  it("resolves a wallet through the ?wallet= lookup, sends SIWX, and returns the detail", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse(accountDetail()));
     const sdk = makeSdk(fetch);
     const result = await sdk.billing.checkBalance(WALLET_UPPER);
 
     assert.equal(calls.length, 1);
-    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${WALLET_LOWER}`);
+    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts?wallet=${WALLET_LOWER}`);
     assert.equal(calls[0]!.method, "GET");
     assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");
 
-    assert.equal(result.identifier_type, "wallet");
+    assert.equal(result.billing_account_id, ACCOUNT_ID);
     assert.equal(result.available_usd_micros, 0);
     assert.equal(result.email_credits_remaining, 0);
     assert.equal(result.tier, "prototype");
@@ -97,43 +115,36 @@ describe("billing.checkBalance", () => {
     assert.equal(result.auto_recharge_threshold, 2000);
   });
 
-  it("preserves null tier and lease_expires_at for unleased accounts", async () => {
+  it("resolves an email through the ?email= lookup and preserves null tier/lease", async () => {
     const { fetch, calls } = mockFetch(() =>
-      jsonResponse({
-        available_usd_micros: 1000000,
-        email_credits_remaining: 0,
-        tier: null,
-        lease_expires_at: null,
-        auto_recharge_enabled: false,
-        auto_recharge_threshold: 0,
-        identifier_type: "email",
-      }),
+      jsonResponse(accountDetail({ available_usd_micros: 1000000, tier: null, lease_expires_at: null, auto_recharge_threshold: 0 })),
     );
     const sdk = makeSdk(fetch);
-    const result = await sdk.billing.checkBalance("user@example.com");
+    const result = await sdk.billing.getAccount("user@example.com");
 
-    assert.equal(calls[0]!.url, "https://api.example.test/billing/v1/accounts/user%40example.com");
+    assert.equal(calls[0]!.url, "https://api.example.test/billing/v1/accounts?email=user%40example.com");
     assert.equal(result.tier, null);
     assert.equal(result.lease_expires_at, null);
-    assert.equal(result.identifier_type, "email");
+    assert.equal(result.billing_account_id, ACCOUNT_ID);
   });
 
-  it("offers getAccount as a generic identifier alias", async () => {
-    const { fetch, calls } = mockFetch(() =>
-      jsonResponse({
-        available_usd_micros: 1000000,
-        email_credits_remaining: 0,
-        tier: null,
-        lease_expires_at: null,
-        auto_recharge_enabled: false,
-        auto_recharge_threshold: 0,
-        identifier_type: "email",
-      }),
-    );
+  it("reads an account id (UUID) directly without a lookup", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse(accountDetail()));
+    const sdk = makeSdk(fetch);
+    await sdk.billing.getAccount(ACCOUNT_ID);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${ACCOUNT_ID}`);
+    assert.equal(calls[0]!.method, "GET");
+    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");
+  });
+
+  it("URL-encodes email identifiers with reserved characters", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse(accountDetail()));
     const sdk = makeSdk(fetch);
     await sdk.billing.getAccount("billing+team@example.com");
 
-    assert.equal(calls[0]!.url, "https://api.example.test/billing/v1/accounts/billing%2Bteam%40example.com");
+    assert.equal(calls[0]!.url, "https://api.example.test/billing/v1/accounts?email=billing%2Bteam%40example.com");
   });
 
   it("rejects malformed balance identifiers before requesting", async () => {
@@ -156,38 +167,79 @@ describe("billing.checkBalance", () => {
   });
 });
 
-describe("billing.history", () => {
-  it("GETs /billing/v1/accounts/:wallet/history and returns identifier-keyed envelope", async () => {
-    const { fetch, calls } = mockFetch(() =>
-      jsonResponse({
-        identifier: WALLET_LOWER,
-        identifier_type: "wallet",
-        entries: [
-          {
-            id: "ent_1",
-            direction: "credit",
-            kind: "stripe_topup",
-            amount_usd_micros: 5000000,
-            balance_after_available: 5000000,
-            balance_after_held: 0,
-            reference_type: "stripe_session",
-            reference_id: "cs_test_123",
-            metadata: { source: "checkout" },
-            created_at: "2026-04-30T10:00:00.000Z",
-          },
-        ],
-      }),
+describe("billing.lookupAccount", () => {
+  it("resolves a wallet to its account via ?wallet=", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse(accountDetail()));
+    const sdk = makeSdk(fetch);
+    const result = await sdk.billing.lookupAccount(WALLET_UPPER);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts?wallet=${WALLET_LOWER}`);
+    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");
+    assert.equal(result.billing_account_id, ACCOUNT_ID);
+  });
+
+  it("resolves an email to its account via ?email=", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse(accountDetail()));
+    const sdk = makeSdk(fetch);
+    await sdk.billing.lookupAccount("user@example.com");
+
+    assert.equal(calls[0]!.url, "https://api.example.test/billing/v1/accounts?email=user%40example.com");
+  });
+
+  it("reads an account id (UUID) directly", async () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse(accountDetail()));
+    const sdk = makeSdk(fetch);
+    await sdk.billing.lookupAccount(ACCOUNT_ID);
+
+    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${ACCOUNT_ID}`);
+  });
+
+  it("rejects malformed identifiers before requesting", async () => {
+    const { fetch, calls } = mockFetch(() => {
+      throw new Error("unexpected fetch for malformed lookup identifier");
+    });
+    const sdk = makeSdk(fetch);
+
+    await assert.rejects(
+      sdk.billing.lookupAccount("nonsense" as any),
+      (err: unknown) =>
+        err instanceof LocalError &&
+        err.context === "looking up billing account",
     );
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("billing.history / getHistory", () => {
+  it("resolves a wallet to its account id, then reads history by id with SIWX on both", async () => {
+    const { fetch, calls } = historyMock([
+      {
+        id: "ent_1",
+        direction: "credit",
+        kind: "stripe_topup",
+        amount_usd_micros: 5000000,
+        balance_after_available: 5000000,
+        balance_after_held: 0,
+        reference_type: "stripe_session",
+        reference_id: "cs_test_123",
+        metadata: { source: "checkout" },
+        created_at: "2026-04-30T10:00:00.000Z",
+      },
+    ]);
     const sdk = makeSdk(fetch);
     const result = await sdk.billing.history(WALLET_UPPER);
 
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${WALLET_LOWER}/history`);
-    assert.equal(calls[0]!.method, "GET");
+    assert.equal(calls.length, 2);
+    // 1) lookup wallet → billing_account_id
+    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts?wallet=${WALLET_LOWER}`);
     assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");
+    // 2) history keyed by the resolved account id
+    assert.equal(calls[1]!.url, `https://api.example.test/billing/v1/accounts/${ACCOUNT_ID}/history`);
+    assert.equal(calls[1]!.method, "GET");
+    assert.equal(calls[1]!.headers["SIGN-IN-WITH-X"], "test-siwx");
 
-    assert.equal(result.identifier, WALLET_LOWER);
-    assert.equal(result.identifier_type, "wallet");
+    assert.equal(result.billing_account_id, ACCOUNT_ID);
     assert.equal(result.entries.length, 1);
 
     const entry = result.entries[0]!;
@@ -203,24 +255,29 @@ describe("billing.history", () => {
     assert.equal(entry.created_at, "2026-04-30T10:00:00.000Z");
   });
 
-  it("appends ?limit=N when limit is provided", async () => {
-    const { fetch, calls } = mockFetch(() =>
-      jsonResponse({ identifier: WALLET_LOWER, identifier_type: "wallet", entries: [] }),
-    );
+  it("reads history by account id (UUID) in a single request", async () => {
+    const { fetch, calls } = historyMock([]);
+    const sdk = makeSdk(fetch);
+    await sdk.billing.getHistory(ACCOUNT_ID);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${ACCOUNT_ID}/history`);
+  });
+
+  it("appends ?limit=N on the history request (wallet flow)", async () => {
+    const { fetch, calls } = historyMock([]);
     const sdk = makeSdk(fetch);
     await sdk.billing.history(WALLET_UPPER, 50);
 
-    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${WALLET_LOWER}/history?limit=50`);
+    assert.equal(calls[1]!.url, `https://api.example.test/billing/v1/accounts/${ACCOUNT_ID}/history?limit=50`);
   });
 
-  it("appends ?limit=1 when the minimum valid limit is provided", async () => {
-    const { fetch, calls } = mockFetch(() =>
-      jsonResponse({ identifier: WALLET_LOWER, identifier_type: "wallet", entries: [] }),
-    );
+  it("appends ?limit=1 on the by-id history request", async () => {
+    const { fetch, calls } = historyMock([]);
     const sdk = makeSdk(fetch);
-    await sdk.billing.history(WALLET_UPPER, 1);
+    await sdk.billing.getHistory(ACCOUNT_ID, 1);
 
-    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${WALLET_LOWER}/history?limit=1`);
+    assert.equal(calls[0]!.url, `https://api.example.test/billing/v1/accounts/${ACCOUNT_ID}/history?limit=1`);
   });
 
   it("throws LocalError and does not request for invalid limits", async () => {
@@ -243,39 +300,32 @@ describe("billing.history", () => {
     }
   });
 
-  it("offers getHistory as a generic identifier alias", async () => {
-    const { fetch, calls } = mockFetch(() =>
-      jsonResponse({ identifier: "user@example.com", identifier_type: "email", entries: [] }),
-    );
+  it("offers getHistory as a generic identifier alias (email flow)", async () => {
+    const { fetch, calls } = historyMock([]);
     const sdk = makeSdk(fetch);
     await sdk.billing.getHistory("user@example.com", 25);
 
-    assert.equal(calls[0]!.url, "https://api.example.test/billing/v1/accounts/user%40example.com/history?limit=25");
+    assert.equal(calls[0]!.url, "https://api.example.test/billing/v1/accounts?email=user%40example.com");
+    assert.equal(calls[1]!.url, `https://api.example.test/billing/v1/accounts/${ACCOUNT_ID}/history?limit=25`);
   });
 
   it("preserves null reference_type and reference_id for entries without references", async () => {
-    const { fetch } = mockFetch(() =>
-      jsonResponse({
-        identifier: WALLET_LOWER,
-        identifier_type: "wallet",
-        entries: [
-          {
-            id: "ent_2",
-            direction: "debit",
-            kind: "api_call",
-            amount_usd_micros: 100,
-            balance_after_available: 999900,
-            balance_after_held: 0,
-            reference_type: null,
-            reference_id: null,
-            metadata: {},
-            created_at: "2026-04-30T10:01:00.000Z",
-          },
-        ],
-      }),
-    );
+    const { fetch } = historyMock([
+      {
+        id: "ent_2",
+        direction: "debit",
+        kind: "api_call",
+        amount_usd_micros: 100,
+        balance_after_available: 999900,
+        balance_after_held: 0,
+        reference_type: null,
+        reference_id: null,
+        metadata: {},
+        created_at: "2026-04-30T10:01:00.000Z",
+      },
+    ]);
     const sdk = makeSdk(fetch);
-    const result = await sdk.billing.history(WALLET_UPPER);
+    const result = await sdk.billing.getHistory(ACCOUNT_ID);
 
     const entry = result.entries[0]!;
     assert.equal(entry.reference_type, null);

--- a/sdk/src/namespaces/billing.ts
+++ b/sdk/src/namespaces/billing.ts
@@ -1,8 +1,14 @@
 /**
- * `billing` namespace — wallet-scoped billing accounts and Stripe checkouts.
- * Identifies accounts by wallet address or email. Reads of an existing account
- * and mutations such as link-wallet / auto-recharge require SIWX (or an admin
- * key); checkout-creation endpoints remain unauthenticated by design.
+ * `billing` namespace — billing accounts and Stripe checkouts.
+ *
+ * Accounts are addressed by their canonical `billing_account_id` (UUID). A
+ * wallet or email is resolved to that id through the
+ * `GET /billing/v1/accounts?wallet=|?email=` lookup; `getAccount` / `history`
+ * accept any of the three identifier forms and resolve internally. Account
+ * reads require SIWX from a wallet linked to the account (or matching the
+ * looked-up `?wallet`), or an admin key; email lookups are admin-only.
+ * Mutations such as link-wallet / auto-recharge require SIWX (or admin);
+ * checkout-creation endpoints remain unauthenticated by design.
  */
 
 import type { Client } from "../kernel.js";
@@ -16,8 +22,9 @@ import {
 } from "../validation.js";
 import type { ProjectTier } from "./projects.types.js";
 
-export interface BillingBalance {
-  identifier_type: "wallet" | "email";
+export interface BillingAccountDetail {
+  /** Canonical billing account id (UUID). */
+  billing_account_id: string;
   available_usd_micros: number;
   /** Held/reserved portion of the balance; absent on gateways that predate the field. */
   held_usd_micros?: number;
@@ -27,6 +34,13 @@ export interface BillingBalance {
   auto_recharge_enabled: boolean;
   auto_recharge_threshold: number;
 }
+
+/**
+ * @deprecated Renamed to {@link BillingAccountDetail}. The account read now
+ * returns the canonical `billing_account_id` and no longer carries
+ * `identifier_type` (accounts are addressed by id, not by wallet/email).
+ */
+export type BillingBalance = BillingAccountDetail;
 
 export interface BillingHistoryEntry {
   id: string;
@@ -42,8 +56,8 @@ export interface BillingHistoryEntry {
 }
 
 export interface BillingHistoryResult {
-  identifier: string;
-  identifier_type: "wallet" | "email";
+  /** Canonical billing account id (UUID) the entries belong to. */
+  billing_account_id: string;
   entries: BillingHistoryEntry[];
 }
 
@@ -99,25 +113,80 @@ export interface AutoRechargeOptions {
 
 const BILLING_TIERS = ["prototype", "hobby", "team"] as const;
 
-function encodeBillingIdentifier(
-  identifier: BillingAccountIdentifier,
-  context: string,
-): string {
-  const normalized = normalizeBillingIdentifier(identifier, context);
-  return encodeURIComponent(normalized);
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type BillingIdentifierKind = "account_id" | "wallet" | "email";
+
+interface ClassifiedBillingIdentifier {
+  kind: BillingIdentifierKind;
+  value: string;
 }
 
-function normalizeBillingIdentifier(
+/**
+ * Classify a billing identifier as a canonical account id (UUID), an EVM
+ * wallet address, or an email. Wallets are lowercased; account ids and emails
+ * are returned verbatim. Throws {@link LocalError} for anything else.
+ */
+function classifyBillingIdentifier(
   identifier: unknown,
   context: string,
-): string {
+): ClassifiedBillingIdentifier {
   assertNonEmptyString(identifier, "identifier", context);
+  if (UUID_RE.test(identifier)) {
+    return { kind: "account_id", value: identifier };
+  }
   if (/^0x/i.test(identifier)) {
     assertEvmAddress(identifier, "identifier", context);
-    return identifier.toLowerCase();
+    return { kind: "wallet", value: identifier.toLowerCase() };
   }
   assertEmailAddress(identifier, "identifier", context);
-  return identifier;
+  return { kind: "email", value: identifier };
+}
+
+/** Read account detail by canonical id: `GET /billing/v1/accounts/:account_id`. */
+function fetchAccountById(
+  client: Client,
+  accountId: string,
+  context: string,
+): Promise<BillingAccountDetail> {
+  return client.request<BillingAccountDetail>(
+    `/billing/v1/accounts/${encodeURIComponent(accountId)}`,
+    { context },
+  );
+}
+
+/**
+ * Resolve a wallet / email to its account detail via the lookup endpoint
+ * `GET /billing/v1/accounts?wallet=|?email=`. The lookup returns the same
+ * detail shape as the by-id read, including the resolved `billing_account_id`.
+ */
+function fetchAccountByLookup(
+  client: Client,
+  kind: "wallet" | "email",
+  value: string,
+  context: string,
+): Promise<BillingAccountDetail> {
+  return client.request<BillingAccountDetail>(
+    `/billing/v1/accounts?${kind}=${encodeURIComponent(value)}`,
+    { context },
+  );
+}
+
+/**
+ * Resolve any identifier form (account id / wallet / email) to the account
+ * detail. Account ids hit the canonical by-id read; wallet/email go through
+ * the `?wallet=`/`?email=` lookup. All paths send SIWX via the kernel default.
+ */
+async function resolveAccountDetail(
+  client: Client,
+  identifier: BillingAccountIdentifier,
+  context: string,
+): Promise<BillingAccountDetail> {
+  const id = classifyBillingIdentifier(identifier, context);
+  return id.kind === "account_id"
+    ? fetchAccountById(client, id.value, context)
+    : fetchAccountByLookup(client, id.kind, id.value, context);
 }
 
 function assertNonNegativeSafeInteger(
@@ -176,7 +245,7 @@ function checkoutIdentifierBody(
 }
 
 export class Billing {
-  readonly balance: (identifier: BillingAccountIdentifier) => Promise<BillingBalance>;
+  readonly balance: (identifier: BillingAccountIdentifier) => Promise<BillingAccountDetail>;
   readonly createEmail: (email: string) => Promise<EmailBillingAccount>;
   readonly autoRecharge: (opts: AutoRechargeOptions) => Promise<void>;
 
@@ -186,33 +255,57 @@ export class Billing {
     this.autoRecharge = this.setAutoRecharge.bind(this);
   }
 
-  /** Check a billing account by wallet or email identifier. */
-  async checkBalance(identifier: BillingAccountIdentifier): Promise<BillingBalance> {
+  /** Check a billing account by account id (UUID), wallet, or email. */
+  async checkBalance(identifier: BillingAccountIdentifier): Promise<BillingAccountDetail> {
     return this.getAccount(identifier);
   }
 
-  /** Check a billing account by wallet or email identifier. */
-  async getAccount(identifier: BillingAccountIdentifier): Promise<BillingBalance> {
-    const encoded = encodeBillingIdentifier(identifier, "checking balance");
-    return this.client.request<BillingBalance>(`/billing/v1/accounts/${encoded}`, {
-      context: "checking balance",
-    });
+  /**
+   * Read a billing account's financial detail by account id (UUID), wallet,
+   * or email. An account id reads `GET /billing/v1/accounts/:account_id`
+   * directly; a wallet/email is resolved through the
+   * `GET /billing/v1/accounts?wallet=|?email=` lookup. Requires SIWX from a
+   * wallet linked to the account (or matching the looked-up `?wallet`), or an
+   * admin key; email lookups are admin-only.
+   */
+  async getAccount(identifier: BillingAccountIdentifier): Promise<BillingAccountDetail> {
+    return resolveAccountDetail(this.client, identifier, "checking balance");
   }
 
-  /** Fetch billing history by wallet or email identifier. */
+  /**
+   * Resolve a wallet or email to its billing account detail — including the
+   * canonical `billing_account_id` — via `GET /billing/v1/accounts?wallet=|?email=`.
+   * An account-id (UUID) argument is read directly instead. SIWX must match the
+   * `?wallet`; email lookups are admin-only.
+   */
+  async lookupAccount(identifier: BillingAccountIdentifier): Promise<BillingAccountDetail> {
+    return resolveAccountDetail(this.client, identifier, "looking up billing account");
+  }
+
+  /** Fetch billing history by account id (UUID), wallet, or email. */
   async history(identifier: BillingAccountIdentifier, limit?: number): Promise<BillingHistoryResult> {
     return this.getHistory(identifier, limit);
   }
 
-  /** Fetch billing history by wallet or email identifier. */
+  /**
+   * Fetch ledger history for a billing account. History is keyed by account id
+   * (UUID): a wallet/email identifier is first resolved to its account via the
+   * lookup, then `GET /billing/v1/accounts/:account_id/history` is read.
+   * Requires SIWX from a wallet linked to the account, or an admin key.
+   */
   async getHistory(identifier: BillingAccountIdentifier, limit?: number): Promise<BillingHistoryResult> {
-    const encoded = encodeBillingIdentifier(identifier, "fetching billing history");
     if (limit !== undefined) {
       assertPositiveSafeInteger(limit, "limit", "fetching billing history");
     }
+    const id = classifyBillingIdentifier(identifier, "fetching billing history");
+    const accountId = id.kind === "account_id"
+      ? id.value
+      : (await fetchAccountByLookup(this.client, id.kind, id.value, "fetching billing history"))
+          .billing_account_id;
+    const base = `/billing/v1/accounts/${encodeURIComponent(accountId)}/history`;
     const path = limit !== undefined
-      ? `/billing/v1/accounts/${encoded}/history?limit=${encodeURIComponent(String(limit))}`
-      : `/billing/v1/accounts/${encoded}/history`;
+      ? `${base}?limit=${encodeURIComponent(String(limit))}`
+      : base;
     return this.client.request<BillingHistoryResult>(path, {
       context: "fetching billing history",
     });
@@ -243,10 +336,13 @@ export class Billing {
 
   /**
    * Link a wallet to an existing email billing account to enable hybrid
-   * Stripe + x402 payments. Returns the gateway response; v1.46+ gateways
-   * include a {@link LinkWalletPoolImplications} block describing the
-   * freshly-shared pool's tier, current usage, and limits so callers can
-   * warn before the merge pushes usage `over_limit`.
+   * Stripe + x402 payments. `billingAccountId` is the canonical
+   * `billing_account_id` (UUID) returned by `createEmailAccount` /
+   * `lookupAccount`; the gateway addresses the route as
+   * `POST /billing/v1/accounts/:account_id/link-wallet`. Returns the gateway
+   * response; v1.46+ gateways include a {@link LinkWalletPoolImplications}
+   * block describing the freshly-shared pool's tier, current usage, and limits
+   * so callers can warn before the merge pushes usage `over_limit`.
    */
   async linkWallet(
     billingAccountId: string,

--- a/sdk/src/namespaces/projects.test.ts
+++ b/sdk/src/namespaces/projects.test.ts
@@ -192,7 +192,7 @@ describe("projects.delete", () => {
 });
 
 describe("projects.list", () => {
-  it("GETs /wallets/v1/:wallet/projects without auth when wallet is explicit", async () => {
+  it("GETs /wallets/v1/:wallet/projects with SIWX when wallet is explicit", async () => {
     const { fetch, calls } = mockFetch(() =>
       jsonResponse({
         wallet: WALLET_LOWER,
@@ -205,8 +205,8 @@ describe("projects.list", () => {
 
     assert.equal(calls[0]!.url, `https://api.example.test/wallets/v1/${WALLET_LOWER}/projects`);
     assert.equal(calls[0]!.method, "GET");
-    // Public endpoint — no SIWX header injected.
-    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], undefined);
+    // Owner-only endpoint (hardened from public) — SIWX header injected.
+    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");
     assert.deepEqual(result, { wallet: WALLET_LOWER, projects: [] });
   });
 
@@ -224,7 +224,7 @@ describe("projects.list", () => {
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0]!.url, `https://api.example.test/wallets/v1/${FEED_WALLET_LOWER}/projects`);
-    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], undefined);
+    assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");
     assert.deepEqual(result, { wallet: FEED_WALLET_LOWER, projects: [] });
   });
 

--- a/sdk/src/namespaces/projects.ts
+++ b/sdk/src/namespaces/projects.ts
@@ -113,8 +113,11 @@ export class Projects {
   }
 
   /**
-   * List active projects for a wallet address. Public endpoint — no auth
-   * required, no payment.
+   * List active projects for a wallet address. Project ids/names/usage are
+   * private, so this requires SIWX from the wallet itself (or an admin key) —
+   * a wallet may list only its own projects. The kernel signs the SIWX header
+   * from the credential provider; a caller listing a different wallet's
+   * projects gets a 403.
    *
    * When `wallet` is omitted, the SDK resolves it from the credential
    * provider's local allowance via `credentials.readAllowance()`. This mirrors
@@ -148,7 +151,6 @@ export class Projects {
     const w = resolvedWallet.toLowerCase();
     return this.client.request<ListProjectsResult>(`/wallets/v1/${w}/projects`, {
       context: "listing projects",
-      withAuth: false,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -768,14 +768,14 @@ server.tool(
 
 server.tool(
   "check_balance",
-  "Check billing account balance for an agent allowance address. Shows available and held funds.",
+  "Check the billing account balance for the agent's allowance wallet — available and held funds. The wallet is resolved to its billing account over SIWX (signed automatically); reading a wallet that is not linked to yours requires an admin key.",
   checkBalanceSchema,
   async (args) => handleCheckBalance(args),
 );
 
 server.tool(
   "list_projects",
-  "List all active projects for an agent allowance address.",
+  "List active projects for the agent's allowance wallet. Owner-only: requires SIWX matching the wallet (signed automatically), so you can list only your own projects (an admin key bypasses).",
   listProjectsSchema,
   async (args) => handleListProjects(args),
 );
@@ -1034,7 +1034,7 @@ server.tool(
 
 server.tool(
   "billing_history",
-  "View billing transaction history for an agent allowance address.",
+  "View billing ledger history for the agent's allowance wallet. The wallet is resolved to its billing account over SIWX (signed automatically); a wallet not linked to yours requires an admin key.",
   billingHistorySchema,
   async (args) => handleBillingHistory(args),
 );

--- a/src/tools/check-balance.test.ts
+++ b/src/tools/check-balance.test.ts
@@ -37,7 +37,7 @@ describe("check_balance tool", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          identifier_type: "wallet",
+          billing_account_id: "00000000-0000-4000-8000-000000000001",
           available_usd_micros: 2500000,
           email_credits_remaining: 42,
           tier: "prototype",
@@ -62,7 +62,7 @@ describe("check_balance tool", () => {
       capturedUrl = input instanceof Request ? input.url : String(input);
       return new Response(
         JSON.stringify({
-          identifier_type: "wallet",
+          billing_account_id: "00000000-0000-4000-8000-000000000001",
           available_usd_micros: 0,
           email_credits_remaining: 0,
           tier: null,
@@ -82,7 +82,7 @@ describe("check_balance tool", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          identifier_type: "wallet",
+          billing_account_id: "00000000-0000-4000-8000-000000000001",
           available_usd_micros: 0,
           email_credits_remaining: 0,
           tier: null,

--- a/src/tools/list-projects.ts
+++ b/src/tools/list-projects.ts
@@ -5,7 +5,11 @@ import { mapSdkError } from "../errors.js";
 export const listProjectsSchema = {
   wallet: z
     .string()
-    .describe("Wallet address (0x...) to list projects for"),
+    .describe(
+      "Wallet address (0x...) to list projects for. Must be your own wallet — " +
+        "the gateway requires SIWX matching this address (signed automatically " +
+        "from the local allowance), so listing another wallet's projects returns 403.",
+    ),
 };
 
 export async function handleListProjects(args: {

--- a/src/tools/status.test.ts
+++ b/src/tools/status.test.ts
@@ -43,7 +43,7 @@ function mockApis(opts: {
     if (url.includes("/tiers/v1/status") && opts.tier) {
       return new Response(JSON.stringify(opts.tier), { status: 200, headers: { "Content-Type": "application/json" } });
     }
-    if (url.includes("/billing/v1/accounts/") && opts.billing) {
+    if (url.includes("/billing/v1/accounts") && opts.billing) {
       return new Response(JSON.stringify(opts.billing), { status: 200, headers: { "Content-Type": "application/json" } });
     }
     if (url.includes("/wallets/v1/") && opts.projects) {
@@ -59,7 +59,7 @@ describe("status tool", () => {
     writeKeystore({ active_project_id: "proj-1", projects: { "proj-1": { anon_key: "ak1", service_key: "sk1" } } });
     mockApis({
       tier: { tier: "prototype", status: "active", lease_expires_at: "2026-04-01T00:00:00Z" },
-      billing: { exists: true, available_usd_micros: 250000, held_usd_micros: 0 },
+      billing: { billing_account_id: "00000000-0000-4000-8000-000000000001", available_usd_micros: 250000, held_usd_micros: 0 },
       projects: { projects: [{ id: "proj-1" }] },
     });
 

--- a/sync.test.ts
+++ b/sync.test.ts
@@ -297,7 +297,7 @@ const SURFACE: Capability[] = [
   { id: "list_versions",     endpoint: "GET /projects/v1/admin/:id/versions",       mcp: "list_versions", cli: "apps:versions", openclaw: "apps:versions" },
 
   // ── Billing ──────────────────────────────────────────────────────────────
-  { id: "check_balance",     endpoint: "GET /billing/v1/accounts/:wallet",           mcp: "check_balance",  cli: "allowance:balance", openclaw: "allowance:balance" },
+  { id: "check_balance",     endpoint: "GET /billing/v1/accounts?wallet=",           mcp: "check_balance",  cli: "allowance:balance", openclaw: "allowance:balance" },
   { id: "list_projects",     endpoint: "GET /wallets/v1/:wallet/projects",           mcp: "list_projects",  cli: "projects:list",  openclaw: "projects:list" },
   { id: "project_info",      endpoint: "(local)",                                    mcp: "project_info",   cli: "projects:info",  openclaw: "projects:info" },
   { id: "project_use",       endpoint: "(local)",                                    mcp: "project_use",    cli: "projects:use",   openclaw: "projects:use" },
@@ -360,7 +360,7 @@ const SURFACE: Capability[] = [
 
   // ── Additional billing ─────────────────────────────────────────────────
   { id: "create_checkout",   endpoint: "POST /billing/v1/checkouts",        mcp: "create_checkout",     cli: "allowance:checkout",  openclaw: "allowance:checkout" },
-  { id: "billing_history",   endpoint: "GET /billing/v1/accounts/:wallet/history", mcp: "billing_history", cli: "allowance:history", openclaw: "allowance:history" },
+  { id: "billing_history",   endpoint: "GET /billing/v1/accounts/:account_id/history", mcp: "billing_history", cli: "allowance:history", openclaw: "allowance:history" },
 
   // ── Version management ─────────────────────────────────────────────────
   { id: "update_version",    endpoint: "PATCH /projects/v1/admin/:id/versions/:version_id", mcp: "update_version", cli: "apps:update", openclaw: "apps:update" },
@@ -411,12 +411,12 @@ const SURFACE: Capability[] = [
 
   // ── Email billing accounts + Stripe tier checkout + email packs ───────
   { id: "create_email_billing_account", endpoint: "POST /billing/v1/accounts",                   mcp: "create_email_billing_account", cli: "billing:create-email",   openclaw: "billing:create-email" },
-  { id: "link_wallet_to_account",       endpoint: "POST /billing/v1/accounts/:id/link-wallet",   mcp: "link_wallet_to_account",       cli: "billing:link-wallet",    openclaw: "billing:link-wallet" },
+  { id: "link_wallet_to_account",       endpoint: "POST /billing/v1/accounts/:account_id/link-wallet",   mcp: "link_wallet_to_account",       cli: "billing:link-wallet",    openclaw: "billing:link-wallet" },
   { id: "tier_checkout",                endpoint: "POST /billing/v1/tiers/:tier/checkout",       mcp: "tier_checkout",                cli: "billing:tier-checkout",  openclaw: "billing:tier-checkout" },
   { id: "buy_email_pack",               endpoint: "POST /billing/v1/email-packs/checkout",       mcp: "buy_email_pack",               cli: "billing:buy-email-pack", openclaw: "billing:buy-email-pack" },
   { id: "set_auto_recharge",            endpoint: "POST /billing/v1/email-packs/auto-recharge",  mcp: "set_auto_recharge",            cli: "billing:auto-recharge",  openclaw: "billing:auto-recharge" },
-  { id: "billing_balance",              endpoint: "GET /billing/v1/accounts/:id",                mcp: null,                           cli: "billing:balance",        openclaw: "billing:balance" },
-  { id: "billing_history_cli",          endpoint: "GET /billing/v1/accounts/:id/history",        mcp: null,                           cli: "billing:history",        openclaw: "billing:history" },
+  { id: "billing_balance",              endpoint: "GET /billing/v1/accounts/:account_id",        mcp: null,                           cli: "billing:balance",        openclaw: "billing:balance" },
+  { id: "billing_history_cli",          endpoint: "GET /billing/v1/accounts/:account_id/history",        mcp: null,                           cli: "billing:history",        openclaw: "billing:history" },
 
   // ── Tier management ────────────────────────────────────────────────────
   { id: "tier_status",       endpoint: "GET /tiers/v1/status",             mcp: "tier_status",      cli: "tier:status",      openclaw: "tier:status" },
@@ -920,6 +920,12 @@ describe("SDK surface alignment", () => {
       "email.resolveMailbox",  // private helper
       "email.pickMailbox",     // private helper
       "email.cacheMailbox",    // private helper
+      // billing.lookupAccount resolves a wallet/email → billing_account_id via
+      // GET /billing/v1/accounts?wallet=|?email=. It's an SDK primitive used by
+      // getAccount/getHistory and exposed for consumers that only need the id;
+      // no dedicated MCP/CLI verb (the wallet/email-keyed balance/history
+      // commands resolve internally).
+      "billing.lookupAccount",
       "projects.active",       // returns active project id from the provider
       "projects.restResponse", // REST proxy with HTTP status for CLI/MCP formatters
       "assets.initUploadSession", // low-level resumable upload primitive for CLI UX


### PR DESCRIPTION
Mirrors the gateway `api-cleanup-batch-1-accounts` contract (Batch 1, piece 3 + exposure hardening) in the public SDK/CLI/MCP. Verified against the gateway implementation + tests on `run402-private`.

## Account reads → `:account_id` (UUID)
- `GET /billing/v1/accounts/:id` (wallet|email-in-path) → canonical `:account_id`. New `GET /billing/v1/accounts?wallet=|?email=` lookup resolves a wallet/email → account.
- SDK `getAccount`/`checkBalance`: UUID → by-id read; wallet/email → lookup (returns detail directly). `getHistory`/`history`: resolve to account id, then `/accounts/:account_id/history`.
- New `billing.lookupAccount(identifier)` primitive.
- Response shape: dropped `identifier_type`, added `billing_account_id`. `BillingBalance` → deprecated alias of `BillingAccountDetail`; `BillingHistoryResult` keyed by `billing_account_id`.

## Exposure hardening
- `projects.list` (`GET /wallets/v1/:address/projects`) now signs SIWX — endpoint went from public to owner-only (admin bypasses).

## Surfaces
- MCP tool descriptions (`check_balance`, `list_projects`, `billing_history`), CLI `billing` help, and comprehensive docs (`llms-cli.txt`, `llms-sdk.txt`, `sdk/README.md`, both `SKILL.md`).
- Tests: billing/projects URL+auth assertions rewritten, `lookupAccount` coverage, CLI-e2e lookup mock, `sync.test.ts` endpoint registry.

Full suite green (1282 unit/sync/skill + 619 e2e, 0 fail; 43 doc snippets compile).

⚠️ Do **not** deploy the gateway until this is merged + republished, or published clients break.

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)