### PR TITLE
fix(cli): ci link github deploy works in CI (stdin source precedence)

### DIFF
--- a/cli-argv.test.mjs
+++ b/cli-argv.test.mjs
@@ -1682,3 +1682,48 @@ describe("email --attach parsing", () => {
     assert.equal(env.code, "BAD_USAGE");
   });
 });
+
+describe("deploy apply manifest source precedence", () => {
+  // Regression: `run402 ci link github` workflows run `deploy apply --manifest`
+  // in GitHub Actions, where the runner's stdin is a FIFO/file. An explicit
+  // source flag must win over that incidental stdin (else BAD_USAGE: "Only one
+  // deploy manifest source").
+  it("explicit --manifest wins over incidental stdin (CI FIFO)", async () => {
+    const { resolveApplySource } = await import("./cli/lib/deploy-v2.mjs");
+    assert.deepEqual(
+      resolveApplySource({ manifest: "m.json", spec: null, dir: null }, true),
+      { source: "manifest" },
+    );
+  });
+
+  it("--dir wins over incidental stdin (CI)", async () => {
+    const { resolveApplySource } = await import("./cli/lib/deploy-v2.mjs");
+    assert.deepEqual(
+      resolveApplySource({ manifest: null, spec: null, dir: "dist" }, true),
+      { source: "dir" },
+    );
+  });
+
+  it("--manifest + --spec is a genuine conflict", async () => {
+    const { resolveApplySource } = await import("./cli/lib/deploy-v2.mjs");
+    const r = resolveApplySource({ manifest: "m.json", spec: "{}", dir: null }, false);
+    assert.equal(r.source, undefined);
+    assert.equal(r.error.code, "BAD_USAGE");
+    assert.match(r.error.message, /Only one deploy manifest source/);
+  });
+
+  it("piped stdin with no source flag resolves to stdin", async () => {
+    const { resolveApplySource } = await import("./cli/lib/deploy-v2.mjs");
+    assert.deepEqual(
+      resolveApplySource({ manifest: null, spec: null, dir: null }, true),
+      { source: "stdin" },
+    );
+  });
+
+  it("no source flag and no stdin is a clear error, not a hang", async () => {
+    const { resolveApplySource } = await import("./cli/lib/deploy-v2.mjs");
+    const r = resolveApplySource({ manifest: null, spec: null, dir: null }, false);
+    assert.equal(r.error.code, "BAD_USAGE");
+    assert.match(r.error.message, /No deploy manifest provided/);
+  });
+});

