### PR TITLE
fix(cli): login membership echo printed 'undefined' for org names

### DIFF
--- a/cli/lib/operator.mjs
+++ b/cli/lib/operator.mjs
@@ -289,7 +289,7 @@ async function loopbackLogin(args, { stepUp }) {
     if (memberships.length) {
       process.stderr.write(
         `Member of ${memberships.length} org(s):\n` +
-          memberships.map((m) => `  - ${m.billing_account_id} (${m.role}, ${m.status})`).join("\n") +
+          memberships.map((m) => `  - ${m.display_name || m.org_id || m.billing_account_id} (${m.role}, ${m.status})`).join("\n") +
           "\n",
       );
     }


### PR DESCRIPTION
The loopback-login stderr echo still read `m.billing_account_id` after the 2.42.0 `org_id` wire rename, so it printed `- undefined (owner, active)`. Now reads `display_name || org_id` (old field kept as last-resort fallback). Cosmetic; JSON output was already correct. Rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)