### PR TITLE
feat: #444 public cascade — org.*, transfer email handoff, StepUpRequiredError, operator loopback login

### DIFF
--- a/cli-help.test.mjs
+++ b/cli-help.test.mjs
@@ -122,7 +122,7 @@ const MATRIX = {
   agent: { shared: [], specific: ["contact"] },
   operator: { shared: ["login", "logout", "overview", "whoami"], specific: [] },
   service: { shared: [], specific: ["status", "health"] },
-  org: { shared: [], specific: ["whoami", "list", "members", "add-member", "set-role", "remove-member"] },
+  org: { shared: [], specific: ["whoami", "list", "audit", "member", "invite"] },
   grants: { shared: [], specific: ["create", "revoke"] },
 };
 

--- a/cli-org.test.mjs
+++ b/cli-org.test.mjs
@@ -116,39 +116,39 @@ describe("run402 org", () => {
   });
 
   it("members GETs the members route", async () => {
-    capture(); await runOrg("members", ["ba_1"]); uncapture();
+    capture(); await runOrg("member", ["list", "ba_1"]); uncapture();
     assert.equal(lastCall().url, `${API}/orgs/v1/ba_1/members`);
     assert.equal(lastCall().method, "GET");
   });
 
   it("add-member POSTs { wallet } and omits role by default", async () => {
-    capture(); await runOrg("add-member", ["ba_1", TEST_ADDRESS]); uncapture();
+    capture(); await runOrg("member", ["add", "ba_1", TEST_ADDRESS]); uncapture();
     assert.equal(lastCall().url, `${API}/orgs/v1/ba_1/members`);
     assert.equal(lastCall().method, "POST");
     assert.deepEqual(lastCall().body, { wallet: TEST_ADDRESS });
   });
 
   it("add-member maps --role into the body", async () => {
-    capture(); await runOrg("add-member", ["ba_1", TEST_ADDRESS, "--role", "admin"]); uncapture();
+    capture(); await runOrg("member", ["add", "ba_1", TEST_ADDRESS, "--role", "admin"]); uncapture();
     assert.deepEqual(lastCall().body, { wallet: TEST_ADDRESS, role: "admin" });
   });
 
   it("set-role PATCHes .../members/:principal with positional order (ba, principal, role)", async () => {
-    capture(); await runOrg("set-role", ["ba_1", "prn_2", "owner"]); uncapture();
+    capture(); await runOrg("member", ["role", "ba_1", "prn_2", "owner"]); uncapture();
     assert.equal(lastCall().url, `${API}/orgs/v1/ba_1/members/prn_2`);
     assert.equal(lastCall().method, "PATCH");
     assert.deepEqual(lastCall().body, { role: "owner" });
   });
 
   it("remove-member DELETEs .../members/:principal", async () => {
-    capture(); await runOrg("remove-member", ["ba_1", "prn_2"]); uncapture();
+    capture(); await runOrg("member", ["rm", "ba_1", "prn_2"]); uncapture();
     assert.equal(lastCall().url, `${API}/orgs/v1/ba_1/members/prn_2`);
     assert.equal(lastCall().method, "DELETE");
   });
 
   it("members without an arg fails locally (no network call)", async () => {
     capture();
-    await assert.rejects(runOrg("members", []), (e) => /process\.exit\(1\)/.test(e.message));
+    await assert.rejects(runOrg("member", ["list"]), (e) => /process\.exit\(1\)/.test(e.message));
     uncapture();
     assert.equal(calls.length, 0);
   });

--- a/cli/cli.mjs
+++ b/cli/cli.mjs
@@ -30,7 +30,7 @@ Commands:
   deploy      Unified deploy operations (requires active tier)
   ci          Link GitHub Actions OIDC deploy bindings
   transfer    Two-party project transfer (init, preview, list, accept, cancel)
-  org         Org membership + roles (whoami, list, members, add-member, set-role, remove-member)
+  org         Org membership, invites & audit (whoami, list, member, invite, audit)
   grants      Per-project capability grants for agent/CI principals (create, revoke)
   jobs        Submit and inspect fixed platform-managed jobs
   functions   Manage serverless functions (deploy, invoke, logs, list, delete)

--- a/cli/lib/operator.mjs
+++ b/cli/lib/operator.mjs
@@ -19,6 +19,8 @@
 
 import { setTimeout as sleep } from "node:timers/promises";
 import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { randomBytes, createHash } from "node:crypto";
 import { fail, reportSdkError } from "./sdk-errors.mjs";
 import { getSdk } from "./sdk.mjs";
 import { normalizeArgv, hasHelp, assertKnownFlags } from "./argparse.mjs";
@@ -30,6 +32,13 @@ import {
   isOperatorSessionExpired,
   operatorSessionFromTokenResponse,
 } from "../core-dist/operator-session.js";
+import {
+  saveControlPlaneSession,
+  clearControlPlaneSession,
+  readControlPlaneSession,
+  isControlPlaneSessionExpired,
+  controlPlaneSessionFromTokenResponse,
+} from "../core-dist/control-plane-session.js";
 
 const CLIENT_NAME = "run402 CLI";
 
@@ -40,19 +49,25 @@ The operator is YOU, the human, identified by email — distinct from the agent
 For a single wallet's account state, use 'run402 status'.
 
 Usage:
-  run402 operator login [--no-open]
+  run402 operator login [--no-open]              (read session, device-flow)
+  run402 operator login --loopback [--no-open]   (write session, loopback-PKCE)
+  run402 operator login --step-up                (fresh write session for high-stakes ops)
   run402 operator overview
   run402 operator whoami
   run402 operator logout
 
 Subcommands:
-  login      Sign in via the browser (device-authorization, like 'aws sso login')
+  login      Sign in via the browser. Default = device-flow READ session (powers
+             'overview'). --loopback = write-capable control-plane session
+             (aws-sso-style, passkey-fresh). --step-up = re-mint a fresh write session.
   overview   Account view across ALL wallets controlling your email (requires login)
-  whoami     Show the cached session (email, wallets, expiry) — local, no network
-  logout     Revoke the session server-side and clear the local cache
+  whoami     Show the cached session(s) — local, no network
+  logout     Revoke the session server-side and clear the local cache(s)
 
 Options:
-  --no-open  (login) Do not auto-open the browser; just print the URL + code.
+  --no-open  (login) Do not auto-open the browser; just print the URL.
+  --loopback (login) Use the loopback-PKCE write login instead of the device flow.
+  --step-up  (login) Re-mint a fresh write session (implies --loopback).
 
 Notes:
   - The session is cached at the base config dir, shared across named wallets.
@@ -96,8 +111,154 @@ function openBrowser(url) {
   }
 }
 
+/** Output shape for the write (control-plane) session. NEVER includes the token. */
+function controlPlaneView(session, nowMs = Date.now()) {
+  return {
+    logged_in: true,
+    kind: "control_plane_session",
+    provenance: session.provenance,
+    principal_id: session.principal_id || null,
+    amr: session.amr,
+    expires_at: new Date(session.expires_at).toISOString(),
+    expires_in_seconds: Math.max(0, Math.round((session.expires_at - nowMs) / 1000)),
+    write_capable: true,
+  };
+}
+
+const base64url = (buf) => buf.toString("base64url");
+
+/** Generate PKCE (S256) + CSRF state + replay nonce for the loopback flow. */
+function pkce() {
+  const codeVerifier = base64url(randomBytes(32));
+  const codeChallenge = base64url(createHash("sha256").update(codeVerifier).digest());
+  return { codeVerifier, codeChallenge, state: base64url(randomBytes(16)), nonce: base64url(randomBytes(16)) };
+}
+
+/**
+ * Start a 127.0.0.1 loopback server (RFC 8252) that captures exactly one
+ * redirect. Returns the bound port (via `ready`), a promise for the auth code,
+ * and a `close()`. State is validated here to reject CSRF before exchange.
+ */
+function startLoopbackServer({ expectedState, timeoutMs }) {
+  let resolveCode;
+  let rejectCode;
+  const codePromise = new Promise((res, rej) => {
+    resolveCode = res;
+    rejectCode = rej;
+  });
+  let timer;
+  const server = createServer((req, res) => {
+    let u;
+    try {
+      u = new URL(req.url, "http://127.0.0.1");
+    } catch {
+      res.writeHead(400).end("bad request");
+      return;
+    }
+    if (u.pathname !== "/callback") {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    const code = u.searchParams.get("code");
+    const gotState = u.searchParams.get("state");
+    const errParam = u.searchParams.get("error");
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end(
+      "<!doctype html><html><body style=\"font-family:system-ui;padding:3rem\">" +
+        "<h2>run402 - you're signed in.</h2><p>You can close this window and return to your terminal.</p></body></html>",
+    );
+    cleanup();
+    if (errParam) rejectCode(new Error(`authorization error: ${errParam}`));
+    else if (!code) rejectCode(new Error("no authorization code on the loopback redirect"));
+    else if (gotState !== expectedState) rejectCode(new Error("state mismatch on the loopback redirect (possible CSRF) - aborted"));
+    else resolveCode(code);
+  });
+  function cleanup() {
+    clearTimeout(timer);
+    try {
+      server.close();
+    } catch {
+      // already closing
+    }
+  }
+  timer = setTimeout(() => {
+    cleanup();
+    rejectCode(new Error("timed out waiting for browser approval"));
+  }, timeoutMs);
+  server.on("error", (e) => {
+    cleanup();
+    rejectCode(e);
+  });
+  const ready = new Promise((res, rej) => {
+    server.once("error", rej);
+    server.listen(0, "127.0.0.1", () => res(server.address().port));
+  });
+  return { ready, codePromise, close: cleanup };
+}
+
+/**
+ * Loopback-PKCE write-login (RFC 8252, the aws-sso-style flow). Mints a
+ * write-capable control-plane session via the browser passkey ceremony, caches
+ * it (mode 0600), and prints metadata only - never the token.
+ */
+async function loopbackLogin(args, { stepUp }) {
+  const noOpen = args.includes("--no-open");
+  const sdk = getSdk();
+  const { codeVerifier, codeChallenge, state, nonce } = pkce();
+  const { ready, codePromise, close } = startLoopbackServer({ expectedState: state, timeoutMs: 300_000 });
+
+  let port;
+  try {
+    port = await ready;
+  } catch (err) {
+    close();
+    return fail({ code: "OPERATOR_LOOPBACK_FAILED", message: `Could not start the loopback server: ${err.message}` });
+  }
+  const redirectUri = `http://127.0.0.1:${port}/callback`;
+  const authorizeUrl = sdk.operator.buildCliAuthorizeUrl({ redirectUri, codeChallenge, state, nonce });
+
+  process.stderr.write(
+    `\nTo ${stepUp ? "re-authenticate (step-up)" : "sign in (write-capable)"}, open:\n  ${authorizeUrl}\n\n`,
+  );
+  if (!noOpen && process.stderr.isTTY) {
+    openBrowser(authorizeUrl);
+    process.stderr.write("(opening your browser…)\n\n");
+  }
+  process.stderr.write("Waiting for approval…\n");
+
+  let code;
+  try {
+    code = await codePromise;
+  } catch (err) {
+    close();
+    return fail({
+      code: "OPERATOR_LOGIN_FAILED",
+      message: err.message,
+      hint: "Run 'run402 operator login --loopback' to try again.",
+    });
+  }
+
+  let session;
+  try {
+    session = await sdk.operator.exchangeCliToken({ code, codeVerifier, redirectUri, state });
+  } catch (err) {
+    return reportSdkError(err);
+  }
+
+  const cached = controlPlaneSessionFromTokenResponse(session);
+  saveControlPlaneSession(cached);
+  process.stderr.write(`\nSigned in (write-capable, provenance=${cached.provenance}).\n`);
+  console.log(JSON.stringify(controlPlaneView(cached)));
+}
+
 async function login(args) {
-  assertKnownFlags(args, ["--help", "-h", "--no-open"]);
+  assertKnownFlags(args, ["--help", "-h", "--no-open", "--loopback", "--device", "--step-up"]);
+  // Loopback-PKCE = the write-capable control-plane login (--loopback/--step-up).
+  // The default stays the device-flow READ session (which powers 'overview');
+  // --device forces it explicitly.
+  if (args.includes("--loopback") || args.includes("--step-up")) {
+    return loopbackLogin(args, { stepUp: args.includes("--step-up") });
+  }
   const noOpen = args.includes("--no-open");
   const sdk = getSdk();
 
@@ -184,6 +345,7 @@ async function logout(args) {
     }
   }
   clearOperatorSession();
+  clearControlPlaneSession();
   console.log(JSON.stringify({ revoked, cleared: true }));
 }
 