--- a/cli-ci.test.mjs
+++ b/cli-ci.test.mjs
@@ -173,7 +173,7 @@ describe("run402 ci", () => {
     assert.match(workflow, /id-token: write/);
     assert.match(workflow, /contents: read/);
     assert.match(workflow, /branches: \["main"\]/);
-    assert.match(workflow, /npx --yes run402@\d+\.\d+\.\d+ deploy apply --manifest 'run402\.deploy\.json' --project 'prj_ci'/);
+    assert.match(workflow, /npx --yes run402@\d+\.\d+\.\d+ deploy apply --manifest 'run402\.deploy\.json' --project 'prj_ci' < \/dev\/null/);
 
     const output = JSON.parse(stdout.join("\n"));
     assert.equal(output.status, "ok");

--- a/cli-e2e.test.mjs
+++ b/cli-e2e.test.mjs
@@ -2665,7 +2665,13 @@ describe("CLI e2e happy path", () => {
     );
   });
 
-  it("deploy apply rejects redirected stdin combined with an explicit source (GH-268)", async () => {
+  it("explicit --spec wins over redirected stdin; stdin is ignored (GH-268 reversed for CI)", async () => {
+    // GH-268 originally REJECTED an explicit source + redirected stdin. But a CI
+    // runner (e.g. GitHub Actions) hands the step a FIFO/file stdin, so that
+    // strictness broke every `ci link github` OIDC deploy. The explicit flag now
+    // wins and stdin is ignored. Proof: pass `--spec '{}'` (empty) while a
+    // NON-empty manifest is redirected on stdin — the empty --spec is used
+    // (MANIFEST_EMPTY), NOT the stdin spec, and there is no source-conflict error.
     const { closeSync, openSync, writeFileSync: wf } = await import("node:fs");
     const { spawnSync } = await import("node:child_process");
     const stdinPath = join(tempDir, "gh268-stdin.json");
@@ -2692,8 +2698,8 @@ describe("CLI e2e happy path", () => {
     }
     assert.notEqual(result.status, 0, `should exit non-zero, stdout: ${result.stdout}, stderr: ${result.stderr}`);
     const parsed = parseStderrEnvelope(result.stderr);
-    assert.equal(parsed.code, "BAD_USAGE");
-    assert.match(parsed.message, /Only one deploy manifest source/);
+    assert.equal(parsed.code, "MANIFEST_EMPTY");
+    assert.doesNotMatch(parsed.message, /Only one deploy manifest source/);
   });
 
   it("deploy apply rejects empty manifest file (GH-232)", async () => {

--- a/cli/lib/ci.mjs
+++ b/cli/lib/ci.mjs
@@ -240,7 +240,9 @@ jobs:
 ${environmentLine}    steps:
       - uses: actions/checkout@v4
       - name: Deploy to run402
-        run: npx --yes run402@${RUN402_VERSION} deploy apply --manifest ${shellQuote(manifest)} --project ${shellQuote(projectId)}
+        # Redirect stdin from /dev/null: a CI runner's stdin is a FIFO/file that
+        # older run402 CLIs counted as a second manifest source alongside --manifest.
+        run: npx --yes run402@${RUN402_VERSION} deploy apply --manifest ${shellQuote(manifest)} --project ${shellQuote(projectId)} < /dev/null
 `;
 }
 

--- a/cli/lib/deploy-v2.mjs
+++ b/cli/lib/deploy-v2.mjs
@@ -559,11 +559,35 @@ function parseApplyArgs(args) {
   return opts;
 }
 
-function applySourceField(opts) {
-  if (opts.manifest !== null) return "manifest";
-  if (opts.spec !== null) return "spec";
-  if (opts.dir !== null && !hasStdinSource()) return "dir";
-  return "stdin";
+// Resolve the single manifest source from parsed opts + whether stdin actually
+// has data (a pipe/file on fd 0). Explicit --manifest/--spec/--dir take
+// precedence over incidental stdin: a CI runner (e.g. GitHub Actions) hands the
+// step a FIFO/file stdin, which must NOT be mistaken for a piped manifest when a
+// source flag is given. Exported for unit testing. Returns { source } | { error }.
+export function resolveApplySource(opts, stdinPresent) {
+  const explicit = [];
+  if (opts.manifest !== null) explicit.push("--manifest");
+  if (opts.spec !== null) explicit.push("--spec");
+  if (explicit.length > 1) {
+    return {
+      error: {
+        code: "BAD_USAGE",
+        message: "Only one deploy manifest source may be provided: --manifest or --spec.",
+        details: { sources: explicit },
+      },
+    };
+  }
+  if (opts.manifest !== null) return { source: "manifest" };
+  if (opts.spec !== null) return { source: "spec" };
+  if (opts.dir !== null) return { source: "dir" };
+  if (stdinPresent) return { source: "stdin" };
+  return {
+    error: {
+      code: "BAD_USAGE",
+      message: "No deploy manifest provided. Use --manifest <path>, --spec '<json>', --dir <build>, or pipe a manifest on stdin.",
+      details: {},
+    },
+  };
 }
 
 async function mergeAstroReleaseSlice(spec, dirArg) {
@@ -621,29 +645,16 @@ async function mergeAstroReleaseSlice(spec, dirArg) {
   spec.functions = { replace: { ...existingFns, ...sliceFns } };
 }
 
-function validateApplySources(opts) {
-  const sources = [];
-  if (opts.manifest !== null) sources.push("--manifest");
-  if (opts.spec !== null) sources.push("--spec");
-  if (hasStdinSource()) sources.push("stdin");
-  if (sources.length > 1) {
-    fail({
-      code: "BAD_USAGE",
-      message: "Only one deploy manifest source may be provided: --spec, --manifest, or stdin.",
-      details: { sources },
-    });
-  }
-}
-
 async function applyCmd(args) {
   const opts = parseApplyArgs(args);
-  validateApplySources(opts);
+  const { source, error: sourceError } = resolveApplySource(opts, hasStdinSource());
+  if (sourceError) fail(sourceError);
 
   let raw;
   let manifestPath = null;
-  if (opts.spec !== null) {
+  if (source === "spec") {
     raw = opts.spec;
-  } else if (opts.manifest !== null) {
+  } else if (source === "manifest") {
     try {
       manifestPath = isAbsolute(opts.manifest) ? opts.manifest : resolve(process.cwd(), opts.manifest);
       raw = readFileSync(manifestPath, "utf-8");
@@ -654,11 +665,12 @@ async function applyCmd(args) {
         details: { flag: "--manifest", path: opts.manifest },
       });
     }
-  } else if (opts.dir !== null && !hasStdinSource()) {
-    // --dir without any other source: start from an empty spec and let the
+  } else if (source === "dir") {
+    // --dir without --manifest/--spec: start from an empty spec and let the
     // Astro release-slice fill in site/functions/routes below.
     raw = "{}";
   } else {
+    // source === "stdin": a manifest piped on stdin.
     raw = await readStdin();
   }
 
@@ -669,11 +681,11 @@ async function applyCmd(args) {
     fail({
       code: "BAD_USAGE",
       message: `Manifest is not valid JSON: ${err.message}`,
-      details: { source: applySourceField(opts), parse_error: err.message },
+      details: { source, parse_error: err.message },
     });
   }
   rejectLegacySecretManifest(spec, {
-    source: applySourceField(opts),
+    source,
     ...(manifestPath ? { path: manifestPath } : {}),
   });
 
@@ -720,7 +732,7 @@ async function applyCmd(args) {
       message: `Manifest contains no deployable sections. Expected at least one of: ${meaningful.join(", ")}`,
       hint: "Did you mean to write a 'site.replace' or 'database.migrations' block? See https://run402.com/schemas/manifest.v1.json",
       details: {
-        field: applySourceField(opts),
+        field: source,
         ...(manifestPath ? { path: manifestPath } : {}),
         meaningful_keys: meaningful,
       },


### PR DESCRIPTION
`run402 ci link github`-generated workflows always failed in GitHub Actions: the workflow runs `deploy apply --manifest …`, but the CLI counted the runner's FIFO/file stdin as a second manifest source (`BAD_USAGE: Only one deploy manifest source`), so every OIDC deploy errored at plan time.

**Fix**
- `deploy-v2.mjs`: `resolveApplySource()` — explicit `--manifest`/`--spec`/`--dir` take precedence over incidental stdin; stdin is a source only when no flag is given; no-source is now a clear error instead of a hang. Exported + unit-tested. (Also removes a dangling `applySourceField` reference.)
- `ci.mjs`: the generated workflow redirects `< /dev/null` so it works even on CLI versions predating this fix.
- Reverses GH-268's reject-stdin+source rule (that strictness is what broke CI); its test now proves the flag wins and stdin is ignored.
- New precedence regression tests in `cli-argv.test.mjs` (CI-tracked). `npm test`: 0 fail.

Separate finding (not this PR): `cli-ci.test.mjs` + `cli-deploy-ci.test.mjs` aren't in the `npm test`/CI script and currently have pre-existing failures from an earlier merge's SDK drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)