### PR TITLE
fix(ci): docs deploy uses run402@latest (OIDC 403 fix)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Deploy to run402
         # Manifest via stdin (one source). Passing --manifest in CI trips the
         # CLI's stdin detection ("Only one deploy manifest source"), so pipe it.
-        run: npx --yes run402@2.33.1 deploy apply --project 'prj_1780488560350_0018' < run402.docs.deploy.json
+        run: npx --yes run402@latest deploy apply --project 'prj_1780488560350_0018' < run402.docs.deploy.json


### PR DESCRIPTION
Follow-up to #439. The OIDC docs deploy reached the gateway but got `403 NOT_AUTHORIZED` — the workflow pinned `run402@2.33.1` (ci-link-time version) whose OIDC exchange the now-much-newer gateway rejects. Use `@latest` so the CI OIDC flow matches the current gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)