### PR TITLE
feat(mcp): run_sql surfaces result column names + types (Anticipatory)

### DIFF
--- a/src/tools/run-sql.test.ts
+++ b/src/tools/run-sql.test.ts
@@ -278,4 +278,57 @@ describe("run_sql tool", () => {
     assert.equal(result.isError, true);
     assert.ok(result.content[0]!.text.includes("active project"));
   });
+
+  it("shows result columns + types for an empty SELECT (not a blind '0 rows')", async () => {
+    const result = await runWithResponse(
+      {
+        status: "ok",
+        schema: "p0001",
+        rows: [],
+        rowCount: 0,
+        fields: [
+          { name: "id", type: "uuid" },
+          { name: "email", type: "text" },
+          { name: "last_login", type: "timestamptz" },
+        ],
+      },
+      "SELECT id, email, last_login FROM users WHERE false",
+    );
+    const text = result.content[0]!.text;
+    assert.ok(text.includes("0 rows"));
+    assert.ok(
+      text.includes("Columns: id (uuid), email (text), last_login (timestamptz)"),
+      "an empty SELECT must still convey the query shape",
+    );
+  });
+
+  it("annotates a non-empty result with its column types", async () => {
+    const result = await runWithResponse(
+      {
+        status: "ok",
+        schema: "p0001",
+        rows: [{ id: 1, name: "Alice" }],
+        rowCount: 1,
+        fields: [
+          { name: "id", type: "int4" },
+          { name: "name", type: "text" },
+        ],
+      },
+      "SELECT id, name FROM users",
+    );
+    const text = result.content[0]!.text;
+    assert.ok(text.includes("1 row returned"));
+    assert.ok(text.includes("Columns: id (int4), name (text)"));
+    assert.ok(text.includes("| id | name |"), "still renders the data table");
+  });
+
+  it("stays a bare '0 rows' for a no-match mutation (no fields)", async () => {
+    const result = await runWithResponse(
+      { status: "ok", schema: "p0001", rows: [], rowCount: 0 },
+      "UPDATE t SET x = 1 WHERE false",
+    );
+    const text = result.content[0]!.text;
+    assert.ok(text.includes("0 rows"));
+    assert.ok(!text.includes("Columns:"), "a mutation has no result columns to show");
+  });
 });

--- a/src/tools/run-sql.ts
+++ b/src/tools/run-sql.ts
@@ -22,6 +22,16 @@ function formatMarkdownTable(rows: Record<string, unknown>[]): string {
   return [header, separator, ...body].join("\n");
 }
 
+/** Render the result column descriptors as a compact "Columns:" line. */
+function formatColumns(
+  fields: { name: string; type?: string }[] | undefined,
+): string | null {
+  if (!fields || fields.length === 0) return null;
+  return (
+    "Columns: " + fields.map((f) => (f.type ? `${f.name} (${f.type})` : f.name)).join(", ")
+  );
+}
+
 export async function handleRunSql(args: {
   project_id?: string;
   sql: string;
@@ -35,6 +45,7 @@ export async function handleRunSql(args: {
     schema: string;
     rows: Record<string, unknown>[];
     rowCount: number | null;
+    fields?: { name: string; type?: string }[];
   };
   try {
     body = await getSdk().projects.sql(project, args.sql, args.params) as typeof body;
@@ -42,22 +53,29 @@ export async function handleRunSql(args: {
     return mapSdkError(err, "running SQL");
   }
 
-  const { rows, rowCount, schema } = body;
+  const { rows, rowCount, schema, fields } = body;
+  const columns = formatColumns(fields);
 
   // The gateway distinguishes statement kinds by `rowCount`: a result set
   // (SELECT / ... RETURNING) populates `rows`; an INSERT/UPDATE/DELETE returns
   // `rows: []` with a numeric affected-row count; DDL returns `rowCount: null`.
   // Surface each kind explicitly — never report a mutation that changed rows
   // as "0 rows returned", which reads to an agent like the statement no-op'd.
+  // `fields` (present only for result-set queries) carries the column names +
+  // types, so an empty SELECT still conveys its shape.
   let text: string;
   if (rows.length > 0) {
-    text = `**${rows.length} row${rows.length !== 1 ? "s" : ""} returned** (schema: ${schema})\n\n${formatMarkdownTable(rows)}`;
+    const head = `**${rows.length} row${rows.length !== 1 ? "s" : ""} returned** (schema: ${schema})`;
+    text = `${head}${columns ? `\n${columns}` : ""}\n\n${formatMarkdownTable(rows)}`;
   } else if (typeof rowCount === "number" && rowCount > 0) {
     text = `**${rowCount} row${rowCount !== 1 ? "s" : ""} affected** (schema: ${schema})`;
   } else if (rowCount === 0) {
-    // A mutation that matched nothing, or an empty result set — indistinguishable
-    // here (both are rows: [], rowCount: 0), so stay neutral.
-    text = `**0 rows** (schema: ${schema})`;
+    // An empty result set OR a no-match mutation. When `fields` is present the
+    // statement was a SELECT / ... RETURNING, so surface the column shape — an
+    // empty SELECT still teaches the agent what it would have returned, instead
+    // of a blind "0 rows". Absent fields ⇒ a mutation that matched nothing.
+    const head = `**0 rows** (schema: ${schema})`;
+    text = columns ? `${head}\n${columns}` : head;
   } else {
     // DDL and other statements with no row semantics (rowCount === null).
     text = `**Statement executed** (schema: ${schema})`;


### PR DESCRIPTION
From the `agent-response-design` backlog — pairs with [run402-private#497](https://github.com/kychee-com/run402-private/pull/497) (gateway sends `fields`).

**Gap (Anticipatory + Faithful):** an empty SELECT rendered a blind `0 rows`. The agent couldn't tell a no-match from an empty table, or see the query's projection shape.

**Change:** `run_sql` now renders a `Columns: id (uuid), email (text), …` line from the gateway's new `fields` array — on empty result sets (where it matters most) and as a type annotation above non-empty tables. A no-match **mutation** (no `fields`) stays a bare `0 rows`, so the two cases are now distinguishable.

No SDK change — the `sql()` adapter already passes `fields` through via `...rest`.

Tests: +3 (empty-SELECT columns, non-empty annotation, mutation stays bare), 16/16. tsc clean. Reaches agents after a `run402-mcp` publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)