### PR TITLE
refactor(client): snake_case response fields + keyset pagination (mirror gateway audit sweeps 2+3)

### DIFF
--- a/cli/lib/billing.mjs
+++ b/cli/lib/billing.mjs
@@ -63,7 +63,7 @@ Examples:
   history: `run402 billing history — Show ledger history for a organization
 
 Usage:
-  run402 billing history <identifier> [--limit <n>]
+  run402 billing history <identifier> [--limit <n>] [--after <cursor>]
 
 Arguments:
   <identifier>        Organization id (UUID), wallet (0x...), or email.
@@ -71,6 +71,7 @@ Arguments:
 
 Options:
   --limit <n>         Max entries to return (default: 50)
+  --after <cursor>    Opaque keyset cursor (next_cursor from a prior page)
 
 Auth:
   Requires SIWX from a wallet linked to the organization (signed automatically from
@@ -317,7 +318,7 @@ async function balance(args) {
 
 async function history(args) {
   const parsedArgs = normalizeArgv(args);
-  const valueFlags = ["--limit"];
+  const valueFlags = ["--limit", "--after"];
   assertKnownFlags(parsedArgs, [...valueFlags, "--help", "-h"], valueFlags);
   const positionals = positionalArgs(parsedArgs, valueFlags);
   const id = positionals[0];
@@ -328,14 +329,15 @@ async function history(args) {
     fail({
       code: "BAD_USAGE",
       message: "Missing <identifier>.",
-      hint: "run402 billing history <org-id | wallet | email> [--limit <n>]",
+      hint: "run402 billing history <org-id | wallet | email> [--limit <n>] [--after <cursor>]",
     });
   }
   const limit = parsedArgs.includes("--limit")
     ? parseIntegerFlag("--limit", flagValue(parsedArgs, "--limit"), { min: 1 })
     : 50;
+  const after = flagValue(parsedArgs, "--after");
   try {
-    const data = await getSdk().billing.getHistory(id, limit);
+    const data = await getSdk().billing.getHistory(id, { limit, after: after ?? undefined });
     console.log(JSON.stringify(data, null, 2));
   } catch (err) {
     reportSdkError(err);

--- a/cli/lib/notifications.mjs
+++ b/cli/lib/notifications.mjs
@@ -3,7 +3,7 @@
  *
  * Wraps the v1.55 `add-operator-health-notifications` API surface:
  *
- *   - run402 notifications list [--type ...] [--since ...] [--limit N] [--offset N]
+ *   - run402 notifications list [--type ...] [--since ...] [--limit N] [--after <cursor>]
  *   - run402 notifications get <id>
  *   - run402 notifications preferences [get|set ...]
  *   - run402 notifications test
@@ -22,7 +22,7 @@ import { assertKnownFlags, flagValue, normalizeArgv, positionalArgs } from "./ar
 const HELP = `run402 notifications — Operator health notifications
 
 Usage:
-  run402 notifications list [--type <event_type>] [--since <iso>] [--limit N] [--offset N]
+  run402 notifications list [--type <event_type>] [--since <iso>] [--limit N] [--after <cursor>]
   run402 notifications get <id>
   run402 notifications preferences
   run402 notifications preferences set <key>=<value> [<key>=<value> ...]
