### PR TITLE
fix(ci): deploy docs via stdin manifest (CI --manifest stdin conflict)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,4 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Deploy to run402
-        run: npx --yes run402@2.33.1 deploy apply --manifest 'run402.docs.deploy.json' --project 'prj_1780488560350_0018'
+        # Manifest via stdin (one source). Passing --manifest in CI trips the
+        # CLI's stdin detection ("Only one deploy manifest source"), so pipe it.
+        run: npx --yes run402@2.33.1 deploy apply --project 'prj_1780488560350_0018' < run402.docs.deploy.json


### PR DESCRIPTION
The auto-deploy from #438 failed: `run402 ci link github` generated `deploy apply --manifest …`, but in GitHub Actions the CLI also detects the runner's (non-TTY) stdin as a second manifest source and rejects it (`BAD_USAGE: Only one deploy manifest source`). Pipe the manifest via stdin (one source) instead — validated locally.

Follow-up (separate): fix the `ci link github` generator + the `deploy apply` stdin detection so future OIDC bindings don't emit a CI-breaking command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)