### PR TITLE
fix: handle MCP metadata flags before startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,30 @@
 #!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import packageJson from "../package.json" with { type: "json" };
+
+function handleCliMetadata(argv = process.argv.slice(2)): boolean {
+  const flags = new Set(argv);
+  if (flags.has("--version") || flags.has("-v")) {
+    console.log(packageJson.version);
+    return true;
+  }
+  if (flags.has("--help") || flags.has("-h")) {
+    console.log(`Usage: run402-mcp [options]
+
+Options:
+  -v, --version  Print the package version.
+  -h, --help     Print this help message.
+
+Run without options to start the Run402 MCP server over stdio.`);
+    return true;
+  }
+  return false;
+}
+
+if (handleCliMetadata()) {
+  process.exit(0);
+}
 
 // Existing tools
 import { provisionSchema, handleProvision } from "./tools/provision.js";


### PR DESCRIPTION
## Summary
- add `run402-mcp --version` / `-v` output sourced from `package.json`
- add `run402-mcp --help` / `-h` usage output
- short-circuit these metadata flags before constructing and connecting the MCP stdio server

## Reproduction
The published `run402-mcp@2.40.0` currently accepts metadata flags but prints nothing:

```sh
npm exec --yes --package=run402-mcp -- run402-mcp --version
npm exec --yes --package=run402-mcp -- run402-mcp --help
```

That makes install/version checks difficult for MCP clients and users debugging `npx` setup.

## Verification
- `npm install`
- `$env:npm_config_script_shell='C:\Program Files\Git\bin\bash.exe'; npm run build`
- `node dist/index.js --version` -> `2.40.0`
- `node dist/index.js -v` -> `2.40.0`
- `node dist/index.js --help` prints usage and exits without starting stdio

Note: on Windows, the repo build script needs `npm_config_script_shell` pointed at Git Bash because it uses POSIX commands such as `rm`, `mkdir -p`, and `cp`.