### PR TITLE
docs(cli): generated workflow example uses < /dev/null (matches #441)

### DIFF
--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -480,7 +480,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Deploy to run402
-        run: npx --yes run402@1.60.0 deploy apply --manifest 'run402.deploy.json' --project 'prj_...'
+        run: npx --yes run402@1.60.0 deploy apply --manifest 'run402.deploy.json' --project 'prj_...' < /dev/null
 ```
 
 Output on success:


### PR DESCRIPTION
Follow-up to #441 — the `ci link github` generated-workflow example in llms-cli.txt now shows the `< /dev/null` redirect that the fixed generator emits. 🤖 Generated with [Claude Code](https://claude.com/claude-code)