### PR TITLE
feat(mcp): get_schema renders per-table row estimate (Anticipatory)

### DIFF
--- a/sdk/src/namespaces/projects.types.ts
+++ b/sdk/src/namespaces/projects.types.ts
@@ -224,6 +224,13 @@ export interface TableSchema {
   columns: ColumnSchema[];
   constraints: ConstraintSchema[];
   rls_enabled: boolean;
+  /**
+   * Planner row estimate (`reltuples`), refreshed by ANALYZE/VACUUM. Always an
+   * estimate, never an exact count. `null` when the table was never analyzed
+   * (so "unknown" stays distinguishable from a real zero); may be absent from
+   * gateways predating the field.
+   */
+  row_estimate?: number | null;
   policies: RlsPolicy[];
 }
 

--- a/src/tools/get-schema.test.ts
+++ b/src/tools/get-schema.test.ts
@@ -118,4 +118,45 @@ describe("get_schema tool", () => {
     assert.ok(text.includes("USING true"));
     assert.ok(!text.includes("WITH CHECK"), "a null check_expression must not render");
   });
+
+  it("renders row_estimate as a labeled estimate", async () => {
+    // Anticipatory + Faithful: surface table size, but never as an exact count.
+    stub({
+      schema: "p0001",
+      tables: [
+        {
+          name: "events",
+          columns: [{ name: "id", type: "uuid", nullable: false, default_value: null }],
+          constraints: [],
+          rls_enabled: false,
+          row_estimate: 1234,
+          policies: [],
+        },
+      ],
+    });
+
+    const result = await handleGetSchema({ project_id: "proj-1" });
+    const text = result.content[0]!.text;
+    assert.ok(text.includes("~1,234 rows (estimate)"), "row count must be shown and labeled as an estimate");
+  });
+
+  it("omits the row estimate when unknown (null / never analyzed)", async () => {
+    stub({
+      schema: "p0001",
+      tables: [
+        {
+          name: "fresh",
+          columns: [{ name: "id", type: "uuid", nullable: false, default_value: null }],
+          constraints: [],
+          rls_enabled: false,
+          row_estimate: null,
+          policies: [],
+        },
+      ],
+    });
+
+    const result = await handleGetSchema({ project_id: "proj-1" });
+    const text = result.content[0]!.text;
+    assert.ok(!text.includes("rows (estimate)"), "unknown row count must not render a misleading estimate or 0");
+  });
 });

--- a/src/tools/get-schema.ts
+++ b/src/tools/get-schema.ts
@@ -30,6 +30,12 @@ export async function handleGetSchema(args: {
 
     for (const table of body.tables) {
       lines.push(`### ${table.name}${table.rls_enabled ? " 🔒 RLS" : ""}`);
+      // The planner's row estimate (reltuples) — labeled as an estimate so the
+      // agent never mistakes it for an exact COUNT(*). Omitted when unknown
+      // (null / never-analyzed) rather than shown as a misleading 0.
+      if (typeof table.row_estimate === "number") {
+        lines.push(`_~${table.row_estimate.toLocaleString("en-US")} rows (estimate)_`);
+      }
       lines.push(``);
       lines.push(`| Column | Type | Nullable | Default |`);
       lines.push(`|--------|------|----------|---------|`);


### PR DESCRIPTION
From the `agent-response-design` backlog — pairs with run402-private#496 (gateway sends `row_estimate`, merged + deploying).

**Gap (Anticipatory):** `get_schema` gave no sense of table size — empty vs large was invisible, no signal for whether a query needs `LIMIT`.

**Change:** renders the gateway's `row_estimate` (planner `reltuples`) as `_~N rows (estimate)_` under each table header — **labeled** so it's never mistaken for an exact `COUNT(*)` (Faithful), and **omitted** when unknown/`null` (never-analyzed) rather than shown as a misleading `0`. Adds `row_estimate?: number | null` to the SDK `TableSchema` type (optional — tolerates older gateways).

Tests: +2 (labeled-estimate render, null-omit), 5/5. tsc clean (SDK rebuilt). Reaches agents after a `run402-mcp` publish.

(Replaces #459, which GitHub auto-closed when its stacked base branch was deleted on #458 merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)