### PR TITLE
fix(sdk,mcp): whoami principal fields are camelCase (displayName/createdAt)

### DIFF
--- a/cli/lib/org.mjs
+++ b/cli/lib/org.mjs
@@ -45,7 +45,7 @@ const SUB_HELP = {
 Usage:
   run402 org whoami
 
-Calls GET /agent/v1/whoami. Returns the control-plane principal (id/type/display_name),
+Calls GET /agent/v1/whoami. Returns the control-plane principal (id/type/displayName/createdAt),
 authenticator_id, and every org membership with role + status. This is the REMOTE
 identity; for local wallet/profile state use \`run402 status\`.
 `,

--- a/sdk/src/namespaces/org.test.ts
+++ b/sdk/src/namespaces/org.test.ts
@@ -47,8 +47,10 @@ function makeSdk(fetchImpl: typeof globalThis.fetch): Run402 {
 
 describe("org.whoami", () => {
   it("GETs /agent/v1/whoami and returns the resolved principal + memberships", async () => {
+    // The gateway serializes `principal` in camelCase (displayName/createdAt),
+    // unlike the snake_case memberships[] and authenticator_id.
     const payload = {
-      principal: { id: "prn_1", type: "human", display_name: "Tal" },
+      principal: { id: "prn_1", type: "human", displayName: "Tal", createdAt: "2026-01-01T00:00:00Z" },
       memberships: [{ billing_account_id: "ba_1", role: "owner", status: "active" }],
       authenticator_id: "auth_1",
     };
@@ -59,7 +61,23 @@ describe("org.whoami", () => {
     });
     const r = await makeSdk(fetch).org.whoami();
     assert.deepEqual(r, payload);
+    // typed camelCase fields resolve (would not compile if the type used snake_case)
+    assert.equal(r.principal.displayName, "Tal");
+    assert.equal(r.principal.createdAt, "2026-01-01T00:00:00Z");
+    assert.equal(r.memberships[0]!.billing_account_id, "ba_1");
     assert.equal(calls.length, 1);
+  });
+
+  it("omits displayName when the gateway does (null → absent)", async () => {
+    const payload = {
+      principal: { id: "prn_1", type: "ci", createdAt: "2026-01-01T00:00:00Z" },
+      memberships: [],
+      authenticator_id: "auth_2",
+    };
+    const { fetch } = mockFetch(() => jsonResponse(payload));
+    const r = await makeSdk(fetch).org.whoami();
+    assert.equal(r.principal.displayName, undefined);
+    assert.equal(r.principal.createdAt, "2026-01-01T00:00:00Z");
   });
 });
 

--- a/sdk/src/namespaces/org.types.ts
+++ b/sdk/src/namespaces/org.types.ts
@@ -13,11 +13,21 @@ export type OrgRole = "owner" | "admin" | "developer" | "billing" | "viewer";
  * A resolved control-plane principal. `type` is the principal kind
  * (`"human"` / `"agent"` / `"ci"` — future kinds pass through). Unknown future
  * fields are preserved via the index signature.
+ *
+ * NOTE: the `principal` sub-object is serialized in **camelCase** by the gateway
+ * (`displayName` / `createdAt` / `disabledAt`), unlike the snake_case
+ * `memberships[]` and top-level `authenticator_id`. The gateway OMITS
+ * `displayName` and `disabledAt` when they are null, so both are optional.
  */
 export interface Principal {
   id: string;
   type: string;
-  display_name: string | null;
+  /** Human-readable label (e.g. the wallet address for a SIWX human). Omitted when unset. */
+  displayName?: string;
+  /** ISO-8601 creation time. */
+  createdAt: string;
+  /** ISO-8601 timestamp present only when the principal is disabled (and thus fails auth); omitted otherwise. */
+  disabledAt?: string;
   [key: string]: unknown;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1389,7 +1389,7 @@ server.tool(
 
 server.tool(
   "whoami",
-  "Resolve the caller's control-plane principal and its org memberships (GET /agent/v1/whoami). A wallet authenticates; ownership is the org. Returns the principal (id/type/display_name), authenticator_id, and every org membership with its role + status. This is the REMOTE identity — for the local wallet/profile state use `status`.",
+  "Resolve the caller's control-plane principal and its org memberships (GET /agent/v1/whoami). A wallet authenticates; ownership is the org. Returns the principal (id/type/displayName/createdAt), authenticator_id, and every org membership with its role + status. This is the REMOTE identity — for the local wallet/profile state use `status`.",
   whoamiSchema,
   async () => handleWhoami(),
 );

--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -22,7 +22,7 @@ export async function handleWhoami(): Promise<ToolResult> {
   try {
     const me = await getSdk().org.whoami();
     const lines = [
-      `Principal \`${me.principal.id}\` (${me.principal.type}${me.principal.display_name ? `, ${me.principal.display_name}` : ""}).`,
+      `Principal \`${me.principal.id}\` (${me.principal.type}${me.principal.displayName ? `, ${me.principal.displayName}` : ""}).`,
       `- authenticator_id: \`${me.authenticator_id}\``,
       `- memberships (${me.memberships.length}):`,
       ...me.memberships.map(


### PR DESCRIPTION
Fixes the minor `Principal` casing bug shipped in `2.39.0` (caught by the live `run402 org whoami` smoke test).

## Root cause
The gateway's `GET /agent/v1/whoami` serializes the **`principal`** sub-object in **camelCase** (`displayName`, `createdAt`, `disabledAt` — its `rowToPrincipal` maps the DB columns and drops null fields via `?? undefined`), while `memberships[]` (`billing_account_id`) and the top-level `authenticator_id` stay snake_case. The SDK `Principal` type declared `display_name`, so:
- the typed `display_name` field was always `undefined` (the `[key: string]: unknown` index signature masked it from `tsc`), and
- the MCP `whoami` tool's markdown therefore never rendered the principal's name.

Verified against the live prod response **and** the gateway serializer (`packages/gateway/src/services/principals.ts` `rowToPrincipal`).

## Fix
- **SDK** `Principal`: `display_name` → `displayName?`; add `createdAt: string` (always present) and `disabledAt?: string` (present only when disabled). `displayName`/`disabledAt` are optional because the gateway omits them when null. Documented the camelCase-vs-snake_case asymmetry on the type.
- **MCP** `whoami` handler reads `me.principal.displayName`; tool description + CLI help updated to `id/type/displayName/createdAt`.
- **Test**: SDK whoami test uses the real camelCase shape and asserts `displayName`/`createdAt` resolve, plus a case proving `displayName` is `undefined` when the gateway omits it.

**Non-breaking:** `r.org.whoami()` already returned the full correct object (the index signature passed `displayName`/`createdAt` through); this only corrects the typed field names and the MCP rendering. Ships as a patch (`2.39.1`).

Full suite green: build + skill + sync + unit/e2e + doc snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