@@ -45,7 +45,7 @@ Auth ladder (enforced server-side):
 
 async function list(args) {
   const parsedArgs = normalizeArgv(args);
-  const valueFlags = ["--type", "--since", "--limit", "--offset"];
+  const valueFlags = ["--type", "--since", "--limit", "--after"];
   assertKnownFlags(parsedArgs, [...valueFlags, "--help", "-h"], valueFlags);
   const extra = positionalArgs(parsedArgs, valueFlags);
   if (extra.length > 0) {
@@ -56,11 +56,11 @@ async function list(args) {
   const type = flagValue(parsedArgs, "--type");
   const since = flagValue(parsedArgs, "--since");
   const limit = flagValue(parsedArgs, "--limit");
-  const offset = flagValue(parsedArgs, "--offset");
+  const after = flagValue(parsedArgs, "--after");
   if (type) opts.type = type;
   if (since) opts.since = since;
   if (limit != null) opts.limit = Number(limit);
-  if (offset != null) opts.offset = Number(offset);
+  if (after != null) opts.after = after;
   try {
     const data = await getSdk().admin.listNotifications(opts);
     console.log(JSON.stringify(data, null, 2));

--- a/cli/lib/org.mjs
+++ b/cli/lib/org.mjs
@@ -18,7 +18,7 @@ Usage:
   run402 org get    <org>
   run402 org rename <org> <display_name>   (or: --clear to remove the label)
   run402 org whoami
-  run402 org audit  <org> [--limit N] [--before <cursor>]
+  run402 org audit  <org> [--limit N] [--after <cursor>] [--before <cursor>]
   run402 org member list <org>
   run402 org member add  <org> <wallet> [--role <role>]
   run402 org member role <org> <principal_id> <role>
@@ -92,7 +92,7 @@ the label.
 Usage:
   run402 org whoami
 
-Calls GET /agent/v1/whoami. Returns the control-plane principal (id/type/displayName/createdAt),
+Calls GET /agent/v1/whoami. Returns the control-plane principal (id/type/display_name/created_at),
 authenticator_id, and every org membership (org_id, display_name, role, status). REMOTE identity;
 for local wallet/profile state use 'run402 status'.
 `,
@@ -120,9 +120,11 @@ An invite is claimed at the recipient's first login. Mutations require an active
   audit: `run402 org audit — control-plane audit trail
 
 Usage:
-  run402 org audit <org> [--limit N] [--before <cursor>]
+  run402 org audit <org> [--limit N] [--after <cursor>] [--before <cursor>]
 
-Requires an admin+ membership on the org. Newest-first; page with --before.
+Requires an admin+ membership on the org. Newest-first. Page forward with --after
+(next_cursor from a prior page); --before is the legacy cursor. Returns
+{ events, has_more, next_cursor }.
 `,
 };
 
@@ -197,7 +199,7 @@ async function rename(args) {
 
 async function audit(args) {
   const a = normalizeArgv(args);
-  const valueFlags = ["--limit", "--before"];
+  const valueFlags = ["--limit", "--after", "--before"];
   assertKnownFlags(a, [...valueFlags, "--help", "-h"], valueFlags);
   const [org] = requirePositionalCount(a, valueFlags, {
     min: 1,
@@ -206,11 +208,16 @@ async function audit(args) {
     missing: "Missing <org>.",
   });
   const limitFlag = flagValue(a, "--limit");
+  const after = flagValue(a, "--after");
   const before = flagValue(a, "--before");
   const limit = limitFlag === null ? undefined : parseIntegerFlag("--limit", limitFlag, { min: 1, max: 1000 });
   try {
-    const events = await getSdk().org(org).audit({ limit, before: before ?? undefined });
-    console.log(JSON.stringify({ events }, null, 2));
+    const result = await getSdk().org(org).audit({
+      limit,
+      after: after ?? undefined,
+      before: before ?? undefined,
+    });
+    console.log(JSON.stringify(result, null, 2));
   } catch (err) {
     reportSdkError(err);
   }

--- a/cli/lib/transfer.mjs
+++ b/cli/lib/transfer.mjs
@@ -15,7 +15,7 @@ const HELP = `run402 transfer — Project transfer, one noun for both recipient 
 Usage:
   run402 transfer init --to <wallet|email> [--project <id>] [--billing-policy migrate] [--message <text>] [--kysigned <record_id>] [--retain-collaborator developer]
   run402 transfer preview <transfer_id>
-  run402 transfer list [--incoming | --outgoing] [--limit N] [--offset N]
+  run402 transfer list [--incoming | --outgoing] [--limit N] [--after <cursor>]
   run402 transfer accept <transfer_id>
   run402 transfer claim <transfer_id> [--into <org_id>] [--accept-retained-collaborator]
   run402 transfer cancel <transfer_id> [--reason <text>]
@@ -72,16 +72,16 @@ party to the transfer may preview.
   list: `run402 transfer list — List pending transfers
 
 Usage:
-  run402 transfer list [--incoming | --outgoing] [--limit N] [--offset N]
+  run402 transfer list [--incoming | --outgoing] [--limit N] [--after <cursor>]
 
 Lists both wallet- and email-addressed transfers, unioned; each row carries
 recipient_kind.
 
 Options:
-  --incoming    List transfers OFFERED TO you (default).
-  --outgoing    List transfers INITIATED BY you.
-  --limit N     Page size (default 50).
-  --offset N    Pagination offset (default 0).
+  --incoming        List transfers OFFERED TO you (default).
+  --outgoing        List transfers INITIATED BY you.
+  --limit N         Page size (default 50).
+  --after <cursor>  Opaque keyset cursor (next_cursor from a prior page).
 `,
   accept: `run402 transfer accept — Accept an incoming WALLET transfer
 
@@ -220,7 +220,7 @@ async function preview(args) {
 
 async function list(args) {
   const parsedArgs = normalizeArgv(args);
-  const valueFlags = ["--limit", "--offset"];
+  const valueFlags = ["--limit", "--after"];
   assertKnownFlags(parsedArgs, [...valueFlags, "--incoming", "--outgoing", "--help", "-h"], valueFlags);
   const extra = positionalArgs(parsedArgs, valueFlags);
   if (extra.length > 0) {
@@ -235,26 +235,33 @@ async function list(args) {
   const direction = outgoing ? "outgoing" : "incoming";
 
   const limitFlag = flagValue(parsedArgs, "--limit");
-  const offsetFlag = flagValue(parsedArgs, "--offset");
+  const after = flagValue(parsedArgs, "--after");
   const limit =
     limitFlag === null
       ? undefined
       : parseIntegerFlag("--limit", limitFlag, { min: 1, max: 1000 });
-  const offset =
-    offsetFlag === null
-      ? undefined
-      : parseIntegerFlag("--offset", offsetFlag, { min: 0 });
 
   // Incoming/outgoing are kind-agnostic — each returns the union of wallet- and
   // email-addressed rows, tagged with recipient_kind.
   allowanceAuthHeaders(`/agent/v1/transfers/${direction}`);
 
   try {
-    const data =
+    const result =
       direction === "incoming"
-        ? await getSdk().admin.transfers.listIncoming({ limit, offset })
-        : await getSdk().admin.transfers.listOutgoing({ limit, offset });
-    console.log(JSON.stringify({ direction, transfers: data }, null, 2));
+        ? await getSdk().admin.transfers.listIncoming({ limit, after: after ?? undefined })
+        : await getSdk().admin.transfers.listOutgoing({ limit, after: after ?? undefined });
+    console.log(
+      JSON.stringify(
+        {
+          direction,
+          transfers: result.transfers,
+          has_more: result.has_more,
+          next_cursor: result.next_cursor,
+        },
+        null,
+        2,
+      ),
+    );
   } catch (err) {
     reportSdkError(err);
   }

--- a/sdk/src/namespaces/admin.ts
+++ b/sdk/src/namespaces/admin.ts
@@ -118,12 +118,14 @@ export interface ListNotificationsOptions {
   since?: string;
   /** Default 50, max 200. */
   limit?: number;
-  offset?: number;
+  /** Opaque keyset cursor — page forward from a prior page's `next_cursor`. */
+  after?: string;
 }
 
 export interface ListNotificationsResult {
   notifications: NotificationRow[];
-  pagination: { limit: number; offset: number; returned: number };
+  has_more: boolean;
+  next_cursor: string | null;
 }
 
 export interface NotificationPreferences {
@@ -315,7 +317,7 @@ export class Admin {
     if (opts.type) q.push(`type=${encodeURIComponent(opts.type)}`);
     if (opts.since) q.push(`since=${encodeURIComponent(opts.since)}`);
     if (opts.limit != null) q.push(`limit=${opts.limit}`);
-    if (opts.offset != null) q.push(`offset=${opts.offset}`);
+    if (opts.after != null) q.push(`after=${encodeURIComponent(opts.after)}`);
     const url = q.length > 0
       ? `/agent/v1/notifications?${q.join("&")}`
       : "/agent/v1/notifications";

--- a/sdk/src/namespaces/billing.test.ts
+++ b/sdk/src/namespaces/billing.test.ts
@@ -90,7 +90,7 @@ function accountDetail(overrides: Record<string, unknown> = {}): Record<string, 
 function historyMock(entries: unknown[] = []) {
   return mockFetch((call) =>
     call.url.includes("/history")
-      ? jsonResponse({ org_id: ACCOUNT_ID, entries })
+      ? jsonResponse({ org_id: ACCOUNT_ID, entries, has_more: false, next_cursor: null })
       : jsonResponse(accountDetail()),
   );
 }
@@ -264,10 +264,24 @@ describe("billing.history / getHistory", () => {
     assert.equal(calls[0]!.url, `https://api.example.test/orgs/v1/${ACCOUNT_ID}/billing/history`);
   });
 
+  it("threads ?after=<cursor> onto the history request and surfaces has_more/next_cursor", async () => {
+    const { fetch, calls } = mockFetch((call) =>
+      call.url.includes("/history")
+        ? jsonResponse({ org_id: ACCOUNT_ID, entries: [], has_more: true, next_cursor: "cur_9" })
+        : jsonResponse(accountDetail()),
+    );
+    const sdk = makeSdk(fetch);
+    const result = await sdk.billing.getHistory(ACCOUNT_ID, { limit: 10, after: "cur_8" });
+
+    assert.equal(calls[0]!.url, `https://api.example.test/orgs/v1/${ACCOUNT_ID}/billing/history?limit=10&after=cur_8`);
+    assert.equal(result.has_more, true);
+    assert.equal(result.next_cursor, "cur_9");
+  });
+
   it("appends ?limit=N on the history request (wallet flow)", async () => {
     const { fetch, calls } = historyMock([]);
     const sdk = makeSdk(fetch);
-    await sdk.billing.history(WALLET_UPPER, 50);
+    await sdk.billing.history(WALLET_UPPER, { limit: 50 });
 
     assert.equal(calls[1]!.url, `https://api.example.test/orgs/v1/${ACCOUNT_ID}/billing/history?limit=50`);
   });
@@ -275,7 +289,7 @@ describe("billing.history / getHistory", () => {
   it("appends ?limit=1 on the by-id history request", async () => {
     const { fetch, calls } = historyMock([]);
     const sdk = makeSdk(fetch);
-    await sdk.billing.getHistory(ACCOUNT_ID, 1);
+    await sdk.billing.getHistory(ACCOUNT_ID, { limit: 1 });
 
     assert.equal(calls[0]!.url, `https://api.example.test/orgs/v1/${ACCOUNT_ID}/billing/history?limit=1`);
   });
@@ -290,7 +304,7 @@ describe("billing.history / getHistory", () => {
       const sdk = makeSdk(fetch);
 
       await assert.rejects(
-        sdk.billing.history(WALLET_UPPER, limit),
+        sdk.billing.history(WALLET_UPPER, { limit }),
         (err: unknown) =>
           err instanceof LocalError &&
           err.context === "fetching billing history" &&
@@ -303,7 +317,7 @@ describe("billing.history / getHistory", () => {
   it("offers getHistory as a generic identifier alias (email flow)", async () => {
     const { fetch, calls } = historyMock([]);
     const sdk = makeSdk(fetch);
-    await sdk.billing.getHistory("user@example.com", 25);
+    await sdk.billing.getHistory("user@example.com", { limit: 25 });
 
     assert.equal(calls[0]!.url, "https://api.example.test/orgs/v1/lookup?email=user%40example.com");
     assert.equal(calls[1]!.url, `https://api.example.test/orgs/v1/${ACCOUNT_ID}/billing/history?limit=25`);

--- a/sdk/src/namespaces/billing.ts
+++ b/sdk/src/namespaces/billing.ts
@@ -52,6 +52,16 @@ export interface BillingHistoryResult {
   /** Canonical organization id (UUID) the entries belong to. */
   org_id: string;
   entries: BillingHistoryEntry[];
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+/** Options for {@link Billing.history} / {@link Billing.getHistory}. */
+export interface BillingHistoryOptions {
+  /** Page size; gateway default applies when omitted. */
+  limit?: number;
+  /** Opaque keyset cursor — page forward from a prior page's `next_cursor`. */
+  after?: string;
 }
 
 export interface CreateCheckoutResult {
@@ -296,9 +306,16 @@ export class Billing {
     return resolveOrganizationDetail(this.client, identifier, "looking up organization");
   }
 
-  /** Fetch billing history by organization id (UUID), wallet, or email. */
-  async history(identifier: OrganizationIdentifier, limit?: number): Promise<BillingHistoryResult> {
-    return this.getHistory(identifier, limit);
+  /**
+   * Fetch billing history by organization id (UUID), wallet, or email. Pass
+   * `{ limit, after }` to page; `after` is the opaque keyset cursor
+   * (`next_cursor` from a prior page).
+   */
+  async history(
+    identifier: OrganizationIdentifier,
+    opts: BillingHistoryOptions = {},
+  ): Promise<BillingHistoryResult> {
+    return this.getHistory(identifier, opts);
   }
 
   /**
@@ -306,20 +323,27 @@ export class Billing {
    * (UUID): a wallet/email identifier is first resolved to its organization via the
    * lookup, then `GET /orgs/v1/:org_id/billing/history` is read.
    * Requires SIWX from a wallet linked to the organization, or an admin key.
+   * Pass `{ limit, after }` to page; `after` is the opaque keyset cursor
+   * (`next_cursor` from a prior page). Returns `{ org_id, entries, has_more,
+   * next_cursor }`.
    */
-  async getHistory(identifier: OrganizationIdentifier, limit?: number): Promise<BillingHistoryResult> {
-    if (limit !== undefined) {
-      assertPositiveSafeInteger(limit, "limit", "fetching billing history");
+  async getHistory(
+    identifier: OrganizationIdentifier,
+    opts: BillingHistoryOptions = {},
+  ): Promise<BillingHistoryResult> {
+    if (opts.limit !== undefined) {
+      assertPositiveSafeInteger(opts.limit, "limit", "fetching billing history");
     }
     const id = classifyBillingIdentifier(identifier, "fetching billing history");
     const organizationId = id.kind === "org_id"
       ? id.value
       : (await fetchOrganizationByLookup(this.client, id.kind, id.value, "fetching billing history"))
           .org_id;
-    const base = `/orgs/v1/${encodeURIComponent(organizationId)}/billing/history`;
-    const path = limit !== undefined
-      ? `${base}?limit=${encodeURIComponent(String(limit))}`
-      : base;
+    const params = new URLSearchParams();
+    if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+    if (opts.after !== undefined) params.set("after", opts.after);
+    const query = params.toString();
+    const path = `/orgs/v1/${encodeURIComponent(organizationId)}/billing/history${query ? `?${query}` : ""}`;
     return this.client.request<BillingHistoryResult>(path, {
       context: "fetching billing history",
     });

--- a/sdk/src/namespaces/cache.ts
+++ b/sdk/src/namespaces/cache.ts
@@ -49,11 +49,11 @@ export interface CacheInspectResult {
   search?: string;
   method?: string;
   locale?: string;
-  releaseId?: string;
-  cachedAt?: string;
-  expiresAt?: string;
-  writtenUnderGeneration?: string;
-  contentSha256?: string;
+  release_id?: string;
+  cached_at?: string;
+  expires_at?: string;
+  written_under_generation?: string;
+  content_sha256?: string;
   headers?: Record<string, string | string[]>;
 }
 

--- a/sdk/src/namespaces/operator-session.test.ts
+++ b/sdk/src/namespaces/operator-session.test.ts
@@ -130,7 +130,7 @@ describe("operator.session — public mint methods (no auth)", () => {
 describe("operator.session — session-bound methods (bearer vs SIWX fallback)", () => {
   it("whoami with a token: bearer, no SIWX; returns principal + memberships", async () => {
     const who = {
-      principal: { id: "prn_1", type: "human", createdAt: "2026-01-01T00:00:00Z" },
+      principal: { id: "prn_1", type: "human", display_name: null, created_at: "2026-01-01T00:00:00Z", disabled_at: null },
       memberships: [{ org_id: "org_1", role: "developer", status: "active" }],
       amr: ["passkey"],
       amr_times: { passkey: 1 },
@@ -148,7 +148,7 @@ describe("operator.session — session-bound methods (bearer vs SIWX fallback)",
 
   it("whoami without a token: falls back to SIWX (credential provider)", async () => {
     const { fetch, calls } = mockFetch(() =>
-      jsonResponse({ principal: { id: "p", type: "human", createdAt: "x" }, memberships: [], amr: [] }),
+      jsonResponse({ principal: { id: "p", type: "human", display_name: null, created_at: "x", disabled_at: null }, memberships: [], amr: [] }),
     );
     await makeSdk(fetch).operator.session.whoami();
     assert.equal(calls[0]!.headers["SIGN-IN-WITH-X"], "test-siwx");

--- a/sdk/src/namespaces/operator-session.ts
+++ b/sdk/src/namespaces/operator-session.ts
@@ -108,6 +108,12 @@ export interface RecoveryCodesResult {
 export interface Authenticator {
   id: string;
   kind: string;
+  /** Provider-side subject hint (e.g. masked email / credential label); absent when unset. */
+  subject_hint?: string;
+  /** ISO-8601 enrollment time. */
+  added_at?: string;
+  /** ISO-8601 last-use time; absent when never used. */
+  last_used_at?: string;
   [key: string]: unknown;
 }
 

--- a/sdk/src/namespaces/org.test.ts
+++ b/sdk/src/namespaces/org.test.ts
@@ -52,9 +52,15 @@ function parseBody(body: unknown): Record<string, unknown> {
 // ─── r.orgs (collection + identity) ─────────────────────────────────────────
 
 describe("r.orgs.whoami", () => {
-  it("GETs /agent/v1/whoami; memberships carry org_id + display_name (not org_id)", async () => {
+  it("GETs /agent/v1/whoami; principal + memberships carry snake_case fields", async () => {
     const payload = {
-      principal: { id: "prn_1", type: "human", displayName: "Tal", createdAt: "2026-01-01T00:00:00Z" },
+      principal: {
+        id: "prn_1",
+        type: "human",
+        display_name: "Tal",
+        created_at: "2026-01-01T00:00:00Z",
+        disabled_at: null,
+      },
       memberships: [{ org_id: "org_1", display_name: "Kychee", role: "owner", status: "active" }],
       authenticator_id: "auth_1",
     };
@@ -66,7 +72,9 @@ describe("r.orgs.whoami", () => {
     const r = await makeSdk(fetch).orgs.whoami();
     assert.equal(r.memberships[0]!.org_id, "org_1");
     assert.equal(r.memberships[0]!.display_name, "Kychee");
-    assert.equal(r.principal.displayName, "Tal");
+    assert.equal(r.principal.display_name, "Tal");
+    assert.equal(r.principal.created_at, "2026-01-01T00:00:00Z");
+    assert.equal(r.principal.disabled_at, null);
     assert.equal(calls.length, 1);
   });
 });

--- a/sdk/src/namespaces/org.ts
+++ b/sdk/src/namespaces/org.ts
@@ -18,6 +18,7 @@ import type {
   AddMemberInput,
   AuditEvent,
   AuditOptions,
+  AuditResult,
   CreateInviteInput,
   CreateOrgInput,
   MemberMutationResult,
@@ -173,19 +174,27 @@ export class ScopedOrg {
 
   /**
    * Control-plane audit trail for this org (`GET /orgs/v1/:org_id/audit`).
-   * admin+. Newest-first; page with the `before` cursor.
+   * admin+. Newest-first; page forward with the `after` keyset cursor
+   * (`next_cursor` from a prior page) — the legacy `before` cursor is still
+   * accepted. Returns `{ events, has_more, next_cursor }`.
    */
-  async audit(opts: AuditOptions = {}): Promise<AuditEvent[]> {
+  async audit(opts: AuditOptions = {}): Promise<AuditResult> {
     const parts: string[] = [];
     if (opts.limit !== undefined) parts.push(`limit=${encodeURIComponent(String(opts.limit))}`);
+    if (opts.after !== undefined) parts.push(`after=${encodeURIComponent(opts.after)}`);
     if (opts.before !== undefined) parts.push(`before=${encodeURIComponent(opts.before)}`);
     const q = parts.join("&");
     const base = `/orgs/v1/${encodeURIComponent(this.orgId)}/audit`;
-    const res = await this.client.request<{ events?: AuditEvent[]; audit_events?: AuditEvent[] }>(
-      q ? `${base}?${q}` : base,
-      { context: "reading org audit trail" },
-    );
-    return res.events ?? res.audit_events ?? [];
+    const res = await this.client.request<{
+      events?: AuditEvent[];
+      has_more?: boolean;
+      next_cursor?: string | null;
+    }>(q ? `${base}?${q}` : base, { context: "reading org audit trail" });
+    return {
+      events: res.events ?? [],
+      has_more: res.has_more ?? false,
+      next_cursor: res.next_cursor ?? null,
+    };
   }
 }
 

--- a/sdk/src/namespaces/org.types.ts
+++ b/sdk/src/namespaces/org.types.ts
@@ -17,20 +17,20 @@ export type OrgRole = "owner" | "admin" | "developer" | "billing" | "viewer";
  * (`"human"` / `"agent"` / `"ci"` — future kinds pass through). Unknown future
  * fields are preserved via the index signature.
  *
- * NOTE: the `principal` sub-object is serialized in **camelCase** by the gateway
- * (`displayName` / `createdAt` / `disabledAt`), unlike the snake_case
- * `memberships[]` and top-level `authenticator_id`. The gateway OMITS
- * `displayName` and `disabledAt` when they are null, so both are optional.
+ * The `principal` sub-object is serialized in **snake_case** by the gateway
+ * (`display_name` / `created_at` / `disabled_at`), matching the snake_case
+ * `memberships[]` and top-level `authenticator_id`. All three renamed fields are
+ * ALWAYS PRESENT and NULLABLE (value-or-null, never omitted).
  */
 export interface Principal {
   id: string;
   type: string;
-  /** Human-readable label (e.g. the wallet address for a SIWX human). Omitted when unset. */
-  displayName?: string;
-  /** ISO-8601 creation time. */
-  createdAt: string;
-  /** ISO-8601 timestamp present only when the principal is disabled (and thus fails auth); omitted otherwise. */
-  disabledAt?: string;
+  /** Human-readable label (e.g. the wallet address for a SIWX human); `null` when unset. */
+  display_name: string | null;
+  /** ISO-8601 creation time; `null` when unset. */
+  created_at: string | null;
+  /** ISO-8601 timestamp when the principal is disabled (and thus fails auth); `null` otherwise. */
+  disabled_at: string | null;
   [key: string]: unknown;
 }
 
@@ -139,13 +139,18 @@ export interface CreateInviteInput {
 /**
  * A pending email invite from {@link OrgInvites.list} (`GET /orgs/v1/:org_id/invites`).
  * Represented by a pending `principal_id` — pass it to {@link OrgInvites.revoke}.
+ * The wire shape carries the owning `org_id`, the `invited_email`, who invited
+ * (`invited_by`, `null` when unattributed), and ISO-8601 `invite_expires_at` /
+ * `created_at` (both nullable).
  */
 export interface OrgInvite {
   principal_id: string;
-  email: string;
+  org_id: string;
+  invited_email: string;
   role: OrgRole;
-  status: string;
-  expires_at?: string;
+  invited_by: string | null;
+  invite_expires_at: string | null;
+  created_at: string | null;
   [key: string]: unknown;
 }
 
@@ -160,11 +165,20 @@ export interface OrgInviteRevokeResult {
 export interface AuditOptions {
   /** Page size; gateway default applies when omitted. */
   limit?: number;
-  /** Cursor — return events before this opaque marker. */
+  /** Keyset cursor — page forward from this opaque marker (`next_cursor` from a prior page). */
+  after?: string;
+  /** Legacy cursor — return events before this opaque marker. Still accepted by the gateway. */
   before?: string;
 }
 
 /** One control-plane audit event from {@link ScopedOrg.audit}. Shape is gateway-owned (forward-compatible). */
 export interface AuditEvent {
   [key: string]: unknown;
+}
+
+/** Result of {@link ScopedOrg.audit} — a keyset page of audit events. */
+export interface AuditResult {
+  events: AuditEvent[];
+  has_more: boolean;
+  next_cursor: string | null;
 }

--- a/sdk/src/namespaces/transfers.test.ts
+++ b/sdk/src/namespaces/transfers.test.ts
@@ -570,29 +570,33 @@ describe("admin.transfers.listIncoming / listOutgoing", () => {
       ],
     };
     const { fetch } = mockFetch((call) => {
-      if (call.url.includes("/incoming")) return jsonResponse(body);
-      return jsonResponse({ transfers: [] });
+      if (call.url.includes("/incoming")) return jsonResponse({ ...body, has_more: true, next_cursor: "cur_1" });
+      return jsonResponse({ transfers: [], has_more: false, next_cursor: null });
     });
     const r = makeSdk(fetch);
     const incoming = await r.admin.transfers.listIncoming();
-    assert.equal(incoming.length, 2);
-    assert.equal(incoming[0].recipient_kind, "wallet");
-    assert.equal(incoming[1].recipient_kind, "email");
-    assert.equal(incoming[1].to_email, "alice@example.com");
-    assert.equal(incoming[0].preview_path, "/agent/v1/transfers/ptx_1");
+    assert.equal(incoming.transfers.length, 2);
+    assert.equal(incoming.transfers[0].recipient_kind, "wallet");
+    assert.equal(incoming.transfers[1].recipient_kind, "email");
+    assert.equal(incoming.transfers[1].to_email, "alice@example.com");
+    assert.equal(incoming.transfers[0].preview_path, "/agent/v1/transfers/ptx_1");
+    assert.equal(incoming.has_more, true);
+    assert.equal(incoming.next_cursor, "cur_1");
     const outgoing = await r.admin.transfers.listOutgoing();
-    assert.deepEqual(outgoing, []);
+    assert.deepEqual(outgoing.transfers, []);
+    assert.equal(outgoing.has_more, false);
+    assert.equal(outgoing.next_cursor, null);
   });
 
-  it("threads limit/offset onto the query string", async () => {
+  it("threads limit/after onto the query string", async () => {
     const seen: string[] = [];
     const { fetch } = mockFetch((call) => {
       seen.push(call.url);
-      return jsonResponse({ transfers: [] });
+      return jsonResponse({ transfers: [], has_more: false, next_cursor: null });
     });
     const r = makeSdk(fetch);
-    await r.admin.transfers.listIncoming({ limit: 10, offset: 20 });
-    assert.equal(seen[0], "https://api.example.test/agent/v1/transfers/incoming?limit=10&offset=20");
+    await r.admin.transfers.listIncoming({ limit: 10, after: "cur_20" });
+    assert.equal(seen[0], "https://api.example.test/agent/v1/transfers/incoming?limit=10&after=cur_20");
     await r.admin.transfers.listOutgoing({ limit: 5 });
     assert.equal(seen[1], "https://api.example.test/agent/v1/transfers/outgoing?limit=5");
   });

--- a/sdk/src/namespaces/transfers.ts
+++ b/sdk/src/namespaces/transfers.ts
@@ -171,7 +171,15 @@ export interface TransferSummary {
 export interface ListTransfersOptions {
   /** Page size; defaults to 50 on the gateway. */
   limit?: number;
-  offset?: number;
+  /** Opaque keyset cursor — page forward from a prior page's `next_cursor`. */
+  after?: string;
+}
+
+/** Result of {@link Transfers.listIncoming} / {@link Transfers.listOutgoing} — a keyset page. */
+export interface ListTransfersResult {
+  transfers: TransferSummary[];
+  has_more: boolean;
+  next_cursor: string | null;
 }
 
 // ─── Preview shape (GET /agent/v1/transfers/:id) ────────────────────────────
@@ -467,29 +475,27 @@ export class Transfers {
   }
 
   /** Pending transfers OFFERED TO the caller — both wallet- and email-addressed. */
-  async listIncoming(opts: ListTransfersOptions = {}): Promise<TransferSummary[]> {
+  async listIncoming(opts: ListTransfersOptions = {}): Promise<ListTransfersResult> {
     const q = buildPagination(opts);
     const path = q ? `/agent/v1/transfers/incoming?${q}` : "/agent/v1/transfers/incoming";
-    const res = await this.client.request<{ transfers: TransferSummary[] }>(path, {
+    return this.client.request<ListTransfersResult>(path, {
       context: "listing incoming transfers",
     });
-    return res.transfers;
   }
 
   /** Pending transfers INITIATED BY the caller — both wallet- and email-addressed. */
-  async listOutgoing(opts: ListTransfersOptions = {}): Promise<TransferSummary[]> {
+  async listOutgoing(opts: ListTransfersOptions = {}): Promise<ListTransfersResult> {
     const q = buildPagination(opts);
     const path = q ? `/agent/v1/transfers/outgoing?${q}` : "/agent/v1/transfers/outgoing";
-    const res = await this.client.request<{ transfers: TransferSummary[] }>(path, {
+    return this.client.request<ListTransfersResult>(path, {
       context: "listing outgoing transfers",
     });
-    return res.transfers;
   }
 }
 
 function buildPagination(opts: ListTransfersOptions): string {
   const parts: string[] = [];
   if (opts.limit !== undefined) parts.push(`limit=${encodeURIComponent(String(opts.limit))}`);
-  if (opts.offset !== undefined) parts.push(`offset=${encodeURIComponent(String(opts.offset))}`);
+  if (opts.after !== undefined) parts.push(`after=${encodeURIComponent(opts.after)}`);
   return parts.join("&");
 }

--- a/src/tools/billing-history.ts
+++ b/src/tools/billing-history.ts
@@ -14,7 +14,7 @@ export async function handleBillingHistory(args: {
   const wallet = args.wallet.toLowerCase();
 
   try {
-    const body = await getSdk().billing.history(wallet, args.limit);
+    const body = await getSdk().billing.history(wallet, { limit: args.limit });
 
     if (body.entries.length === 0) {
       return {

--- a/src/tools/list-notifications.ts
+++ b/src/tools/list-notifications.ts
@@ -7,14 +7,14 @@ export const listNotificationsSchema = {
   type: z.string().optional().describe("Filter by event_type (e.g. project_past_due)"),
   since: z.string().optional().describe("ISO timestamp; only notifications at or after this time"),
   limit: z.number().int().min(1).max(200).optional().describe("Page size (default 50, max 200)"),
-  offset: z.number().int().min(0).optional().describe("Pagination offset"),
+  after: z.string().optional().describe("Opaque pagination cursor (next_cursor from a prior page)."),
 };
 
 export async function handleListNotifications(args: {
   type?: string;
   since?: string;
   limit?: number;
-  offset?: number;
+  after?: string;
 }): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   const auth = requireAllowanceAuth("/agent/v1/notifications");
   if ("error" in auth) return auth.error;

--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -106,7 +106,7 @@ export async function handleWhoami(): Promise<ToolResult> {
   try {
     const me = await getSdk().orgs.whoami();
     const lines = [
-      `Principal \`${me.principal.id}\` (${me.principal.type}${me.principal.displayName ? `, ${me.principal.displayName}` : ""}).`,
+      `Principal \`${me.principal.id}\` (${me.principal.type}${me.principal.display_name ? `, ${me.principal.display_name}` : ""}).`,
       `- authenticator_id: \`${me.authenticator_id}\``,
       `- memberships (${me.memberships.length}):`,
       ...me.memberships.map(

--- a/src/tools/transfers.ts
+++ b/src/tools/transfers.ts
@@ -258,26 +258,29 @@ export async function handleCancelProjectTransfer(args: {
 
 export const listIncomingTransfersSchema = {
   limit: z.number().int().positive().optional().describe("Page size (default 50)."),
-  offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)."),
+  after: z.string().optional().describe("Opaque pagination cursor (next_cursor from a prior page)."),
 };
 
 export async function handleListIncomingTransfers(args: {
   limit?: number;
-  offset?: number;
+  after?: string;
 }): Promise<ToolResult> {
   try {
-    const list = await getSdk().admin.transfers.listIncoming({
+    const res = await getSdk().admin.transfers.listIncoming({
       limit: args.limit,
-      offset: args.offset,
+      after: args.after,
     });
-    if (list.length === 0) {
+    if (res.transfers.length === 0) {
       return { content: [{ type: "text", text: "No pending incoming transfers." }] };
     }
-    const lines = [`Pending incoming transfers (${list.length}):`];
-    for (const t of list) {
+    const lines = [`Pending incoming transfers (${res.transfers.length}):`];
+    for (const t of res.transfers) {
       const who = t.recipient_kind === "email" ? `to_email ${t.to_email}` : `from ${t.from_wallet}`;
       lines.push(`- \`${t.transfer_id}\` [${t.recipient_kind}] — project \`${t.project_id}\`${t.project_name_snapshot ? ` (${t.project_name_snapshot})` : ""}, ${who}, billing_policy=${t.billing_policy}, expires ${t.expires_at}`);
       lines.push(`  preview: ${t.preview_path}`);
+    }
+    if (res.has_more) {
+      lines.push(`More available (next_cursor: ${res.next_cursor}). Re-run with after=<cursor>.`);
     }
     return { content: [{ type: "text", text: lines.join("\n") }] };
   } catch (err) {
@@ -289,26 +292,29 @@ export async function handleListIncomingTransfers(args: {
 
 export const listOutgoingTransfersSchema = {
   limit: z.number().int().positive().optional().describe("Page size (default 50)."),
-  offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)."),
+  after: z.string().optional().describe("Opaque pagination cursor (next_cursor from a prior page)."),
 };
 
 export async function handleListOutgoingTransfers(args: {
   limit?: number;
-  offset?: number;
+  after?: string;
 }): Promise<ToolResult> {
   try {
-    const list = await getSdk().admin.transfers.listOutgoing({
+    const res = await getSdk().admin.transfers.listOutgoing({
       limit: args.limit,
-      offset: args.offset,
+      after: args.after,
     });
-    if (list.length === 0) {
+    if (res.transfers.length === 0) {
       return { content: [{ type: "text", text: "No pending outgoing transfers." }] };
     }
-    const lines = [`Pending outgoing transfers (${list.length}):`];
-    for (const t of list) {
+    const lines = [`Pending outgoing transfers (${res.transfers.length}):`];
+    for (const t of res.transfers) {
       const who = t.recipient_kind === "email" ? `to_email ${t.to_email}` : `to ${t.to_wallet}`;
       lines.push(`- \`${t.transfer_id}\` [${t.recipient_kind}] — project \`${t.project_id}\`${t.project_name_snapshot ? ` (${t.project_name_snapshot})` : ""}, ${who}, billing_policy=${t.billing_policy}, expires ${t.expires_at}`);
       lines.push(`  preview: ${t.preview_path}`);
+    }
+    if (res.has_more) {
+      lines.push(`More available (next_cursor: ${res.next_cursor}). Re-run with after=<cursor>.`);
     }
     return { content: [{ type: "text", text: lines.join("\n") }] };
   } catch (err) {


### PR DESCRIPTION
Consumer cascade for two pre-launch gateway API cleanups ([run402-private #516](https://github.com/kychee-com/run402-private/pull/516) casing + [#517](https://github.com/kychee-com/run402-private/pull/517) pagination, both deployed). Pre-launch, no users → clean break, no `offset`/camelCase aliases.

## Casing (sweep 2) — 4 responses flipped camelCase → snake_case
| Type | change |
|---|---|
| `Principal` (both whoami paths) | `display_name`/`created_at`/`disabled_at` (present + nullable) |
| `Authenticator` | +`subject_hint?`/`added_at?`/`last_used_at?` (additive) |
| `OrgInvite` | `{org_id,principal_id,invited_email,invited_by,invite_expires_at,created_at}` (dropped `email`/`status`/`expires_at`) |
| `CacheInspectResult` | `release_id`/`cached_at`/`expires_at`/`written_under_generation`/`content_sha256` |

Generic `createdAt`/`expiresAt` on unrelated types left untouched. `CreateOrgInput.displayName` (ergonomic input arg) still maps to the wire key `display_name` — unchanged.

## Pagination (sweep 3) — 4 list endpoints unified onto keyset
`transfers` / `notifications` / `audit` / `billing/history` now take `?after` (opaque cursor) + `?limit` and return `{ <plural>, has_more, next_cursor }`, matching the canonical `projects.list`. `listIncoming`/`listOutgoing` + `audit()` now return the full keyset result (was a bare array); `notifications` drops the nested `pagination{}` block; `billing.history()`/`getHistory()` take an options object `{ limit?, after? }`. CLI `--offset` → `--after`; MCP `offset` zod → `after`.

## Verify
- `npm run build` green (SDK + all `src/tools/*` MCP consumers typecheck).
- SDK tests 1403 pass / 0 fail; CLI-e2e 683 pass / 0 fail; contracts 8, docs 43 clean.
- Gateway prod e2e green on both deploys (`4118371c` casing, `2a5b91a8` pagination).

Lockstep `run402-mcp` + `run402` + `@run402/sdk` publish (→ 3.3.2) follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)