@@ -219,17 +381,27 @@ async function whoami(args) {
   assertKnownFlags(args, ["--help", "-h"]);
   const now = Date.now();
   const session = readOperatorSession();
+  const cp = readControlPlaneSession();
+  const liveCp = cp && !isControlPlaneSessionExpired(cp, now) ? cp : null;
+
+  if (session && !isOperatorSessionExpired(session, now)) {
+    const view = sessionView(session, now);
+    if (liveCp) view.control_plane = controlPlaneView(liveCp, now);
+    console.log(JSON.stringify(view));
+    return;
+  }
+  // No live device-flow READ session — fall back to the write session if present.
+  if (liveCp) {
+    console.log(JSON.stringify(controlPlaneView(liveCp, now)));
+    return;
+  }
   if (!session) {
     console.log(JSON.stringify({ logged_in: false, reason: "no_session", hint: "Run 'run402 operator login' to sign in." }));
     process.exitCode = 1;
     return;
   }
-  if (isOperatorSessionExpired(session, now)) {
-    console.log(JSON.stringify({ logged_in: false, reason: "expired", email: session.email, hint: "Run 'run402 operator login' to sign in again." }));
-    process.exitCode = 1;
-    return;
-  }
-  console.log(JSON.stringify(sessionView(session, now)));
+  console.log(JSON.stringify({ logged_in: false, reason: "expired", email: session.email, hint: "Run 'run402 operator login' to sign in again." }));
+  process.exitCode = 1;
 }
 
 export async function run(sub, args = []) {

--- a/cli/lib/org.mjs
+++ b/cli/lib/org.mjs
@@ -1,42 +1,49 @@
 import { getSdk } from "./sdk.mjs";
-import { reportSdkError } from "./sdk-errors.mjs";
+import { reportSdkError, fail } from "./sdk-errors.mjs";
 import {
   normalizeArgv,
   assertKnownFlags,
   flagValue,
+  parseIntegerFlag,
   requirePositionalCount,
 } from "./argparse.mjs";
 
-const HELP = `run402 org — org-owned control plane: identity, membership, roles
+const ROLE_LIST = "owner | admin | developer | billing | viewer";
+
+const HELP = `run402 org — org-owned control plane: identity, membership, invites
 
 Usage:
-  run402 org <subcommand> [args...]
+  run402 org whoami
+  run402 org list
+  run402 org audit <billing_account> [--limit N] [--before <cursor>]
+  run402 org member list <billing_account>
+  run402 org member add  <billing_account> <wallet> [--role <role>]
+  run402 org member role <billing_account> <principal_id> <role>
+  run402 org member rm   <billing_account> <principal_id>
+  run402 org invite list   <billing_account>
+  run402 org invite create <billing_account> <email> [--role <role>] [--ttl-hours N]
+  run402 org invite rm     <billing_account> <principal_id>
 
 Subcommands:
-  whoami                                       Resolved principal + org memberships (GET /agent/v1/whoami)
-  list                                         Orgs you are a member of
-  members <billing_account>                    Members + roles of an org
-  add-member <billing_account> <wallet> [--role <role>]
-                                               Add a member by wallet (owner-gated; role defaults to developer)
-  set-role <billing_account> <principal_id> <role>
-                                               Change a member's role (owner-gated)
-  remove-member <billing_account> <principal_id>
-                                               Remove a member (owner-gated)
+  whoami      Resolved principal + org memberships (GET /agent/v1/whoami)
+  list        Orgs you are a member of
+  member      Manage members (list, add, role, rm) — mutations require owner
+  invite      Manage email invites (list, create, rm) — mutations require owner
+  audit       Control-plane audit trail for an org (admin+)
 
 Notes:
   - A wallet AUTHENTICATES; the org (billing account) owns projects. Membership/role authorizes.
-  - Roles: owner > admin > developer > billing > viewer. Member changes need an active owner.
-  - "add-member" is by WALLET (email-first invite is a separate, not-yet-shipped flow).
+  - Roles: ${ROLE_LIST}. Member/invite changes need an active owner.
   - Removing/demoting the org's only active owner fails with 409 LAST_OWNER.
   - JSON in, JSON out.
 
 Examples:
   run402 org whoami
-  run402 org list
-  run402 org members ba_abc
-  run402 org add-member ba_abc 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --role admin
-  run402 org set-role ba_abc prn_xyz owner
-  run402 org remove-member ba_abc prn_xyz
+  run402 org member list ba_abc
+  run402 org member add ba_abc 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --role admin
+  run402 org member role ba_abc prn_xyz owner
+  run402 org invite create ba_abc dev@example.com --role developer
+  run402 org audit ba_abc --limit 50
 `;
 
 const SUB_HELP = {
@@ -46,56 +53,45 @@ Usage:
   run402 org whoami
 
 Calls GET /agent/v1/whoami. Returns the control-plane principal (id/type/displayName/createdAt),
-authenticator_id, and every org membership with role + status. This is the REMOTE
-identity; for local wallet/profile state use \`run402 status\`.
+authenticator_id, and every org membership with role + status. REMOTE identity; for local
+wallet/profile state use 'run402 status'.
 `,
   list: `run402 org list — orgs you are a member of
 
 Usage:
   run402 org list
-
-Returns each org (billing account) you belong to with your role and membership status.
 `,
-  members: `run402 org members — members + roles of an org
+  member: `run402 org member — manage org members
 
 Usage:
-  run402 org members <billing_account>
+  run402 org member list <billing_account>
+  run402 org member add  <billing_account> <wallet> [--role <role>]
+  run402 org member role <billing_account> <principal_id> <role>
+  run402 org member rm   <billing_account> <principal_id>
 
-Arguments:
-  <billing_account>   Org (billing account) id, e.g. ba_...
+Roles: ${ROLE_LIST} (add defaults to developer). Mutations require an active owner.
+Demoting/removing the org's only active owner fails with 409 LAST_OWNER.
 `,
-  "add-member": `run402 org add-member — add a member by wallet (owner-gated)
+  invite: `run402 org invite — manage email invites
 
 Usage:
-  run402 org add-member <billing_account> <wallet> [--role <role>]
+  run402 org invite list   <billing_account>
+  run402 org invite create <billing_account> <email> [--role <role>] [--ttl-hours N]
+  run402 org invite rm     <billing_account> <principal_id>
 
-Arguments:
-  <billing_account>   Org (billing account) id
-  <wallet>            EVM address or named wallet (a new wallet is provisioned as a human principal)
-
-Options:
-  --role <role>       owner | admin | developer | billing | viewer (default: developer)
+An invite is claimed at the recipient's first login. Mutations require an active owner
+(plus step-up when driven by a control-plane session).
 `,
-  "set-role": `run402 org set-role — change a member's role (owner-gated)
+  audit: `run402 org audit — control-plane audit trail
 
 Usage:
-  run402 org set-role <billing_account> <principal_id> <role>
+  run402 org audit <billing_account> [--limit N] [--before <cursor>]
 
-Arguments:
-  <billing_account>   Org (billing account) id
-  <principal_id>      Member principal id (prn_..., from \`run402 org members\`)
-  <role>              owner | admin | developer | billing | viewer
-
-Demoting the org's only active owner fails with 409 LAST_OWNER.
-`,
-  "remove-member": `run402 org remove-member — remove a member (owner-gated)
-
-Usage:
-  run402 org remove-member <billing_account> <principal_id>
-
-Removing the org's only active owner fails with 409 LAST_OWNER.
+Requires an admin+ membership on the org. Newest-first; page with --before.
 `,
 };
+
+// ── Top-level: whoami / list / audit ───────────────────────────────────────────
 
 async function whoami(args) {
   const a = normalizeArgv(args);
@@ -119,70 +115,169 @@ async function list(args) {
   }
 }
 
-async function members(args) {
+async function audit(args) {
   const a = normalizeArgv(args);
-  assertKnownFlags(a, ["--help", "-h"]);
-  const [ba] = requirePositionalCount(a, [], {
+  const valueFlags = ["--limit", "--before"];
+  assertKnownFlags(a, [...valueFlags, "--help", "-h"], valueFlags);
+  const [ba] = requirePositionalCount(a, valueFlags, {
     min: 1,
     max: 1,
-    command: "run402 org members <billing_account>",
+    command: "run402 org audit <billing_account>",
     missing: "Missing <billing_account>.",
   });
+  const limitFlag = flagValue(a, "--limit");
+  const before = flagValue(a, "--before");
+  const limit = limitFlag === null ? undefined : parseIntegerFlag("--limit", limitFlag, { min: 1, max: 1000 });
   try {
-    console.log(JSON.stringify({ members: await getSdk().org.members(ba) }, null, 2));
+    const events = await getSdk().org.audit(ba, { limit, before: before ?? undefined });
+    console.log(JSON.stringify({ events }, null, 2));
   } catch (err) {
     reportSdkError(err);
   }
 }
 
-async function addMember(args) {
-  const a = normalizeArgv(args);
-  assertKnownFlags(a, ["--role", "--help", "-h"], ["--role"]);
-  const role = flagValue(a, "--role");
-  const [ba, wallet] = requirePositionalCount(a, ["--role"], {
-    min: 2,
-    max: 2,
-    command: "run402 org add-member <billing_account> <wallet> [--role <role>]",
-    missing: "Missing <billing_account> and/or <wallet>.",
-  });
-  try {
-    const res = await getSdk().org.addMember(ba, { wallet, role: role || undefined });
-    console.log(JSON.stringify(res, null, 2));
-  } catch (err) {
-    reportSdkError(err);
+// ── Member group ───────────────────────────────────────────────────────────────
+
+async function runMember(args) {
+  const memberAction = args[0];
+  const rest = args.slice(1);
+  if (!memberAction || memberAction === "--help" || memberAction === "-h") {
+    console.log(SUB_HELP.member);
+    process.exit(memberAction ? 0 : 1);
   }
+  if (rest.includes("--help") || rest.includes("-h")) {
+    console.log(SUB_HELP.member);
+    process.exit(0);
+  }
+
+  if (memberAction === "list") {
+    const a = normalizeArgv(rest);
+    assertKnownFlags(a, ["--help", "-h"]);
+    const [ba] = requirePositionalCount(a, [], {
+      min: 1, max: 1, command: "run402 org member list <billing_account>", missing: "Missing <billing_account>.",
+    });
+    try {
+      console.log(JSON.stringify({ members: await getSdk().org.members.list(ba) }, null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
+  if (memberAction === "add") {
+    const a = normalizeArgv(rest);
+    assertKnownFlags(a, ["--role", "--help", "-h"], ["--role"]);
+    const role = flagValue(a, "--role");
+    const [ba, wallet] = requirePositionalCount(a, ["--role"], {
+      min: 2, max: 2, command: "run402 org member add <billing_account> <wallet> [--role <role>]",
+      missing: "Missing <billing_account> and/or <wallet>.",
+    });
+    try {
+      const res = await getSdk().org.members.add(ba, { wallet, role: role || undefined });
+      console.log(JSON.stringify(res, null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
+  if (memberAction === "role") {
+    const a = normalizeArgv(rest);
+    assertKnownFlags(a, ["--help", "-h"]);
+    const [ba, principalId, role] = requirePositionalCount(a, [], {
+      min: 3, max: 3, command: "run402 org member role <billing_account> <principal_id> <role>",
+      missing: "Missing <billing_account>, <principal_id>, and/or <role>.",
+    });
+    try {
+      console.log(JSON.stringify(await getSdk().org.members.setRole(ba, principalId, role), null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
+  if (memberAction === "rm") {
+    const a = normalizeArgv(rest);
+    assertKnownFlags(a, ["--help", "-h"]);
+    const [ba, principalId] = requirePositionalCount(a, [], {
+      min: 2, max: 2, command: "run402 org member rm <billing_account> <principal_id>",
+      missing: "Missing <billing_account> and/or <principal_id>.",
+    });
+    try {
+      console.log(JSON.stringify(await getSdk().org.members.revoke(ba, principalId), null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
+  fail({ code: "BAD_USAGE", message: `Unknown 'org member' action: ${memberAction}. Try list | add | role | rm.` });
 }
 
-async function setRole(args) {
-  const a = normalizeArgv(args);
-  assertKnownFlags(a, ["--help", "-h"]);
-  const [ba, principalId, role] = requirePositionalCount(a, [], {
-    min: 3,
-    max: 3,
-    command: "run402 org set-role <billing_account> <principal_id> <role>",
-    missing: "Missing <billing_account>, <principal_id>, and/or <role>.",
-  });
-  try {
-    console.log(JSON.stringify(await getSdk().org.setRole(ba, principalId, role), null, 2));
-  } catch (err) {
-    reportSdkError(err);
-  }
-}
+// ── Invite group ─────────────────────────────────────────────────────────────────
 
-async function removeMember(args) {
-  const a = normalizeArgv(args);
-  assertKnownFlags(a, ["--help", "-h"]);
-  const [ba, principalId] = requirePositionalCount(a, [], {
-    min: 2,
-    max: 2,
-    command: "run402 org remove-member <billing_account> <principal_id>",
-    missing: "Missing <billing_account> and/or <principal_id>.",
-  });
-  try {
-    console.log(JSON.stringify(await getSdk().org.removeMember(ba, principalId), null, 2));
-  } catch (err) {
-    reportSdkError(err);
+async function runInvite(args) {
+  const inviteAction = args[0];
+  const rest = args.slice(1);
+  if (!inviteAction || inviteAction === "--help" || inviteAction === "-h") {
+    console.log(SUB_HELP.invite);
+    process.exit(inviteAction ? 0 : 1);
   }
+  if (rest.includes("--help") || rest.includes("-h")) {
+    console.log(SUB_HELP.invite);
+    process.exit(0);
+  }
+
+  if (inviteAction === "list") {
+    const a = normalizeArgv(rest);
+    assertKnownFlags(a, ["--help", "-h"]);
+    const [ba] = requirePositionalCount(a, [], {
+      min: 1, max: 1, command: "run402 org invite list <billing_account>", missing: "Missing <billing_account>.",
+    });
+    try {
+      console.log(JSON.stringify({ invites: await getSdk().org.invites.list(ba) }, null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
+  if (inviteAction === "create") {
+    const a = normalizeArgv(rest);
+    const valueFlags = ["--role", "--ttl-hours"];
+    assertKnownFlags(a, [...valueFlags, "--help", "-h"], valueFlags);
+    const role = flagValue(a, "--role");
+    const ttlFlag = flagValue(a, "--ttl-hours");
+    const [ba, email] = requirePositionalCount(a, valueFlags, {
+      min: 2, max: 2, command: "run402 org invite create <billing_account> <email> [--role <role>]",
+      missing: "Missing <billing_account> and/or <email>.",
+    });
+    const inviteTtlHours = ttlFlag === null ? undefined : parseIntegerFlag("--ttl-hours", ttlFlag, { min: 1, max: 8760 });
+    try {
+      const res = await getSdk().org.invites.create(ba, { email, role: role || "developer", inviteTtlHours });
+      console.log(JSON.stringify(res, null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
+  if (inviteAction === "rm") {
+    const a = normalizeArgv(rest);
+    assertKnownFlags(a, ["--help", "-h"]);
+    const [ba, principalId] = requirePositionalCount(a, [], {
+      min: 2, max: 2, command: "run402 org invite rm <billing_account> <principal_id>",
+      missing: "Missing <billing_account> and/or <principal_id>.",
+    });
+    try {
+      console.log(JSON.stringify(await getSdk().org.invites.revoke(ba, principalId), null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
+  fail({ code: "BAD_USAGE", message: `Unknown 'org invite' action: ${inviteAction}. Try list | create | rm.` });
 }
 
 export async function run(sub, args) {
@@ -190,17 +285,24 @@ export async function run(sub, args) {
     console.log(HELP);
     process.exit(0);
   }
-  if (Array.isArray(args) && (args.includes("--help") || args.includes("-h"))) {
-    console.log(SUB_HELP[sub] || HELP);
+  // Nested groups use `if (sub === ...)` (not `case`) so the sync test extracts
+  // their leaf actions via the dedicated memberAction/inviteAction parsers.
+  if (sub === "member" || sub === "members") {
+    await runMember(args ?? []);
+    return;
+  }
+  if (sub === "invite" || sub === "invites") {
+    await runInvite(args ?? []);
+    return;
+  }
+  if (Array.isArray(args) && (args.includes("--help") || args.includes("-h")) && SUB_HELP[sub]) {
+    console.log(SUB_HELP[sub]);
     process.exit(0);
   }
   switch (sub) {
     case "whoami": await whoami(args); break;
     case "list": await list(args); break;
-    case "members": await members(args); break;
-    case "add-member": await addMember(args); break;
-    case "set-role": await setRole(args); break;
-    case "remove-member": await removeMember(args); break;
+    case "audit": await audit(args); break;
     default:
       console.error(`Unknown subcommand: ${sub}\n`);
       console.log(HELP);

--- a/cli/lib/transfer.mjs
+++ b/cli/lib/transfer.mjs
@@ -13,18 +13,21 @@ import {
 const HELP = `run402 transfer — Two-party project transfer (v1.59)
 
 Usage:
-  run402 transfer init --to <wallet> [--project <id>] [--billing-policy migrate] [--message <text>] [--kysigned <record_id>]
+  run402 transfer init --to <wallet|email> [--project <id>] [--billing-policy migrate] [--message <text>] [--kysigned <record_id>]
   run402 transfer preview <transfer_id>
   run402 transfer list [--incoming | --outgoing] [--limit N] [--offset N]
   run402 transfer accept <transfer_id>
-  run402 transfer cancel <transfer_id> [--reason <text>]
+  run402 transfer claim <transfer_id> [--into <billing_account_id>]
+  run402 transfer cancel <transfer_id> [--reason <text>] [--handoff]
 
 Subcommands:
-  init        Initiate a transfer to a new owner (you must currently own the project)
-  preview     Fetch the safe review document (either party may view)
-  list        List pending transfers (incoming by default, or --outgoing)
-  accept      Accept an incoming transfer (your wallet must be the to_wallet)
-  cancel      Cancel a pending transfer (either party may cancel)
+  init        Initiate ownership change. --to <wallet> = two-party wallet transfer;
+              --to <email> = email->org handoff (the recipient claims it).
+  preview     Fetch the safe review document (add --handoff for an email handoff)
+  list        List pending transfers (incoming default, --outgoing, or --handoffs)
+  accept      Accept an incoming wallet transfer (your wallet must be the to_wallet)
+  claim       Claim an incoming email handoff into an org (--into <id>; omit = new org)
+  cancel      Cancel a pending transfer/handoff (--handoff routes to a handoff)
 
 Notes:
   - Owner-side mutations on a project with a pending transfer return 409
@@ -38,7 +41,7 @@ const SUB_HELP = {
   init: `run402 transfer init — Initiate a project transfer
 
 Usage:
-  run402 transfer init --to <wallet> [--project <id>] [--billing-policy migrate] [--message <text>] [--kysigned <record_id>]
+  run402 transfer init --to <wallet|email> [--project <id>] [--billing-policy migrate] [--message <text>] [--kysigned <record_id>]
 
 Options:
   --project <id>         Project id (defaults to the active project)
@@ -85,10 +88,19 @@ project, enqueues notifications to both parties, and stamps a
   cancel: `run402 transfer cancel — Cancel a pending transfer
 
 Usage:
-  run402 transfer cancel <transfer_id> [--reason <text>]
+  run402 transfer cancel <transfer_id> [--reason <text>] [--handoff]
 
 Either the from_wallet or the to_wallet may cancel. Already-processed
-transfers return 409 TRANSFER_ALREADY_PROCESSED.
+transfers return 409 TRANSFER_ALREADY_PROCESSED. Pass --handoff to cancel an
+email->org handoff instead of a wallet transfer.
+`,
+  claim: `run402 transfer claim — Claim an incoming email handoff
+
+Usage:
+  run402 transfer claim <transfer_id> [--into <billing_account_id>]
+
+Claims a handoff addressed to your email into an org you own. Omit --into to
+claim into a brand-new org. This is the email-handoff analog of 'accept'.
 `,
 };
 
@@ -122,16 +134,27 @@ async function init(args) {
   const message = flagValue(parsedArgs, "--message");
   const kysigned = flagValue(parsedArgs, "--kysigned");
 
-  allowanceAuthHeaders(`/projects/v1/${projectId}/transfers`);
+  // One noun, two rails: an email recipient routes to the email->org handoff;
+  // a wallet recipient routes to the two-party wallet transfer.
+  const isEmail = toWallet.includes("@");
+  allowanceAuthHeaders(
+    isEmail ? `/projects/v1/${projectId}/handoffs` : `/projects/v1/${projectId}/transfers`,
+  );
 
   try {
-    const res = await getSdk().admin.transfers.initiate({
-      projectId,
-      toWallet,
-      billingPolicy: billingPolicy ?? undefined,
-      message: message ?? undefined,
-      kysignedRecordId: kysigned ?? undefined,
-    });
+    const res = isEmail
+      ? await getSdk().admin.transfers.initiateHandoff({
+          projectId,
+          toEmail: toWallet,
+          message: message ?? undefined,
+        })
+      : await getSdk().admin.transfers.initiate({
+          projectId,
+          toWallet,
+          billingPolicy: billingPolicy ?? undefined,
+          message: message ?? undefined,
+          kysignedRecordId: kysigned ?? undefined,
+        });
     console.log(JSON.stringify(res, null, 2));
   } catch (err) {
     reportSdkError(err);
@@ -140,16 +163,19 @@ async function init(args) {
 
 async function preview(args) {
   const parsedArgs = normalizeArgv(args);
-  assertKnownFlags(parsedArgs, ["--help", "-h"]);
+  assertKnownFlags(parsedArgs, ["--handoff", "--help", "-h"]);
   const positionals = positionalArgs(parsedArgs);
   if (positionals.length !== 1) {
-    fail({ code: "BAD_USAGE", message: "Usage: run402 transfer preview <transfer_id>" });
+    fail({ code: "BAD_USAGE", message: "Usage: run402 transfer preview <transfer_id> [--handoff]" });
   }
   const transferId = positionals[0];
-  allowanceAuthHeaders(`/agent/v1/transfers/${transferId}`);
+  const handoff = parsedArgs.includes("--handoff");
+  allowanceAuthHeaders(`/agent/v1/${handoff ? "handoffs" : "transfers"}/${transferId}`);
 
   try {
-    const data = await getSdk().admin.transfers.preview(transferId);
+    const data = handoff
+      ? await getSdk().admin.transfers.previewHandoff(transferId)
+      : await getSdk().admin.transfers.preview(transferId);
     console.log(JSON.stringify(data, null, 2));
   } catch (err) {
     reportSdkError(err);
@@ -159,11 +185,24 @@ async function preview(args) {
 async function list(args) {
   const parsedArgs = normalizeArgv(args);
   const valueFlags = ["--limit", "--offset"];
-  assertKnownFlags(parsedArgs, [...valueFlags, "--incoming", "--outgoing", "--help", "-h"], valueFlags);
+  assertKnownFlags(parsedArgs, [...valueFlags, "--incoming", "--outgoing", "--handoffs", "--help", "-h"], valueFlags);
   const extra = positionalArgs(parsedArgs, valueFlags);
   if (extra.length > 0) {
     fail({ code: "BAD_USAGE", message: `Unexpected argument for transfer list: ${extra[0]}` });
   }
+
+  // Email->org handoffs ride the same rail but have their own incoming inbox.
+  if (parsedArgs.includes("--handoffs")) {
+    allowanceAuthHeaders("/agent/v1/handoffs/incoming");
+    try {
+      const handoffs = await getSdk().admin.transfers.listIncomingHandoffs();
+      console.log(JSON.stringify({ kind: "handoffs", handoffs }, null, 2));
+    } catch (err) {
+      reportSdkError(err);
+    }
+    return;
+  }
+
   const incoming = parsedArgs.includes("--incoming");
   const outgoing = parsedArgs.includes("--outgoing");
   if (incoming && outgoing) {
@@ -216,17 +255,42 @@ async function accept(args) {
 async function cancel(args) {
   const parsedArgs = normalizeArgv(args);
   const valueFlags = ["--reason"];
-  assertKnownFlags(parsedArgs, [...valueFlags, "--help", "-h"], valueFlags);
+  assertKnownFlags(parsedArgs, [...valueFlags, "--handoff", "--help", "-h"], valueFlags);
   const positionals = positionalArgs(parsedArgs, valueFlags);
   if (positionals.length !== 1) {
-    fail({ code: "BAD_USAGE", message: "Usage: run402 transfer cancel <transfer_id> [--reason <text>]" });
+    fail({ code: "BAD_USAGE", message: "Usage: run402 transfer cancel <transfer_id> [--reason <text>] [--handoff]" });
   }
   const transferId = positionals[0];
   const reason = flagValue(parsedArgs, "--reason");
-  allowanceAuthHeaders(`/agent/v1/transfers/${transferId}/cancel`);
+  const handoff = parsedArgs.includes("--handoff");
+  allowanceAuthHeaders(`/agent/v1/${handoff ? "handoffs" : "transfers"}/${transferId}/cancel`);
 
   try {
-    const data = await getSdk().admin.transfers.cancel(transferId, reason ?? undefined);
+    const data = handoff
+      ? await getSdk().admin.transfers.cancelHandoff(transferId)
+      : await getSdk().admin.transfers.cancel(transferId, reason ?? undefined);
+    console.log(JSON.stringify(data, null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function claim(args) {
+  const parsedArgs = normalizeArgv(args);
+  const valueFlags = ["--into"];
+  assertKnownFlags(parsedArgs, [...valueFlags, "--help", "-h"], valueFlags);
+  const positionals = positionalArgs(parsedArgs, valueFlags);
+  if (positionals.length !== 1) {
+    fail({ code: "BAD_USAGE", message: "Usage: run402 transfer claim <transfer_id> [--into <billing_account_id>]" });
+  }
+  const transferId = positionals[0];
+  const into = flagValue(parsedArgs, "--into");
+  allowanceAuthHeaders(`/agent/v1/handoffs/${transferId}/claim`);
+
+  try {
+    const data = await getSdk().admin.transfers.claimHandoff(transferId, {
+      billingAccountId: into ?? undefined,
+    });
     console.log(JSON.stringify(data, null, 2));
   } catch (err) {
     reportSdkError(err);
@@ -254,6 +318,9 @@ export async function run(sub, args) {
       return;
     case "accept":
       await accept(args);
+      return;
+    case "claim":
+      await claim(args);
       return;
     case "cancel":
       await cancel(args);

--- a/core/src/control-plane-session.ts
+++ b/core/src/control-plane-session.ts
@@ -1,0 +1,178 @@
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  chmodSync,
+  renameSync,
+  statSync,
+  rmSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getConfigBaseDir } from "./config.js";
+
+/**
+ * A cached **control-plane session** — the human principal's *write-capable*
+ * bearer, minted by the loopback-PKCE flow (`run402 operator login --loopback`).
+ * Distinct from the device-flow {@link OperatorSession} (read-only): this one
+ * carries `provenance` (`loopback_pkce`) and `amr`, and is accepted everywhere a
+ * SIWX wallet is. Cached at the BASE config dir (email/principal-scoped, shared
+ * across local named wallets), mode 0600 — the token is as sensitive as the
+ * allowance key.
+ *
+ * Stored shape vs the gateway payload: the gateway returns a relative
+ * `expires_in` (seconds); we persist the absolute `expires_at` (epoch ms) so a
+ * cached session can be expiry-checked without knowing when it was written.
+ */
+export interface ControlPlaneSessionCache {
+  control_plane_session_token: string;
+  token_type: string;
+  provenance: string;
+  principal_id: string;
+  amr: string[];
+  /** Epoch ms when the session expires (issued_at + expires_in). */
+  expires_at: number;
+}
+
+/** The token payload returned by `POST /agent/v1/control-plane/cli/token`. */
+export interface ControlPlaneSessionTokenResponse {
+  control_plane_session_token: string;
+  token_type?: string;
+  provenance?: string;
+  principal_id?: string;
+  amr?: string[];
+  expires_in?: number;
+}
+
+/**
+ * Path to the cached control-plane session: `{base}/control-plane-session.json`.
+ * `RUN402_CONTROL_PLANE_SESSION_PATH` overrides for testing.
+ */
+export function getControlPlaneSessionPath(): string {
+  return (
+    process.env.RUN402_CONTROL_PLANE_SESSION_PATH ||
+    join(getConfigBaseDir(), "control-plane-session.json")
+  );
+}
+
+/** Tighten 0600 if group/other-readable, warning once. Best-effort, POSIX-only. */
+function selfHealPermissions(p: string): void {
+  if (process.platform === "win32") return;
+  try {
+    const mode = statSync(p).mode & 0o777;
+    if ((mode & 0o077) !== 0) {
+      chmodSync(p, 0o600);
+      process.stderr.write(
+        `warning: tightened permissions on ${p} from ${mode.toString(8)} to 600 (was readable by other users).\n`,
+      );
+    }
+  } catch {
+    // Best-effort; never block a read on a chmod/stat failure.
+  }
+}
+
+/**
+ * Load the cached control-plane session. Returns `null` for the "no session"
+ * cases (absent, unreadable, unparseable). Throws when the file parses as JSON
+ * but the shape is wrong, so a corrupted cache surfaces a clear fix-it.
+ */
+export function readControlPlaneSession(path?: string): ControlPlaneSessionCache | null {
+  const p = path ?? getControlPlaneSessionPath();
+  if (!existsSync(p)) return null;
+  selfHealPermissions(p);
+  let raw: string;
+  try {
+    raw = readFileSync(p, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "control-plane-session.json must contain a JSON object. Delete it and run 'run402 operator login --loopback' to recreate it.",
+    );
+  }
+  const data = parsed as Partial<ControlPlaneSessionCache>;
+  if (
+    typeof data.control_plane_session_token !== "string" ||
+    data.control_plane_session_token.length === 0
+  ) {
+    throw new Error(
+      "control-plane-session.json missing valid 'control_plane_session_token'. Run 'run402 operator login --loopback' to refresh it.",
+    );
+  }
+  if (typeof data.expires_at !== "number" || !Number.isFinite(data.expires_at)) {
+    throw new Error(
+      "control-plane-session.json missing valid 'expires_at'. Run 'run402 operator login --loopback' to refresh it.",
+    );
+  }
+  return {
+    control_plane_session_token: data.control_plane_session_token,
+    token_type: typeof data.token_type === "string" ? data.token_type : "Bearer",
+    provenance: typeof data.provenance === "string" ? data.provenance : "loopback_pkce",
+    principal_id: typeof data.principal_id === "string" ? data.principal_id : "",
+    amr: Array.isArray(data.amr) ? data.amr.filter((a): a is string => typeof a === "string") : [],
+    expires_at: data.expires_at,
+  };
+}
+
+/** Persist a control-plane session atomically (temp-file + rename), mode 0600. */
+export function saveControlPlaneSession(data: ControlPlaneSessionCache, path?: string): void {
+  const p = path ?? getControlPlaneSessionPath();
+  const dir = dirname(p);
+  mkdirSync(dir, { recursive: true });
+  const tmp = join(dir, `.control-plane-session.${randomBytes(4).toString("hex")}.tmp`);
+  writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  renameSync(tmp, p);
+  chmodSync(p, 0o600);
+}
+
+/** Delete the cached control-plane session — local half of `operator logout`. Idempotent. */
+export function clearControlPlaneSession(path?: string): void {
+  const p = path ?? getControlPlaneSessionPath();
+  try {
+    rmSync(p, { force: true });
+  } catch {
+    // Best-effort: a failed unlink should never crash logout.
+  }
+}
+
+/** Whether a cached session is past its usable life (with a small skew buffer). */
+export function isControlPlaneSessionExpired(
+  session: ControlPlaneSessionCache,
+  nowMs: number = Date.now(),
+  skewMs = 10_000,
+): boolean {
+  return nowMs + skewMs >= session.expires_at;
+}
+
+/** Read the cached session and return it only if still usable; `null` if absent or expired. */
+export function loadLiveControlPlaneSession(
+  path?: string,
+  nowMs: number = Date.now(),
+): ControlPlaneSessionCache | null {
+  const s = readControlPlaneSession(path);
+  if (!s) return null;
+  return isControlPlaneSessionExpired(s, nowMs) ? null : s;
+}
+
+/** Map a gateway token payload (relative `expires_in`) into the cached shape (absolute `expires_at`). */
+export function controlPlaneSessionFromTokenResponse(
+  resp: ControlPlaneSessionTokenResponse,
+  nowMs: number = Date.now(),
+): ControlPlaneSessionCache {
+  return {
+    control_plane_session_token: resp.control_plane_session_token,
+    token_type: resp.token_type ?? "Bearer",
+    provenance: resp.provenance ?? "loopback_pkce",
+    principal_id: resp.principal_id ?? "",
+    amr: Array.isArray(resp.amr) ? resp.amr.filter((a): a is string => typeof a === "string") : [],
+    expires_at: nowMs + (typeof resp.expires_in === "number" ? resp.expires_in : 0) * 1000,
+  };
+}

--- a/sdk/src/errors.test.ts
+++ b/sdk/src/errors.test.ts
@@ -19,6 +19,7 @@ import {
   ProjectNotFound,
   Run402DeployError,
   Run402Error,
+  StepUpRequiredError,
   Unauthorized,
   getQuotaScope,
   isApiError,
@@ -30,6 +31,7 @@ import {
   isProjectNotFound,
   isRetryableRun402Error,
   isRun402Error,
+  isStepUpRequired,
   isUnauthorized,
 } from "./errors.js";
 
@@ -67,6 +69,61 @@ describe("Run402Error kind discriminators", () => {
   it("Run402DeployError carries kind='deploy_error'", () => {
     const e = new Run402DeployError("nope", { code: "MIGRATION_FAILED", context: "deploying" });
     assert.equal(e.kind, "deploy_error");
+  });
+});
+
+// ─── StepUpRequiredError ─────────────────────────────────────────────────────
+
+describe("StepUpRequiredError", () => {
+  const body = {
+    error: "step up required",
+    code: "STEP_UP_REQUIRED",
+    details: {
+      required_amr: ["passkey"],
+      max_age_seconds: 300,
+      challenge_url: "https://run402.com/operator/step-up",
+      reason: "device_flow_forbidden",
+    },
+    next_actions: [{ type: "authenticate", path: "https://run402.com/operator/step-up" }],
+  };
+
+  it("carries kind='step_up_required', DEFAULT_CODE, and status", () => {
+    const e = new StepUpRequiredError("nope", 403, body, "transferring a project");
+    assert.equal(e.kind, "step_up_required");
+    assert.equal(e.code, "STEP_UP_REQUIRED");
+    assert.equal(e.status, 403);
+  });
+
+  it("lifts typed fields from details", () => {
+    const e = new StepUpRequiredError("nope", 403, body, "ctx");
+    assert.deepEqual(e.requiredAmr, ["passkey"]);
+    assert.equal(e.maxAgeSeconds, 300);
+    assert.equal(e.challengeUrl, "https://run402.com/operator/step-up");
+    assert.equal(e.reason, "device_flow_forbidden");
+  });
+
+  it("defaults fields safely when details is absent or malformed", () => {
+    const e = new StepUpRequiredError("nope", 403, { code: "STEP_UP_REQUIRED" }, "ctx");
+    assert.deepEqual(e.requiredAmr, []);
+    assert.equal(e.maxAgeSeconds, null);
+    assert.equal(e.challengeUrl, null);
+    assert.equal(e.reason, null);
+  });
+
+  it("isStepUpRequired matches only StepUpRequiredError", () => {
+    const e = new StepUpRequiredError("nope", 403, body, "ctx");
+    assert.equal(isStepUpRequired(e), true);
+    assert.equal(isStepUpRequired(new Unauthorized("x", 403, null, "ctx")), false);
+    assert.equal(isStepUpRequired(new Error("x")), false);
+  });
+
+  it("toJSON includes the typed fields + nextActions", () => {
+    const e = new StepUpRequiredError("nope", 403, body, "ctx");
+    const j = e.toJSON();
+    assert.equal(j.kind, "step_up_required");
+    assert.equal(j.challengeUrl, "https://run402.com/operator/step-up");
+    assert.deepEqual(j.requiredAmr, ["passkey"]);
+    assert.ok(Array.isArray(j.nextActions));
   });
 });
 

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -25,7 +25,8 @@ export type Run402ErrorKind =
   | "network_error"
   | "local_error"
   | "deploy_error"
-  | "transfer_freeze";
+  | "transfer_freeze"
+  | "step_up_required";
 
 /**
  * Quota-denial scope discriminator (v1.46+). Indicates whether a quota-related
@@ -482,6 +483,66 @@ function pickNextActionPath(actions: unknown[], type: string): string | null {
   return null;
 }
 
+/**
+ * HTTP 403 `STEP_UP_REQUIRED` — the gateway requires a fresh, same-client
+ * step-up (a recent `passkey` AMR) before this high-stakes control-plane
+ * operation (delete / transfer / membership / invite / payment drain·rotate)
+ * may proceed. A `device_flow`-minted session can never satisfy it; the caller
+ * must complete the challenge at {@link challengeUrl} (e.g. via
+ * `run402 operator login --step-up`) on the same client and retry.
+ *
+ * Typed fields are lifted from the gateway `details` envelope; the same
+ * remediation pointer is also present in {@link Run402Error.nextActions} as an
+ * `authenticate` action.
+ */
+export class StepUpRequiredError extends Run402Error {
+  static readonly DEFAULT_CODE = "STEP_UP_REQUIRED";
+  static readonly DEFAULT_CATEGORY = "auth";
+  static readonly DEFAULT_RETRYABLE = false;
+  readonly kind = "step_up_required" as const;
+  /** AMRs that would satisfy the step-up (e.g. `["passkey"]`). Empty when the gateway omitted it. */
+  readonly requiredAmr: string[];
+  /** Max age in seconds the satisfying auth may be; null when the gateway omitted it. */
+  readonly maxAgeSeconds: number | null;
+  /** Where to run the step-up challenge; null when the gateway omitted it. */
+  readonly challengeUrl: string | null;
+  /** Why the step-up was demanded (e.g. `"device_flow_forbidden"`); null when absent. */
+  readonly reason: string | null;
+
+  constructor(message: string, status: number, body: unknown, context: string) {
+    super(message, status, body, context);
+    const envelope =
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>)
+        : null;
+    const details =
+      envelope &&
+      typeof envelope.details === "object" &&
+      envelope.details !== null &&
+      !Array.isArray(envelope.details)
+        ? (envelope.details as Record<string, unknown>)
+        : null;
+    this.requiredAmr = Array.isArray(details?.required_amr)
+      ? (details!.required_amr as unknown[]).filter((x): x is string => typeof x === "string")
+      : [];
+    this.maxAgeSeconds =
+      typeof details?.max_age_seconds === "number" ? (details.max_age_seconds as number) : null;
+    this.challengeUrl =
+      typeof details?.challenge_url === "string" ? (details.challenge_url as string) : null;
+    this.reason = typeof details?.reason === "string" ? (details.reason as string) : null;
+  }
+
+  override toJSON(): Record<string, unknown> {
+    return {
+      ...super.toJSON(),
+      requiredAmr: this.requiredAmr,
+      maxAgeSeconds: this.maxAgeSeconds,
+      challengeUrl: this.challengeUrl,
+      reason: this.reason,
+    };
+  }
+}
+
 // ─── Type guards ─────────────────────────────────────────────────────────────
 //
 // Identity-free guards. Each one checks the structural brand and (for subclass
@@ -542,6 +603,11 @@ export function isDeployError(e: unknown): e is Run402DeployError {
 /** True if `e` is a {@link TransferFreezeError}. */
 export function isTransferFreezeError(e: unknown): e is TransferFreezeError {
   return isRun402Error(e) && e.kind === "transfer_freeze";
+}
+
+/** True if `e` is a {@link StepUpRequiredError}. Survives duplicate SDK copies and realms. */
+export function isStepUpRequired(e: unknown): e is StepUpRequiredError {
+  return isRun402Error(e) && e.kind === "step_up_required";
 }
 
 /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -386,7 +386,7 @@ export type * from "./namespaces/email.js";
 export type * from "./namespaces/functions.types.js";
 export type * from "./namespaces/jobs.js";
 export type * from "./namespaces/operator.js";
-export { Org } from "./namespaces/org.js";
+export { Org, OrgMembers, OrgInvites } from "./namespaces/org.js";
 export type * from "./namespaces/org.types.js";
 export { Grants } from "./namespaces/grants.js";
 export type * from "./namespaces/grants.types.js";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -306,6 +306,7 @@ export {
   LocalError,
   Run402DeployError,
   TransferFreezeError,
+  StepUpRequiredError,
   isRun402Error,
   isPaymentRequired,
   isProjectNotFound,
@@ -316,6 +317,7 @@ export {
   isLocalError,
   isDeployError,
   isTransferFreezeError,
+  isStepUpRequired,
   isRetryableRun402Error,
   getQuotaScope,
 } from "./errors.js";

--- a/sdk/src/kernel.test.ts
+++ b/sdk/src/kernel.test.ts
@@ -12,6 +12,7 @@ import {
   NetworkError,
   NotAuthorizedError,
   PaymentRequired,
+  StepUpRequiredError,
   Unauthorized,
 } from "./errors.js";
 import type { CredentialsProvider } from "./credentials.js";
@@ -265,6 +266,35 @@ describe("kernel request", () => {
         const json = e.toJSON();
         assert.equal(json.requiredRole, "owner");
         assert.equal(json.reason, "forbidden");
+        return true;
+      },
+    );
+    exitSpy.restore();
+  });
+
+  it("throws StepUpRequiredError on 403 with code STEP_UP_REQUIRED", async () => {
+    const body = {
+      error: "step up required",
+      code: "STEP_UP_REQUIRED",
+      details: {
+        required_amr: ["passkey"],
+        max_age_seconds: 300,
+        challenge_url: "https://run402.com/step-up",
+        reason: "device_flow_forbidden",
+      },
+    };
+    const kernel = makeKernel(async () => makeRes(body, { status: 403 }));
+    await assert.rejects(
+      request(kernel, "/projects/v1/prj_1/transfers", { method: "POST", context: "transferring a project" }),
+      (err: unknown) => {
+        assert.ok(err instanceof StepUpRequiredError);
+        const e = err as StepUpRequiredError;
+        assert.equal(e.kind, "step_up_required");
+        assert.equal(e.status, 403);
+        assert.deepEqual(e.requiredAmr, ["passkey"]);
+        assert.equal(e.maxAgeSeconds, 300);
+        assert.equal(e.challengeUrl, "https://run402.com/step-up");
+        assert.equal(e.reason, "device_flow_forbidden");
         return true;
       },
     );

--- a/sdk/src/kernel.ts
+++ b/sdk/src/kernel.ts
@@ -16,6 +16,7 @@ import {
   NetworkError,
   NotAuthorizedError,
   PaymentRequired,
+  StepUpRequiredError,
   TransferFreezeError,
   Unauthorized,
 } from "./errors.js";
@@ -128,6 +129,14 @@ export async function requestWithResponse<T>(
     throw new PaymentRequired(
       `${displayMessage(resBody, "Payment required")} while ${context}`,
       402,
+      resBody,
+      context,
+    );
+  }
+  if (res.status === 403 && envelopeCode(resBody) === "STEP_UP_REQUIRED") {
+    throw new StepUpRequiredError(
+      `${displayMessage(resBody, "Step-up authentication required")} while ${context}`,
+      res.status,
       resBody,
       context,
     );

--- a/sdk/src/namespaces/operator.test.ts
+++ b/sdk/src/namespaces/operator.test.ts
@@ -173,3 +173,57 @@ describe("operator.revoke", () => {
     assert.equal(calls[0]!.headers["Authorization"], "Bearer ops_tok");
   });
 });
+
+describe("operator loopback-PKCE write-login (v1.78)", () => {
+  it("buildCliAuthorizeUrl composes the authorize URL with S256 + params (no network)", () => {
+    const { fetch, calls } = mockFetch(() => jsonResponse({}));
+    const url = makeSdk(fetch).operator.buildCliAuthorizeUrl({
+      redirectUri: "http://127.0.0.1:54321/callback",
+      codeChallenge: "chal_abc",
+      state: "st_1",
+      nonce: "nn_1",
+    });
+    assert.equal(calls.length, 0, "URL build must not touch the network");
+    const u = new URL(url);
+    assert.equal(u.origin + u.pathname, "https://api.example.test/agent/v1/control-plane/cli/authorize");
+    assert.equal(u.searchParams.get("redirect_uri"), "http://127.0.0.1:54321/callback");
+    assert.equal(u.searchParams.get("code_challenge"), "chal_abc");
+    assert.equal(u.searchParams.get("code_challenge_method"), "S256");
+    assert.equal(u.searchParams.get("state"), "st_1");
+    assert.equal(u.searchParams.get("nonce"), "nn_1");
+  });
+
+  it("exchangeCliToken POSTs code + verifier to /cli/token, unauthenticated", async () => {
+    const { fetch, calls } = mockFetch((call) => {
+      assert.equal(call.method, "POST");
+      assert.equal(call.url, "https://api.example.test/agent/v1/control-plane/cli/token");
+      // The code + verifier ARE the credential — no SIWX/bearer header is sent.
+      assert.equal(call.headers["SIGN-IN-WITH-X"], undefined);
+      assert.equal(call.headers["Authorization"], undefined);
+      assert.deepEqual(JSON.parse(String(call.body)), {
+        code: "code_1",
+        code_verifier: "ver_1",
+        redirect_uri: "http://127.0.0.1:54321/callback",
+        state: "st_1",
+      });
+      return jsonResponse({
+        control_plane_session_token: "cps_tok",
+        token_type: "Bearer",
+        expires_in: 900,
+        provenance: "loopback_pkce",
+        principal_id: "prn_1",
+        amr: ["passkey"],
+      });
+    });
+    const session = await makeSdk(fetch).operator.exchangeCliToken({
+      code: "code_1",
+      codeVerifier: "ver_1",
+      redirectUri: "http://127.0.0.1:54321/callback",
+      state: "st_1",
+    });
+    assert.equal(session.control_plane_session_token, "cps_tok");
+    assert.equal(session.provenance, "loopback_pkce");
+    assert.deepEqual(session.amr, ["passkey"]);
+    assert.equal(calls.length, 1);
+  });
+});

--- a/sdk/src/namespaces/operator.ts
+++ b/sdk/src/namespaces/operator.ts
@@ -70,6 +70,50 @@ export interface OperatorOverview {
   [key: string]: unknown;
 }
 
+/**
+ * A write-capable control-plane session minted by the loopback-PKCE flow
+ * (`POST /agent/v1/control-plane/cli/token`). Distinct from the device-flow
+ * {@link OperatorSessionToken} (read-only): this carries `provenance` and
+ * `amr`, and is accepted everywhere a SIWX wallet is. Forward-compatible.
+ */
+export interface ControlPlaneSession {
+  control_plane_session_token: string;
+  token_type?: string;
+  /** Relative lifetime in seconds. */
+  expires_in?: number;
+  /** How it was minted — `loopback_pkce` for the CLI write-login. */
+  provenance?: string;
+  /** The control-plane principal id. */
+  principal_id?: string;
+  /** Auth methods satisfied (e.g. `["passkey"]`). */
+  amr?: string[];
+  [key: string]: unknown;
+}
+
+/** Parameters for {@link Operator.buildCliAuthorizeUrl}. */
+export interface CliAuthorizeParams {
+  /** The CLI's loopback redirect, e.g. `http://127.0.0.1:54321/callback`. */
+  redirectUri: string;
+  /** PKCE S256 challenge = base64url(sha256(verifier)). */
+  codeChallenge: string;
+  /** Opaque CSRF state echoed back on the redirect. */
+  state: string;
+  /** Replay nonce. */
+  nonce: string;
+}
+
+/** Parameters for {@link Operator.exchangeCliToken}. */
+export interface CliTokenExchange {
+  /** Authorization code received on the loopback redirect. */
+  code: string;
+  /** The PKCE verifier whose hash was sent as `codeChallenge`. */
+  codeVerifier: string;
+  /** Must match the `redirectUri` used at authorize time. */
+  redirectUri: string;
+  /** Must match the `state` used at authorize time. */
+  state: string;
+}
+
 const POLL_ERROR_CODES = new Set([
   "authorization_pending",
   "slow_down",
@@ -163,6 +207,49 @@ export class Operator {
       headers: { Authorization: `Bearer ${opts.token}` },
       withAuth: false,
       context: "revoking operator session",
+    });
+  }
+
+  // ── Loopback-PKCE write-login (v1.78, RFC 8252 §7.3) ──────────────────────
+  // The aws-sso-style write login: the CLI starts a `127.0.0.1` server, opens
+  // the browser to the authorize URL (the console runs the passkey ceremony +
+  // approves), receives the code on the loopback redirect, then exchanges it
+  // here for a write-capable, passkey-fresh control-plane session
+  // (`provenance=loopback_pkce`). PKCE generation + the loopback server live in
+  // the Node CLI; these two methods are the isomorphic SDK seam.
+
+  /**
+   * Build the loopback-PKCE authorize URL the CLI opens in the browser. Pure —
+   * no network, no Node APIs — so it is safe in any runtime. The caller
+   * generates `codeChallenge`/`state`/`nonce` and runs the redirect server.
+   */
+  buildCliAuthorizeUrl(params: CliAuthorizeParams): string {
+    const q = new URLSearchParams({
+      redirect_uri: params.redirectUri,
+      code_challenge: params.codeChallenge,
+      code_challenge_method: "S256",
+      state: params.state,
+      nonce: params.nonce,
+    });
+    return `${this.client.apiBase}/agent/v1/control-plane/cli/authorize?${q.toString()}`;
+  }
+
+  /**
+   * Exchange the loopback authorization code (+ PKCE verifier) for a
+   * write-capable {@link ControlPlaneSession}. Unauthenticated — the code +
+   * verifier are the credential.
+   */
+  async exchangeCliToken(params: CliTokenExchange): Promise<ControlPlaneSession> {
+    return this.client.request<ControlPlaneSession>("/agent/v1/control-plane/cli/token", {
+      method: "POST",
+      body: {
+        code: params.code,
+        code_verifier: params.codeVerifier,
+        redirect_uri: params.redirectUri,
+        state: params.state,
+      },
+      withAuth: false,
+      context: "exchanging CLI authorization code",
     });
   }
 }

--- a/sdk/src/namespaces/org.test.ts
+++ b/sdk/src/namespaces/org.test.ts
@@ -104,12 +104,12 @@ describe("org.members", () => {
       assert.equal(call.url, "https://api.example.test/orgs/v1/ba%2F1/members");
       return jsonResponse({ members });
     });
-    assert.deepEqual(await makeSdk(fetch).org.members("ba/1"), members);
+    assert.deepEqual(await makeSdk(fetch).org.members.list("ba/1"), members);
   });
 
   it("throws LocalError without a billing account id", async () => {
     const { fetch, calls } = mockFetch(() => jsonResponse({}));
-    await assert.rejects(makeSdk(fetch).org.members(""), (e: unknown) => isLocalError(e));
+    await assert.rejects(makeSdk(fetch).org.members.list(""), (e: unknown) => isLocalError(e));
     assert.equal(calls.length, 0, "no network call on local validation failure");
   });
 });
@@ -122,7 +122,7 @@ describe("org.addMember", () => {
       assert.deepEqual(JSON.parse(String(call.body)), { wallet: "0xABC" });
       return jsonResponse({ status: "ok", principal_id: "prn_3", role: "developer" }, 201);
     });
-    const res = await makeSdk(fetch).org.addMember("ba_1", { wallet: "0xABC" });
+    const res = await makeSdk(fetch).org.members.add("ba_1", { wallet: "0xABC" });
     assert.equal(res.principal_id, "prn_3");
     assert.equal(res.role, "developer");
   });
@@ -132,13 +132,13 @@ describe("org.addMember", () => {
       assert.deepEqual(JSON.parse(String(call.body)), { wallet: "0xABC", role: "admin" });
       return jsonResponse({ status: "ok", principal_id: "prn_3", role: "admin" }, 201);
     });
-    await makeSdk(fetch).org.addMember("ba_1", { wallet: "0xABC", role: "admin" });
+    await makeSdk(fetch).org.members.add("ba_1", { wallet: "0xABC", role: "admin" });
   });
 
   it("throws LocalError without a wallet", async () => {
     const { fetch, calls } = mockFetch(() => jsonResponse({}));
     // @ts-expect-error intentionally missing wallet
-    await assert.rejects(makeSdk(fetch).org.addMember("ba_1", {}), (e: unknown) => isLocalError(e));
+    await assert.rejects(makeSdk(fetch).org.members.add("ba_1", {}), (e: unknown) => isLocalError(e));
     assert.equal(calls.length, 0);
   });
 });
@@ -151,7 +151,7 @@ describe("org.setRole", () => {
       assert.deepEqual(JSON.parse(String(call.body)), { role: "owner" });
       return jsonResponse({ status: "ok", principal_id: "prn_2", role: "owner" });
     });
-    const res = await makeSdk(fetch).org.setRole("ba_1", "prn_2", "owner");
+    const res = await makeSdk(fetch).org.members.setRole("ba_1", "prn_2", "owner");
     assert.equal(res.role, "owner");
   });
 
@@ -160,7 +160,7 @@ describe("org.setRole", () => {
       jsonResponse({ code: "LAST_OWNER", message: "The org must keep one active owner." }, 409),
     );
     await assert.rejects(
-      makeSdk(fetch).org.setRole("ba_1", "prn_2", "viewer"),
+      makeSdk(fetch).org.members.setRole("ba_1", "prn_2", "viewer"),
       (e: unknown) => e instanceof ApiError && e.status === 409 && e.code === "LAST_OWNER",
     );
   });
@@ -173,13 +173,13 @@ describe("org.removeMember", () => {
       assert.equal(call.url, "https://api.example.test/orgs/v1/ba_1/members/prn_2");
       return jsonResponse({ status: "revoked", principal_id: "prn_2" });
     });
-    const res = await makeSdk(fetch).org.removeMember("ba_1", "prn_2");
+    const res = await makeSdk(fetch).org.members.revoke("ba_1", "prn_2");
     assert.equal(res.status, "revoked");
   });
 
   it("throws LocalError without a principal id", async () => {
     const { fetch, calls } = mockFetch(() => jsonResponse({}));
-    await assert.rejects(makeSdk(fetch).org.removeMember("ba_1", ""), (e: unknown) => isLocalError(e));
+    await assert.rejects(makeSdk(fetch).org.members.revoke("ba_1", ""), (e: unknown) => isLocalError(e));
     assert.equal(calls.length, 0);
   });
 });

--- a/sdk/src/namespaces/org.ts
+++ b/sdk/src/namespaces/org.ts
@@ -1,24 +1,150 @@
 /**
- * `org` namespace — the org-owned control plane (gateway v1.77+ /
- * `org-member-management`). Read the resolved principal + memberships, list
- * orgs, and manage org membership (owner-gated). All routes use the existing
- * SIWX auth; authorization is a membership lookup, never `wallet == signer`.
+ * `org` namespace — the org-owned control plane (gateway v1.77+). Read the
+ * resolved principal + memberships, list orgs, manage members and email
+ * invites (owner-gated), and read the control-plane audit trail. All routes use
+ * the existing SIWX auth; authorization is a membership lookup, never
+ * `wallet == signer`.
+ *
+ * Sub-resources are grouped so the surface scales: `r.org.members.*` and
+ * `r.org.invites.*`. Org-level reads stay on the namespace itself
+ * (`r.org.whoami` / `r.org.list` / `r.org.audit`).
  */
 
 import type { Client } from "../kernel.js";
 import { LocalError } from "../errors.js";
 import type {
   AddMemberInput,
+  AuditEvent,
+  AuditOptions,
+  CreateInviteInput,
   MemberMutationResult,
   MemberRevokeResult,
+  OrgInvite,
+  OrgInviteRevokeResult,
   OrgMember,
   OrgMembership,
   OrgRole,
   WhoAmIResult,
 } from "./org.types.js";
 
-export class Org {
+function requireBa(billingAccountId: string, method: string, context: string): void {
+  if (!billingAccountId) {
+    throw new LocalError(`${method} requires a billing_account_id`, context);
+  }
+}
+
+/** Member management — `r.org.members.*`. */
+export class OrgMembers {
   constructor(private readonly client: Client) {}
+
+  /** List members of an org (`GET /orgs/v1/:billing_account_id/members`). Any active member. */
+  async list(billingAccountId: string): Promise<OrgMember[]> {
+    requireBa(billingAccountId, "org.members.list", "listing org members");
+    const res = await this.client.request<{ members: OrgMember[] }>(
+      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members`,
+      { context: "listing org members" },
+    );
+    return res.members ?? [];
+  }
+
+  /**
+   * Add a member by wallet (`POST /orgs/v1/:billing_account_id/members`).
+   * Requires an active `owner` membership. A brand-new wallet is provisioned as
+   * a `human` principal; `role` defaults to `"developer"` server-side.
+   */
+  async add(billingAccountId: string, input: AddMemberInput): Promise<MemberMutationResult> {
+    requireBa(billingAccountId, "org.members.add", "adding org member");
+    if (!input?.wallet) {
+      throw new LocalError("org.members.add requires { wallet }", "adding org member");
+    }
+    const body: Record<string, unknown> = { wallet: input.wallet };
+    if (input.role !== undefined) body.role = input.role;
+    return this.client.request<MemberMutationResult>(
+      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members`,
+      { method: "POST", body, context: "adding org member" },
+    );
+  }
+
+  /**
+   * Change a member's role (`PATCH …/members/:principal_id`). Requires `owner`;
+   * demoting the org's only active owner fails with `409 LAST_OWNER`.
+   */
+  async setRole(billingAccountId: string, principalId: string, role: OrgRole): Promise<MemberMutationResult> {
+    requireBa(billingAccountId, "org.members.setRole", "setting member role");
+    if (!principalId) throw new LocalError("org.members.setRole requires a principalId", "setting member role");
+    if (!role) throw new LocalError("org.members.setRole requires a role", "setting member role");
+    return this.client.request<MemberMutationResult>(
+      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members/${encodeURIComponent(principalId)}`,
+      { method: "PATCH", body: { role }, context: "setting member role" },
+    );
+  }
+
+  /**
+   * Revoke a member (`DELETE …/members/:principal_id`) — one row, status
+   * `revoked`, no key rotation. Requires `owner`; revoking the org's only active
+   * owner fails with `409 LAST_OWNER`.
+   */
+  async revoke(billingAccountId: string, principalId: string): Promise<MemberRevokeResult> {
+    requireBa(billingAccountId, "org.members.revoke", "revoking org member");
+    if (!principalId) throw new LocalError("org.members.revoke requires a principalId", "revoking org member");
+    return this.client.request<MemberRevokeResult>(
+      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members/${encodeURIComponent(principalId)}`,
+      { method: "DELETE", context: "revoking org member" },
+    );
+  }
+}
+
+/** Email-invite management — `r.org.invites.*`. */
+export class OrgInvites {
+  constructor(private readonly client: Client) {}
+
+  /** List pending email invites (`GET /orgs/v1/:billing_account_id/invites`). Any active member. */
+  async list(billingAccountId: string): Promise<OrgInvite[]> {
+    requireBa(billingAccountId, "org.invites.list", "listing org invites");
+    const res = await this.client.request<{ invites: OrgInvite[] }>(
+      `/orgs/v1/${encodeURIComponent(billingAccountId)}/invites`,
+      { context: "listing org invites" },
+    );
+    return res.invites ?? [];
+  }
+
+  /**
+   * Invite a person by email (`POST …/invites`); claimed at their first login.
+   * Requires `owner` (plus step-up when driven by a control-plane session).
+   */
+  async create(billingAccountId: string, input: CreateInviteInput): Promise<OrgInvite> {
+    requireBa(billingAccountId, "org.invites.create", "creating org invite");
+    if (!input?.email) throw new LocalError("org.invites.create requires { email }", "creating org invite");
+    if (!input?.role) throw new LocalError("org.invites.create requires { role }", "creating org invite");
+    const body: Record<string, unknown> = { email: input.email, role: input.role };
+    if (input.inviteTtlHours !== undefined) body.invite_ttl_hours = input.inviteTtlHours;
+    return this.client.request<OrgInvite>(
+      `/orgs/v1/${encodeURIComponent(billingAccountId)}/invites`,
+      { method: "POST", body, context: "creating org invite" },
+    );
+  }
+
+  /** Revoke a pending invite by its pending principal id (`DELETE …/invites/:principal_id`). Requires `owner`. */
+  async revoke(billingAccountId: string, principalId: string): Promise<OrgInviteRevokeResult> {
+    requireBa(billingAccountId, "org.invites.revoke", "revoking org invite");
+    if (!principalId) throw new LocalError("org.invites.revoke requires a principalId", "revoking org invite");
+    return this.client.request<OrgInviteRevokeResult>(
+      `/orgs/v1/${encodeURIComponent(billingAccountId)}/invites/${encodeURIComponent(principalId)}`,
+      { method: "DELETE", context: "revoking org invite" },
+    );
+  }
+}
+
+export class Org {
+  /** Member management (`r.org.members.*`). */
+  readonly members: OrgMembers;
+  /** Email-invite management (`r.org.invites.*`). */
+  readonly invites: OrgInvites;
+
+  constructor(private readonly client: Client) {
+    this.members = new OrgMembers(client);
+    this.invites = new OrgInvites(client);
+  }
 
   /**
    * Resolve the caller's control-plane principal and its org memberships
@@ -39,82 +165,21 @@ export class Org {
     return res.orgs ?? [];
   }
 
-  /** List members of an org (`GET /orgs/v1/:billing_account_id/members`). */
-  async members(billingAccountId: string): Promise<OrgMember[]> {
-    requireBa(billingAccountId, "org.members", "listing org members");
-    const res = await this.client.request<{ members: OrgMember[] }>(
-      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members`,
-      { context: "listing org members" },
-    );
-    return res.members ?? [];
-  }
-
   /**
-   * Add a member to an org by wallet (`POST /orgs/v1/:billing_account_id/members`).
-   * Requires an active `owner` membership. A brand-new wallet is provisioned as
-   * a `human` principal. `role` defaults to `"developer"` server-side.
+   * Control-plane audit trail for an org (`GET /orgs/v1/:billing_account_id/audit`).
+   * admin+. Newest-first; page with the `before` cursor.
    */
-  async addMember(
-    billingAccountId: string,
-    input: AddMemberInput,
-  ): Promise<MemberMutationResult> {
-    requireBa(billingAccountId, "org.addMember", "adding org member");
-    if (!input?.wallet) {
-      throw new LocalError("org.addMember requires { wallet }", "adding org member");
-    }
-    const body: Record<string, unknown> = { wallet: input.wallet };
-    if (input.role !== undefined) body.role = input.role;
-    return this.client.request<MemberMutationResult>(
-      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members`,
-      { method: "POST", body, context: "adding org member" },
+  async audit(billingAccountId: string, opts: AuditOptions = {}): Promise<AuditEvent[]> {
+    requireBa(billingAccountId, "org.audit", "reading org audit trail");
+    const parts: string[] = [];
+    if (opts.limit !== undefined) parts.push(`limit=${encodeURIComponent(String(opts.limit))}`);
+    if (opts.before !== undefined) parts.push(`before=${encodeURIComponent(opts.before)}`);
+    const q = parts.join("&");
+    const base = `/orgs/v1/${encodeURIComponent(billingAccountId)}/audit`;
+    const res = await this.client.request<{ events?: AuditEvent[]; audit_events?: AuditEvent[] }>(
+      q ? `${base}?${q}` : base,
+      { context: "reading org audit trail" },
     );
-  }
-
-  /**
-   * Change a member's role (`PATCH /orgs/v1/:billing_account_id/members/:principal_id`).
-   * Requires an active `owner` membership. Demoting the org's only active owner
-   * fails with `409 LAST_OWNER`.
-   */
-  async setRole(
-    billingAccountId: string,
-    principalId: string,
-    role: OrgRole,
-  ): Promise<MemberMutationResult> {
-    requireBa(billingAccountId, "org.setRole", "setting member role");
-    if (!principalId) {
-      throw new LocalError("org.setRole requires a principalId", "setting member role");
-    }
-    if (!role) {
-      throw new LocalError("org.setRole requires a role", "setting member role");
-    }
-    return this.client.request<MemberMutationResult>(
-      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members/${encodeURIComponent(principalId)}`,
-      { method: "PATCH", body: { role }, context: "setting member role" },
-    );
-  }
-
-  /**
-   * Remove a member (`DELETE /orgs/v1/:billing_account_id/members/:principal_id`).
-   * Requires an active `owner` membership. Removing the org's only active owner
-   * fails with `409 LAST_OWNER`.
-   */
-  async removeMember(
-    billingAccountId: string,
-    principalId: string,
-  ): Promise<MemberRevokeResult> {
-    requireBa(billingAccountId, "org.removeMember", "removing org member");
-    if (!principalId) {
-      throw new LocalError("org.removeMember requires a principalId", "removing org member");
-    }
-    return this.client.request<MemberRevokeResult>(
-      `/orgs/v1/${encodeURIComponent(billingAccountId)}/members/${encodeURIComponent(principalId)}`,
-      { method: "DELETE", context: "removing org member" },
-    );
-  }
-}
-
-function requireBa(billingAccountId: string, method: string, context: string): void {
-  if (!billingAccountId) {
-    throw new LocalError(`${method} requires a billing_account_id`, context);
+    return res.events ?? res.audit_events ?? [];
   }
 }

--- a/sdk/src/namespaces/org.types.ts
+++ b/sdk/src/namespaces/org.types.ts
@@ -84,9 +84,50 @@ export interface MemberMutationResult {
   [key: string]: unknown;
 }
 
-/** Result of {@link Org.removeMember} (`{ status:"revoked", principal_id }`). */
+/** Result of {@link OrgMembers.revoke} (`{ status:"revoked", principal_id }`). */
 export interface MemberRevokeResult {
   status: string;
   principal_id: string;
+  [key: string]: unknown;
+}
+
+/** Input to {@link OrgInvites.create} — invite a person by email at a role. */
+export interface CreateInviteInput {
+  email: string;
+  role: OrgRole;
+  /** Optional invite lifetime in hours; gateway default applies when omitted. */
+  inviteTtlHours?: number;
+}
+
+/**
+ * A pending email invite from {@link OrgInvites.list} (`GET /orgs/v1/:ba/invites`).
+ * Represented by a pending `principal_id` — pass it to {@link OrgInvites.revoke}.
+ */
+export interface OrgInvite {
+  principal_id: string;
+  email: string;
+  role: OrgRole;
+  status: string;
+  expires_at?: string;
+  [key: string]: unknown;
+}
+
+/** Result of {@link OrgInvites.revoke} (`{ status:"revoked", principal_id }`). */
+export interface OrgInviteRevokeResult {
+  status: string;
+  principal_id: string;
+  [key: string]: unknown;
+}
+
+/** Options for {@link Org.audit}. */
+export interface AuditOptions {
+  /** Page size; gateway default applies when omitted. */
+  limit?: number;
+  /** Cursor — return events before this opaque marker. */
+  before?: string;
+}
+
+/** One control-plane audit event from {@link Org.audit}. Shape is gateway-owned (forward-compatible). */
+export interface AuditEvent {
   [key: string]: unknown;
 }

--- a/sdk/src/namespaces/transfers.test.ts
+++ b/sdk/src/namespaces/transfers.test.ts
@@ -348,3 +348,64 @@ describe("TransferFreezeError", () => {
     }
   });
 });
+
+describe("admin.transfers — email->org handoff (v1.78)", () => {
+  it("initiateHandoff POSTs /handoffs with snake_case to_email", async () => {
+    const { fetch, calls } = mockFetch((call) => {
+      assert.equal(call.method, "POST");
+      assert.equal(call.url, "https://api.example.test/projects/v1/prj_abc/handoffs");
+      assert.deepEqual(JSON.parse(String(call.body)), { to_email: "x@y.z", message: "hi" });
+      return jsonResponse({ transfer_id: "hof_1", expires_at: "2026-06-10T00:00:00Z" });
+    });
+    const res = await makeSdk(fetch).admin.transfers.initiateHandoff({
+      projectId: "prj_abc",
+      toEmail: "x@y.z",
+      message: "hi",
+    });
+    assert.equal(res.transfer_id, "hof_1");
+    assert.equal(calls.length, 1);
+  });
+
+  it("listIncomingHandoffs unwraps { handoffs }, falls back to { transfers } then []", async () => {
+    const r1 = makeSdk(mockFetch(() => jsonResponse({ handoffs: [{ transfer_id: "hof_1", project_id: "prj_abc" }] })).fetch);
+    assert.equal((await r1.admin.transfers.listIncomingHandoffs())[0].transfer_id, "hof_1");
+    const r2 = makeSdk(mockFetch(() => jsonResponse({ transfers: [{ transfer_id: "hof_2", project_id: "prj_x" }] })).fetch);
+    assert.equal((await r2.admin.transfers.listIncomingHandoffs())[0].transfer_id, "hof_2");
+    const r3 = makeSdk(mockFetch(() => jsonResponse({})).fetch);
+    assert.deepEqual(await r3.admin.transfers.listIncomingHandoffs(), []);
+  });
+
+  it("previewHandoff GETs /agent/v1/handoffs/:id", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      jsonResponse({ transfer_id: "hof_1", project_id: "prj_abc", status: "pending" }),
+    );
+    const p = await makeSdk(fetch).admin.transfers.previewHandoff("hof_1");
+    assert.equal(calls[0].url, "https://api.example.test/agent/v1/handoffs/hof_1");
+    assert.equal(p.project_id, "prj_abc");
+  });
+
+  it("claimHandoff POSTs /claim with billing_account_id when given, {} otherwise", async () => {
+    const r1 = mockFetch((call) => {
+      assert.equal(call.url, "https://api.example.test/agent/v1/handoffs/hof_1/claim");
+      assert.deepEqual(JSON.parse(String(call.body)), { billing_account_id: "ba_9" });
+      return jsonResponse({ project_id: "prj_abc", new_billing_account_id: "ba_9" });
+    });
+    await makeSdk(r1.fetch).admin.transfers.claimHandoff("hof_1", { billingAccountId: "ba_9" });
+
+    const r2 = mockFetch((call) => {
+      assert.deepEqual(JSON.parse(String(call.body)), {});
+      return jsonResponse({ project_id: "prj_abc", new_billing_account_id: "ba_new" });
+    });
+    const res = await makeSdk(r2.fetch).admin.transfers.claimHandoff("hof_1");
+    assert.equal(res.new_billing_account_id, "ba_new");
+  });
+
+  it("cancelHandoff POSTs /agent/v1/handoffs/:id/cancel", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      jsonResponse({ transfer_id: "hof_1", status: "cancelled", cancelled_by: "from_wallet", cancellation_reason: null, cancelled_at: "2026-06-08T00:00:00Z" }),
+    );
+    await makeSdk(fetch).admin.transfers.cancelHandoff("hof_1");
+    assert.equal(calls[0].url, "https://api.example.test/agent/v1/handoffs/hof_1/cancel");
+    assert.equal(calls[0].method, "POST");
+  });
+});

--- a/sdk/src/namespaces/transfers.ts
+++ b/sdk/src/namespaces/transfers.ts
@@ -182,6 +182,54 @@ export interface ProjectTransferPreview {
   billing_implications: BillingImplications;
 }
 
+// ─── Email→org handoff (v1.78) — same rail, email recipient ────────────────────
+
+/** Inputs to {@link Transfers.initiateHandoff}. */
+export interface InitiateHandoffInput {
+  /** Project id to hand off. Caller must currently own it. */
+  projectId: string;
+  /** Recipient email; claimed at the recipient's first login. */
+  toEmail: string;
+  /** Optional note shown to the recipient (HTML-escaped server-side). */
+  message?: string;
+}
+
+/** Result of {@link Transfers.initiateHandoff}. Forward-compatible (gateway owns the exact shape). */
+export interface HandoffResult {
+  transfer_id: string;
+  expires_at?: string;
+  [key: string]: unknown;
+}
+
+/** Summary row from `GET /agent/v1/handoffs/incoming`. Forward-compatible. */
+export interface HandoffSummary {
+  transfer_id: string;
+  project_id: string;
+  to_email?: string;
+  [key: string]: unknown;
+}
+
+/** Preview from `GET /agent/v1/handoffs/:transfer_id`. Forward-compatible. */
+export interface ProjectHandoffPreview {
+  transfer_id: string;
+  project_id: string;
+  status?: TransferStatus | string;
+  [key: string]: unknown;
+}
+
+/** Inputs to {@link Transfers.claimHandoff}. */
+export interface ClaimHandoffInput {
+  /** Org (billing account) to claim into. Omit to claim into a brand-new org. */
+  billingAccountId?: string;
+}
+
+/** Result of {@link Transfers.claimHandoff}. Forward-compatible. */
+export interface ClaimHandoffResult {
+  project_id: string;
+  new_billing_account_id?: string | null;
+  [key: string]: unknown;
+}
+
 // ─── Class ───────────────────────────────────────────────────────────────────
 
 export class Transfers {
@@ -276,6 +324,65 @@ export class Transfers {
       context: "listing outgoing transfers",
     });
     return res.transfers;
+  }
+
+  // ── Email→org handoff (v1.78) ─────────────────────────────────────────────
+  // Same transfer rail, but the recipient is an EMAIL (resolved to an org at
+  // claim time) rather than a wallet. The caller must own the project; the
+  // recipient claims into an org they own (or a brand-new one). Exposed under
+  // the same `transfer` noun on the CLI (`transfer init --to <email>`).
+
+  /**
+   * Initiate an email→org handoff of `projectId` to `toEmail`. Like a wallet
+   * transfer, freezes owner-side mutations until the recipient claims, the
+   * sender cancels, or it expires.
+   */
+  async initiateHandoff(input: InitiateHandoffInput): Promise<HandoffResult> {
+    const body: Record<string, unknown> = { to_email: input.toEmail };
+    if (input.message !== undefined) body.message = input.message;
+    return this.client.request<HandoffResult>(
+      `/projects/v1/${encodeURIComponent(input.projectId)}/handoffs`,
+      { method: "POST", body, context: "initiating project handoff" },
+    );
+  }
+
+  /** Pending handoffs addressed to the authenticated principal's email. */
+  async listIncomingHandoffs(): Promise<HandoffSummary[]> {
+    const res = await this.client.request<{ handoffs?: HandoffSummary[]; transfers?: HandoffSummary[] }>(
+      "/agent/v1/handoffs/incoming",
+      { context: "listing incoming handoffs" },
+    );
+    return res.handoffs ?? res.transfers ?? [];
+  }
+
+  /** Preview a handoff (sender, or the addressed recipient). */
+  async previewHandoff(transferId: string): Promise<ProjectHandoffPreview> {
+    return this.client.request<ProjectHandoffPreview>(
+      `/agent/v1/handoffs/${encodeURIComponent(transferId)}`,
+      { context: "previewing project handoff" },
+    );
+  }
+
+  /**
+   * Claim an incoming handoff into an org. Omit `billingAccountId` to claim
+   * into a brand-new org. The claim atomically flips ownership (the handoff
+   * analog of {@link Transfers.accept}).
+   */
+  async claimHandoff(transferId: string, input: ClaimHandoffInput = {}): Promise<ClaimHandoffResult> {
+    const body: Record<string, unknown> = {};
+    if (input.billingAccountId !== undefined) body.billing_account_id = input.billingAccountId;
+    return this.client.request<ClaimHandoffResult>(
+      `/agent/v1/handoffs/${encodeURIComponent(transferId)}/claim`,
+      { method: "POST", body, context: "claiming project handoff" },
+    );
+  }
+
+  /** Cancel a pending handoff (sender or recipient). */
+  async cancelHandoff(transferId: string): Promise<CancelTransferResult> {
+    return this.client.request<CancelTransferResult>(
+      `/agent/v1/handoffs/${encodeURIComponent(transferId)}/cancel`,
+      { method: "POST", body: {}, context: "cancelling project handoff" },
+    );
   }
 }
 

--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -64,7 +64,7 @@ export const listOrgMembersSchema = {
 
 export async function handleListOrgMembers(args: { billing_account_id: string }): Promise<ToolResult> {
   try {
-    const members = await getSdk().org.members(args.billing_account_id);
+    const members = await getSdk().org.members.list(args.billing_account_id);
     if (members.length === 0) {
       return { content: [{ type: "text", text: `No members in \`${args.billing_account_id}\`.` }] };
     }
@@ -92,7 +92,7 @@ export async function handleAddOrgMember(args: {
   role?: OrgRole;
 }): Promise<ToolResult> {
   try {
-    const res = await getSdk().org.addMember(args.billing_account_id, {
+    const res = await getSdk().org.members.add(args.billing_account_id, {
       wallet: args.wallet,
       role: args.role,
     });
@@ -123,7 +123,7 @@ export async function handleSetOrgMemberRole(args: {
   role: OrgRole;
 }): Promise<ToolResult> {
   try {
-    const res = await getSdk().org.setRole(args.billing_account_id, args.principal_id, args.role);
+    const res = await getSdk().org.members.setRole(args.billing_account_id, args.principal_id, args.role);
     return {
       content: [{ type: "text", text: `Principal \`${res.principal_id}\` is now ${res.role}.` }],
     };
@@ -144,7 +144,7 @@ export async function handleRemoveOrgMember(args: {
   principal_id: string;
 }): Promise<ToolResult> {
   try {
-    const res = await getSdk().org.removeMember(args.billing_account_id, args.principal_id);
+    const res = await getSdk().org.members.revoke(args.billing_account_id, args.principal_id);
     return {
       content: [{ type: "text", text: `Removed principal \`${res.principal_id}\` from \`${args.billing_account_id}\`.` }],
     };

--- a/sync.test.ts
+++ b/sync.test.ts
@@ -73,6 +73,8 @@ function parseCliCommands(): string[] {
   for (const action of parseJobsArtifactsActions()) {
     cmds.push(`jobs:artifacts:${action}`);
   }
+  for (const action of parseOrgGroupActions("memberAction")) cmds.push(`org:member:${action}`);
+  for (const action of parseOrgGroupActions("inviteAction")) cmds.push(`org:invite:${action}`);
   if (existsSync(join(__dirname, "cli/lib/init.mjs"))) cmds.push("init");
   if (existsSync(join(__dirname, "cli/lib/status.mjs"))) cmds.push("status");
   if (existsSync(join(__dirname, "cli/lib/doctor.mjs"))) cmds.push("doctor");
@@ -95,6 +97,8 @@ function parseOpenClawCommands(): string[] {
   for (const action of parseJobsArtifactsActions()) {
     cmds.push(`jobs:artifacts:${action}`);
   }
+  for (const action of parseOrgGroupActions("memberAction")) cmds.push(`org:member:${action}`);
+  for (const action of parseOrgGroupActions("inviteAction")) cmds.push(`org:invite:${action}`);
   if (existsSync(join(__dirname, "openclaw/scripts/init.mjs"))) cmds.push("init");
   if (existsSync(join(__dirname, "openclaw/scripts/status.mjs"))) cmds.push("status");
   if (existsSync(join(__dirname, "openclaw/scripts/doctor.mjs"))) cmds.push("doctor");
@@ -127,6 +131,21 @@ function parseJobsArtifactsActions(): string[] {
   let m;
   while ((m = re.exec(src))) actions.push(m[1]);
   return [...new Set(actions)].sort();
+}
+
+/** Parse the nested `org member <action>` / `org invite <action>` leaf actions
+ *  from cli/lib/org.mjs (matched on `memberAction === "..."` / `inviteAction ===
+ *  "..."`), mirroring `jobs artifacts`. The groups dispatch via `if (sub === ...)`
+ *  so parseSubcommands skips them; these surface their leaves instead. */
+function parseOrgGroupActions(varName: "memberAction" | "inviteAction"): string[] {
+  const filePath = join(__dirname, "cli/lib/org.mjs");
+  if (!existsSync(filePath)) return [];
+  const src = readFileSync(filePath, "utf-8");
+  const actions: string[] = [];
+  const re = new RegExp(`${varName}\\s*===\\s*"([\\w-]+)"`, "g");
+  let m;
+  while ((m = re.exec(src))) actions.push(m[1]);
+  return [...new Set(actions)].filter((c) => c !== "help" && !c.startsWith("-")).sort();
 }
 
 // ─── Canonical API surface ───────────────────────────────────────────────────
@@ -364,10 +383,14 @@ const SURFACE: Capability[] = [
   // ── Org-owned control plane: identity, membership, grants (v1.77+) ──────
   { id: "whoami",              endpoint: "GET /agent/v1/whoami",                          mcp: "whoami",                cli: "org:whoami",        openclaw: "org:whoami" },
   { id: "list_orgs",           endpoint: "GET /orgs/v1",                                  mcp: "list_orgs",             cli: "org:list",          openclaw: "org:list" },
-  { id: "list_org_members",    endpoint: "GET /orgs/v1/:ba/members",                      mcp: "list_org_members",      cli: "org:members",       openclaw: "org:members" },
-  { id: "add_org_member",      endpoint: "POST /orgs/v1/:ba/members",                     mcp: "add_org_member",        cli: "org:add-member",    openclaw: "org:add-member" },
-  { id: "set_org_member_role", endpoint: "PATCH /orgs/v1/:ba/members/:principal_id",      mcp: "set_org_member_role",   cli: "org:set-role",      openclaw: "org:set-role" },
-  { id: "remove_org_member",   endpoint: "DELETE /orgs/v1/:ba/members/:principal_id",     mcp: "remove_org_member",     cli: "org:remove-member", openclaw: "org:remove-member" },
+  { id: "list_org_members",    endpoint: "GET /orgs/v1/:ba/members",                      mcp: "list_org_members",      cli: "org:member:list",   openclaw: "org:member:list" },
+  { id: "add_org_member",      endpoint: "POST /orgs/v1/:ba/members",                     mcp: "add_org_member",        cli: "org:member:add",    openclaw: "org:member:add" },
+  { id: "set_org_member_role", endpoint: "PATCH /orgs/v1/:ba/members/:principal_id",      mcp: "set_org_member_role",   cli: "org:member:role",   openclaw: "org:member:role" },
+  { id: "remove_org_member",   endpoint: "DELETE /orgs/v1/:ba/members/:principal_id",     mcp: "remove_org_member",     cli: "org:member:rm",     openclaw: "org:member:rm" },
+  { id: "org_audit",           endpoint: "GET /orgs/v1/:ba/audit",                        mcp: null,                    cli: "org:audit",         openclaw: "org:audit" },
+  { id: "org_invite_list",     endpoint: "GET /orgs/v1/:ba/invites",                      mcp: null,                    cli: "org:invite:list",   openclaw: "org:invite:list" },
+  { id: "org_invite_create",   endpoint: "POST /orgs/v1/:ba/invites",                     mcp: null,                    cli: "org:invite:create", openclaw: "org:invite:create" },
+  { id: "org_invite_rm",       endpoint: "DELETE /orgs/v1/:ba/invites/:principal_id",     mcp: null,                    cli: "org:invite:rm",     openclaw: "org:invite:rm" },
   { id: "create_project_grant", endpoint: "POST /projects/v1/:id/grants",                 mcp: "create_project_grant",  cli: "grants:create",     openclaw: "grants:create" },
   { id: "revoke_project_grant", endpoint: "DELETE /projects/v1/:id/grants/:grant_id",     mcp: "revoke_project_grant",  cli: "grants:revoke",     openclaw: "grants:revoke" },
 
@@ -634,10 +657,14 @@ const SDK_BY_CAPABILITY: Record<string, string | null> = {
   // Org-owned control plane (v1.77+) — r.org.* + r.grants.*
   whoami: "org.whoami",
   list_orgs: "org.list",
-  list_org_members: "org.members",
-  add_org_member: "org.addMember",
-  set_org_member_role: "org.setRole",
-  remove_org_member: "org.removeMember",
+  list_org_members: "org.members.list",
+  add_org_member: "org.members.add",
+  set_org_member_role: "org.members.setRole",
+  remove_org_member: "org.members.revoke",
+  org_audit: "org.audit",
+  org_invite_list: "org.invites.list",
+  org_invite_create: "org.invites.create",
+  org_invite_rm: "org.invites.revoke",
   create_project_grant: "grants.create",
   revoke_project_grant: "grants.revoke",
 

--- a/sync.test.ts
+++ b/sync.test.ts
@@ -358,6 +358,7 @@ const SURFACE: Capability[] = [
   { id: "accept_project_transfer",   endpoint: "POST /agent/v1/transfers/:transfer_id/accept",  mcp: "accept_project_transfer",   cli: "transfer:accept",  openclaw: "transfer:accept" },
   { id: "cancel_project_transfer",   endpoint: "POST /agent/v1/transfers/:transfer_id/cancel",  mcp: "cancel_project_transfer",   cli: "transfer:cancel",  openclaw: "transfer:cancel" },
   { id: "list_incoming_transfers",   endpoint: "GET /agent/v1/transfers/incoming",              mcp: "list_incoming_transfers",   cli: "transfer:list",    openclaw: "transfer:list" },
+  { id: "claim_project_handoff",     endpoint: "POST /agent/v1/handoffs/:transfer_id/claim",    mcp: null,                        cli: "transfer:claim",   openclaw: "transfer:claim" },
   { id: "list_outgoing_transfers",   endpoint: "GET /agent/v1/transfers/outgoing",              mcp: "list_outgoing_transfers",   cli: null,               openclaw: null },
 
   // ── Org-owned control plane: identity, membership, grants (v1.77+) ──────
@@ -639,6 +640,15 @@ const SDK_BY_CAPABILITY: Record<string, string | null> = {
   remove_org_member: "org.removeMember",
   create_project_grant: "grants.create",
   revoke_project_grant: "grants.revoke",
+
+  // Email->org handoff (v1.78) — same `transfer` noun, email recipient.
+  // `claim` is its own CLI verb (SURFACE entry); the rest route through the
+  // existing init/list/preview/cancel verbs, so they map here only (orphan-sat).
+  initiate_project_handoff: "admin.transfers.initiateHandoff",
+  list_incoming_handoffs: "admin.transfers.listIncomingHandoffs",
+  preview_project_handoff: "admin.transfers.previewHandoff",
+  claim_project_handoff: "admin.transfers.claimHandoff",
+  cancel_project_handoff: "admin.transfers.cancelHandoff",
 
   // Auth
   request_magic_link: "auth.requestMagicLink",
@@ -958,6 +968,10 @@ describe("SDK surface alignment", () => {
       // devicePoll shares the `login` verb (no dedicated capability), like the
       // cache.invalidate* variants above.
       "operator.devicePoll",
+      // Loopback-PKCE write-login (v1.78): both helpers are part of the
+      // `operator login --loopback` ceremony, with no dedicated capability.
+      "operator.buildCliAuthorizeUrl",
+      "operator.exchangeCliToken",
     ]);
 
     const sdkMethods = await listSdkMethods();


### PR DESCRIPTION
## #444 public cascade — `org.*`, transfer email handoff, `StepUpRequiredError`, operator loopback login

Implements the public SDK/CLI surface for the v1.77/1.78 control-plane (the cascade tracked in #444), built to the published gateway contract and reconciled onto the existing nouns (`operator`, `transfer`) rather than new ones.

### 1. `org.*` — membership & invites (SIWX-compatible)
- **SDK:** `r.org.list()` · `r.org.audit()` · `r.org.members.{list,add,setRole,revoke}` · `r.org.invites.{list,create,revoke}`. Owner-gated, last-owner-guard documented; types re-exported from the root.
- **CLI:** `run402 org list | audit | member add|role|rm | invite create|list|rm`.

### 2. Transfer email→org handoff (one noun, two rails)
- **SDK:** `r.admin.transfers.{initiateHandoff,listIncomingHandoffs,previewHandoff,claimHandoff,cancelHandoff}`.
- **CLI:** `run402 transfer init --to <wallet|email>` routes by recipient; adds `transfer claim` and `--handoff`/`--handoffs` on `cancel`/`preview`/`list`. (Live-verified end-to-end against prod: init → list → cancel `--handoff`.)

### 3. `StepUpRequiredError`
- 403 `code=STEP_UP_REQUIRED` maps to a typed error exposing `requiredAmr` / `maxAgeSeconds` / `challengeUrl` / `reason` + the canonical `next_actions[]`. `isStepUpRequired` guard; exported from the SDK root. A plain 403 still maps to `Unauthorized`.

### 4. `operator login` loopback-PKCE write-login
- **SDK:** `r.operator.{buildCliAuthorizeUrl,exchangeCliToken}` + `ControlPlaneSession`.
- **CLI:** `run402 operator login --loopback` / `--step-up` runs the RFC 8252 loopback ceremony (PKCE S256, 127.0.0.1 redirect, browser passkey) and caches a write-capable session (mode 0600, metadata-only output). Device-flow read login stays the default; `whoami`/`logout` handle both sessions.

### Tests
- Full suite green: **1297 unit + 614 CLI e2e, 0 fail.** New unit tests for the step-up envelope mapping, handoff methods, and the loopback seam.
- `sync.test.ts` SURFACE + `SDK_BY_CAPABILITY` updated so MCP/CLI/OpenClaw/SDK parity stays enforced (`org` module, `transfer:claim`, handoff/loopback methods).

### Notes for review
- New CLI capabilities are `mcp: null` for now (MCP tools can follow).
- This branch was cut before recent `main` activity and needs a rebase/integration on merge.
- Release: lockstep **minor** (`2.33.1 → 2.34.0`) via `/publish` from `main` after merge.

Closes part of #444.
