### PR TITLE
notifications: Telegram channel + routing rules (SDK/CLI/MCP cascade)

### DIFF
--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Provision Postgres + REST API + auth + content-addressed storage + serverless functions + email — paid with x402 USDC on Base. Prototype tier is free on testnet. Use when the user asks to build a webapp, deploy a site, create a database, generate images, or mentions Run402.",
       "url": "https://docs.run402.com/SKILL.md",
-      "digest": "sha256:af310ec445c286fd0f17fa1076b6ea50c5c9fae0215f557f4c2f74e75794249b"
+      "digest": "sha256:c6695c47c67f4765717e0a6cb579a9559488c5ab44926bc8b70f5ff7c327b7ea"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@run402/sdk`, `run402` (CLI), and `run402-mcp`. Versions are kept in lockstep across the three packages in this repo. `@run402/functions` lives in the public `run402-core` repo and publishes on its own cadence.
 
+## Unreleased — Telegram notification channel + routing rules
+
+- **SDK:** added `r.admin.channels.{connectTelegram, list, revokeTelegram}` and `r.admin.rules.{list, create, update, delete}` (self-serve Telegram push on top of the v1.55 operator-notifications substrate). `admin.testNotification(opts?)` now accepts `{ source?, eventType? }` and its result carries `telegram.destinations[]`, the per-binding delivery outcome for the synthetic event.
+- **CLI:** `run402 notifications channels connect telegram [--label X]` prints the connect/connect-group deep links and polls `channels list` until the binding activates or the code expires; `channels list`/`channels revoke <binding_id>`; `notifications rules add --binding <id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]` / `rules list` / `rules rm <rule_id>`; `notifications test` gained `--source`/`--type`. `--help` on `channels`/`rules` teaches the full rule model (ANDed match dimensions, absent = wildcard, one rule -> one chat, no rules -> no Telegram traffic, mandatory email floor untouched).
+- **MCP:** added `list_notification_channels`, `list_notification_rules`, `create_notification_rule`, `delete_notification_rule`; `test_notification` gained optional `source`/`event_type` params. Connecting/revoking a Telegram binding stays CLI/SDK-only (blocks on a human tapping a Telegram deep link out-of-band).
+- **Docs/tests:** CLI/SDK/MCP references and `llms-*.txt` document the new surface; `sync.test.ts` SURFACE/SDK_BY_CAPABILITY cover it end-to-end.
+
 ## Unreleased — resilient x402 balance preflight
 
 - **Node SDK:** x402 USDC balance reads now use bounded retry/backoff with independent Base and Base Sepolia RPC failover. RPC exhaustion remains an unknown balance and never collapses to numeric zero.

--- a/SKILL.md
+++ b/SKILL.md
@@ -648,6 +648,7 @@ For agents that need to sign Ethereum transactions. Private keys never leave AWS
 - **`list_notifications`** — per-delivery-attempt audit log. Paginated; filter by event_type / since.
 - **`test_notification`** — fire a real test through the full pipeline. Audit row marked `is_test=true`. Rate-limited per wallet at 1/min.
 - **`rotate_webhook_secret`** — new HMAC signing secret for the operator webhook (returned once). Previous remains valid 24h. Requires `operator_passkey`.
+- **`list_notification_channels`** / **`list_notification_rules`** / **`create_notification_rule`** / **`delete_notification_rule`** — self-serve Telegram push: connect a chat via `run402 notifications channels connect telegram` (CLI/SDK-only — MCP reads channels but doesn't connect/revoke), then add rules (project/source/event_types/classes, all ANDed, omitted = wildcard) so only matching events page it. No rules = no Telegram traffic; the mandatory email floor is untouched.
 
 ### Service status (no auth, no setup)
 

--- a/cli-help.test.mjs
+++ b/cli-help.test.mjs
@@ -126,6 +126,11 @@ const MATRIX = {
   agent: { shared: [], specific: ["contact"] },
   operator: { shared: ["login", "logout", "overview", "whoami", "claim-wallet-org"], specific: [] },
   service: { shared: [], specific: ["status", "health"] },
+  notifications: {
+    shared: ["list", "get", "preferences", "test"],
+    specific: ["channels", "rules"],
+  },
+  "webhook-secret": { shared: ["rotate"], specific: [] },
   org: { shared: [], specific: ["create", "get", "rename", "whoami", "list", "audit", "member", "invite"] },
   grants: { shared: [], specific: ["create", "revoke"] },
   events: { shared: [], specific: [] },
@@ -147,6 +152,18 @@ const DEPLOY_RELEASE = {
 const JOBS_ARTIFACTS = {
   shared: [],
   specific: ["get"],
+};
+
+// `run402 notifications channels|rules <action>` are nested groups dispatched
+// in lib/notifications.mjs; every action falls back to its GROUP's help (the
+// group --help itself is covered via MATRIX.notifications.specific).
+const NOTIFICATIONS_CHANNELS = {
+  shared: ["connect", "list", "revoke"],
+  specific: [],
+};
+const NOTIFICATIONS_RULES = {
+  shared: ["add", "list", "rm"],
+  specific: [],
 };
 
 // ─── Mock API server ────────────────────────────────────────────────────────
@@ -414,6 +431,26 @@ describe("CLI --help contract", () => {
         assertHelp(await runCli(["jobs", "artifacts", action, "--help"]),
           `run402 jobs artifacts ${action} --help`,
           { expectHeadingStartsWith: `run402 jobs artifacts ${action}` });
+      });
+    }
+  });
+
+  describe("run402 notifications channels (nested)", () => {
+    for (const action of NOTIFICATIONS_CHANNELS.shared) {
+      it(`notifications channels ${action} --help prints usage (group-level help)`, async () => {
+        assertHelp(await runCli(["notifications", "channels", action, "--help"]),
+          `run402 notifications channels ${action} --help`,
+          { expectHeadingStartsWith: "run402 notifications channels" });
+      });
+    }
+  });
+
+  describe("run402 notifications rules (nested)", () => {
+    for (const action of NOTIFICATIONS_RULES.shared) {
+      it(`notifications rules ${action} --help prints usage (group-level help)`, async () => {
+        assertHelp(await runCli(["notifications", "rules", action, "--help"]),
+          `run402 notifications rules ${action} --help`,
+          { expectHeadingStartsWith: "run402 notifications rules" });
       });
     }
   });

--- a/cli/lib/notifications.mjs
+++ b/cli/lib/notifications.mjs
@@ -1,32 +1,61 @@
 /**
- * run402 notifications — Operator health notifications.
+ * run402 notifications — Operator health notifications + Telegram channel/rules.
  *
  * Wraps the v1.55 `add-operator-health-notifications` API surface:
  *
  *   - run402 notifications list [--type ...] [--since ...] [--limit N] [--after <cursor>]
  *   - run402 notifications get <id>
  *   - run402 notifications preferences [get|set ...]
- *   - run402 notifications test
+ *   - run402 notifications test [--source app|platform] [--type <event_type>]
  *   - run402 webhook-secret rotate
  *
+ * ...and the `notification-channel-routing-telegram` cascade (self-serve
+ * Telegram push + per-rule routing on top of the substrate above):
+ *
+ *   - run402 notifications channels connect telegram [--label <name>]
+ *   - run402 notifications channels list
+ *   - run402 notifications channels revoke <binding_id>
+ *   - run402 notifications rules add --binding <id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]
+ *   - run402 notifications rules list
+ *   - run402 notifications rules rm <rule_id>
+ *
  * All commands use the allowance-wallet auth path (SIWX). The assurance
- * ladder is enforced server-side; CLI surfaces 403 errors with the
- * required-assurance hint.
+ * ladder is enforced server-side; CLI surfaces 403/412/503 errors verbatim
+ * (message + code + next_actions) via reportSdkError — no client-side
+ * special-casing needed, e.g. a not-yet-provisioned Telegram bot surfaces as
+ * 503 TELEGRAM_CHANNEL_NOT_CONFIGURED with its next_actions intact.
+ *
+ * `channels`/`rules` are nested groups dispatched via `if (sub === ...)`
+ * (not `case`), mirroring cli/lib/org.mjs's `member`/`invite` groups — see
+ * sync.test.ts's parseNotificationsGroupActions for why.
  */
 
 import { allowanceAuthHeaders } from "./config.mjs";
 import { getSdk } from "./sdk.mjs";
 import { reportSdkError, fail } from "./sdk-errors.mjs";
-import { assertKnownFlags, flagValue, normalizeArgv, positionalArgs } from "./argparse.mjs";
+import {
+  assertAllowedValue,
+  assertKnownFlags,
+  flagValue,
+  normalizeArgv,
+  positionalArgs,
+  requirePositionalCount,
+} from "./argparse.mjs";
 
-const HELP = `run402 notifications — Operator health notifications
+const HELP = `run402 notifications — Operator health notifications + Telegram channel/rules
 
 Usage:
   run402 notifications list [--type <event_type>] [--since <iso>] [--limit N] [--after <cursor>]
   run402 notifications get <id>
   run402 notifications preferences
   run402 notifications preferences set <key>=<value> [<key>=<value> ...]
-  run402 notifications test
+  run402 notifications test [--source app|platform] [--type <event_type>]
+  run402 notifications channels connect telegram [--label <name>]
+  run402 notifications channels list
+  run402 notifications channels revoke <binding_id>
+  run402 notifications rules add --binding <binding_id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]
+  run402 notifications rules list
+  run402 notifications rules rm <rule_id>
 
 Examples:
   run402 notifications list --limit 10
@@ -36,12 +65,111 @@ Examples:
   run402 notifications preferences set digest_cadence=weekly digest_day_of_week=1
   run402 notifications preferences set webhook_url=https://my-receiver.example.com/hook
   run402 notifications test
+  run402 notifications test --source app --type signature_failed
+  run402 notifications channels connect telegram --label "kychon alerts"
+  run402 notifications channels list
+  run402 notifications rules add --binding bnd_1 --project prj_abc --source app --type signature_failed
 
 Auth ladder (enforced server-side):
   - SIWX wallet:      read own notifications + preferences
   - email_verified:   cross-wallet rollup reads + multi-wallet preference updates
-  - operator_passkey: webhook URL changes, webhook secret rotation
+  - operator_passkey: webhook URL changes, webhook secret rotation, Telegram
+                       channel connect/revoke, routing rule add/rm (channel
+                       connect additionally requires a VERIFIED operator email)
+
+Telegram channels + routing rules teach their own rule model in detail via
+'run402 notifications channels --help' / 'run402 notifications rules --help'
+(AND'd match dimensions, wildcards, one rule -> one chat, no rules -> no
+Telegram traffic).
 `;
+
+const CHANNELS_HELP = `run402 notifications channels — Telegram channel bindings
+
+Usage:
+  run402 notifications channels connect telegram [--label <name>]
+  run402 notifications channels list
+  run402 notifications channels revoke <binding_id>
+
+connect telegram:
+  Creates a PENDING binding and prints two single-use, 15-minute deep links:
+  a private-chat link and a group-chat link. Open ONE of them in Telegram and
+  tap Start — whichever is tapped first consumes the code. This command then
+  POLLS 'channels list' (every few seconds, printing progress to stderr)
+  until the binding flips to active, or the code expires, whichever happens
+  first. Requires operator_passkey assurance AND a VERIFIED operator email
+  (bindings are addressed to it — see 'run402 agent verify-email').
+
+  --label <name>   Human-readable name for the chat (e.g. "kychon alerts"),
+                   1-64 characters.
+
+list:
+  Shows every notification channel — email, webhook, and every live
+  (non-revoked) Telegram binding — for the authenticated wallet.
+
+revoke <binding_id>:
+  Revokes a Telegram binding. Requires operator_passkey assurance. A
+  missing / already-revoked / another operator's binding id all return the
+  same not-found error (no existence oracle).
+
+Until the platform's dedicated Telegram bot is provisioned on this
+deployment, 'connect telegram' returns 503 TELEGRAM_CHANNEL_NOT_CONFIGURED
+with a next_actions entry pointing at the operator to finish setup.
+
+Examples:
+  run402 notifications channels connect telegram
+  run402 notifications channels connect telegram --label "kychon alerts"
+  run402 notifications channels list
+  run402 notifications channels revoke bnd_1a2b3c
+`;
+
+const RULES_HELP = `run402 notifications rules — Telegram routing rules
+
+Usage:
+  run402 notifications rules add --binding <binding_id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]
+  run402 notifications rules list
+  run402 notifications rules rm <rule_id>
+
+The rule model:
+  - One rule routes to exactly ONE Telegram binding (one chat) — "N
+    destinations" is N rules, never a fan-out list on a single rule.
+  - Every match dimension you set is ANDed: --project + --source + --type +
+    --class must ALL match an event for the rule to fire.
+  - An OMITTED dimension is a WILDCARD (matches anything for that
+    dimension). 'rules add --binding bnd_1' with no other flags matches
+    EVERY event routed to that operator.
+  - --type and --class accept comma-separated lists and match if the event
+    is ANY of the listed values, e.g.
+    --type signature_failed,signature_expired.
+  - --source is "app" (your deployed function's events.emit(...) calls from
+    @run402/functions) or "platform" (deploys, lifecycle, verification,
+    ...). Omit it to match both.
+  - Multiple rules OR together across an event; if two of YOUR rules both
+    resolve to the SAME binding for one event, only one message is sent
+    (deduped per chat, not per rule).
+  - NO RULES = NO TELEGRAM TRAFFIC for that operator. The Telegram channel
+    is opt-in per event, per rule — there is no "send everything" default,
+    unlike the always-on email channel.
+  - Rules govern the Telegram channel ONLY (v1). The mandatory email floor
+    (security / recovery / billing_critical / destructive_lifecycle /
+    verification classes) is completely untouched by this command and can
+    NEVER be silenced by adding or omitting a rule.
+
+Requires operator_passkey assurance for add/rm. 'rules add' rejects an
+unusable telegram_binding_id (revoked / not yours / nonexistent) with the
+same 404 either way (authorize-before-reveal) — run 'channels list' first to
+confirm the binding is 'active'.
+
+Examples:
+  run402 notifications rules add --binding bnd_1
+  run402 notifications rules add --binding bnd_1 --project prj_abc --source app --type signature_failed
+  run402 notifications rules add --binding bnd_1 --class security,recovery
+  run402 notifications rules list
+  run402 notifications rules rm rule_9b21fa0a
+`;
+
+// ---------------------------------------------------------------------------
+// Operator health notifications (v1.55) — list / get / preferences / test.
+// ---------------------------------------------------------------------------
 
 async function list(args) {
   const parsedArgs = normalizeArgv(args);
@@ -133,24 +261,309 @@ async function preferences(args) {
 
 async function test(args) {
   const parsedArgs = normalizeArgv(args);
-  assertKnownFlags(parsedArgs, ["--help", "-h"]);
-  const extra = positionalArgs(parsedArgs);
+  const valueFlags = ["--source", "--type"];
+  assertKnownFlags(parsedArgs, [...valueFlags, "--help", "-h"], valueFlags);
+  const extra = positionalArgs(parsedArgs, valueFlags);
   if (extra.length > 0) {
     fail({ code: "BAD_USAGE", message: `Unexpected argument for notifications test: ${extra[0]}` });
   }
+  const source = flagValue(parsedArgs, "--source");
+  if (source !== null) assertAllowedValue(source, ["app", "platform"], "--source");
+  const eventType = flagValue(parsedArgs, "--type");
   allowanceAuthHeaders("/agent/v1/notifications/test");
+  const opts = {};
+  if (source) opts.source = source;
+  if (eventType) opts.eventType = eventType;
   try {
-    const data = await getSdk().admin.testNotification();
+    const data = await getSdk().admin.testNotification(opts);
     console.log(JSON.stringify(data, null, 2));
   } catch (err) {
     reportSdkError(err);
   }
 }
 
+// ---------------------------------------------------------------------------
+// Telegram channel bindings — notification-channel-routing-telegram.
+// ---------------------------------------------------------------------------
+
+const TELEGRAM_CONNECT_POLL_INTERVAL_MS = 3000;
+/** Fallback wait bound if the server's code_expires_at is somehow
+ *  unparseable — the connect code's real TTL is 15 minutes server-side. */
+const TELEGRAM_CONNECT_FALLBACK_TIMEOUT_MS = 20 * 60 * 1000;
+/** Print a progress line every Nth poll tick (~15s at the interval above) —
+ *  frequent enough to reassure, not so frequent it floods stderr. */
+const TELEGRAM_CONNECT_PROGRESS_EVERY_N_TICKS = 5;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll `GET /agent/v1/notifications/channels` until `bindingId` shows
+ * `status: "active"`, or the connect code's `codeExpiresAt` passes.
+ * Transient poll failures (network blips) are logged and retried rather
+ * than aborting the whole connect flow — bounded by the same expiry.
+ */
+async function pollTelegramBindingActive(bindingId, codeExpiresAt) {
+  const parsedExpiry = Date.parse(codeExpiresAt);
+  const deadlineMs = Number.isFinite(parsedExpiry) ? parsedExpiry : Date.now() + TELEGRAM_CONNECT_FALLBACK_TIMEOUT_MS;
+  let tick = 0;
+  for (;;) {
+    await sleep(TELEGRAM_CONNECT_POLL_INTERVAL_MS);
+    tick += 1;
+    let channels;
+    try {
+      channels = await getSdk().admin.channels.list();
+    } catch (err) {
+      console.error(`  (poll failed, retrying: ${err?.message || err})`);
+      if (Date.now() >= deadlineMs) return { active: false, timedOut: true, binding: null };
+      continue;
+    }
+    const binding = (channels.telegram || []).find((b) => b.id === bindingId) || null;
+    if (binding && binding.status === "active") {
+      return { active: true, binding };
+    }
+    if (Date.now() >= deadlineMs) {
+      return { active: false, timedOut: true, binding };
+    }
+    if (tick % TELEGRAM_CONNECT_PROGRESS_EVERY_N_TICKS === 1) {
+      const remainingSec = Math.max(0, Math.round((deadlineMs - Date.now()) / 1000));
+      const status = binding ? binding.status : "pending";
+      console.error(`  waiting for you to tap the link in Telegram... (status: ${status}, ${remainingSec}s left)`);
+    }
+  }
+}
+
+async function channelsConnect(args) {
+  const a = normalizeArgv(args);
+  assertKnownFlags(a, ["--label", "--help", "-h"], ["--label"]);
+  const label = flagValue(a, "--label");
+  const positionals = positionalArgs(a, ["--label"]);
+  if (positionals.length === 0) {
+    fail({
+      code: "BAD_USAGE",
+      message: "Usage: run402 notifications channels connect telegram [--label <name>]",
+    });
+  }
+  if (positionals[0] !== "telegram") {
+    fail({
+      code: "BAD_USAGE",
+      message: `Unknown channel type: ${positionals[0]}. Only 'telegram' is supported.`,
+      details: { channel_type: positionals[0] },
+    });
+  }
+  if (positionals.length > 1) {
+    fail({ code: "BAD_USAGE", message: `Unexpected argument for notifications channels connect: ${positionals[1]}` });
+  }
+
+  allowanceAuthHeaders("/agent/v1/notifications/channels/telegram");
+  let pending;
+  try {
+    pending = await getSdk().admin.channels.connectTelegram(label ? { label } : {});
+  } catch (err) {
+    reportSdkError(err);
+    return;
+  }
+
+  console.error("");
+  console.error("Open ONE of these links in Telegram and tap Start to connect this channel:");
+  console.error(`  Private chat:  ${pending.connect_url}`);
+  console.error(`  Group chat:    ${pending.connect_group_url}`);
+  console.error(`  Expires:       ${pending.code_expires_at}`);
+  console.error("");
+  console.error("Waiting for you to tap the link...");
+
+  const outcome = await pollTelegramBindingActive(pending.binding_id, pending.code_expires_at);
+  if (outcome.active) {
+    console.error("Connected.");
+    console.log(JSON.stringify({ ...pending, connected: true, binding: outcome.binding }, null, 2));
+    return;
+  }
+  console.error("Timed out waiting for you to tap the link — the connect code has expired.");
+  console.error("Run `run402 notifications channels connect telegram` again for a fresh link.");
+  console.log(JSON.stringify({ ...pending, connected: false, timed_out: true }, null, 2));
+  process.exit(1);
+}
+
+async function channelsList() {
+  allowanceAuthHeaders("/agent/v1/notifications/channels");
+  try {
+    console.log(JSON.stringify(await getSdk().admin.channels.list(), null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function channelsRevoke(args) {
+  const a = normalizeArgv(args);
+  assertKnownFlags(a, ["--help", "-h"]);
+  const [bindingId] = requirePositionalCount(a, [], {
+    min: 1,
+    max: 1,
+    command: "run402 notifications channels revoke <binding_id>",
+    missing: "Missing <binding_id>.",
+  });
+  allowanceAuthHeaders("/agent/v1/notifications/channels/telegram");
+  try {
+    console.log(JSON.stringify(await getSdk().admin.channels.revokeTelegram(bindingId), null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function runChannels(args) {
+  const channelsAction = args[0];
+  const rest = args.slice(1);
+  if (!channelsAction || channelsAction === "--help" || channelsAction === "-h") {
+    console.log(CHANNELS_HELP);
+    process.exit(channelsAction ? 0 : 1);
+  }
+  if (rest.includes("--help") || rest.includes("-h")) {
+    console.log(CHANNELS_HELP);
+    process.exit(0);
+  }
+
+  if (channelsAction === "connect") {
+    await channelsConnect(rest);
+    return;
+  }
+  if (channelsAction === "list") {
+    await channelsList();
+    return;
+  }
+  if (channelsAction === "revoke") {
+    await channelsRevoke(rest);
+    return;
+  }
+  fail({
+    code: "BAD_USAGE",
+    message: `Unknown 'notifications channels' action: ${channelsAction}. Try connect | list | revoke.`,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Telegram routing rules — notification-channel-routing-telegram.
+// ---------------------------------------------------------------------------
+
+function splitCsv(value) {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+async function rulesAdd(args) {
+  const a = normalizeArgv(args);
+  const valueFlags = ["--binding", "--project", "--source", "--type", "--class"];
+  assertKnownFlags(a, [...valueFlags, "--help", "-h"], valueFlags);
+  const positionals = positionalArgs(a, valueFlags);
+  if (positionals.length > 0) {
+    fail({ code: "BAD_USAGE", message: `Unexpected argument for notifications rules add: ${positionals[0]}` });
+  }
+
+  const bindingId = flagValue(a, "--binding");
+  if (!bindingId) {
+    fail({
+      code: "BAD_USAGE",
+      message:
+        "Usage: run402 notifications rules add --binding <binding_id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]",
+    });
+  }
+  const projectId = flagValue(a, "--project");
+  const source = flagValue(a, "--source");
+  if (source !== null) assertAllowedValue(source, ["app", "platform"], "--source");
+  const typeRaw = flagValue(a, "--type");
+  const classRaw = flagValue(a, "--class");
+
+  const input = { telegramBindingId: bindingId };
+  if (projectId) input.projectId = projectId;
+  if (source) input.source = source;
+  if (typeRaw !== null) input.eventTypes = splitCsv(typeRaw);
+  if (classRaw !== null) input.classes = splitCsv(classRaw);
+
+  allowanceAuthHeaders("/agent/v1/notifications/rules");
+  try {
+    console.log(JSON.stringify(await getSdk().admin.rules.create(input), null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function rulesList() {
+  allowanceAuthHeaders("/agent/v1/notifications/rules");
+  try {
+    console.log(JSON.stringify(await getSdk().admin.rules.list(), null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function rulesRm(args) {
+  const a = normalizeArgv(args);
+  assertKnownFlags(a, ["--help", "-h"]);
+  const [ruleId] = requirePositionalCount(a, [], {
+    min: 1,
+    max: 1,
+    command: "run402 notifications rules rm <rule_id>",
+    missing: "Missing <rule_id>.",
+  });
+  allowanceAuthHeaders("/agent/v1/notifications/rules");
+  try {
+    console.log(JSON.stringify(await getSdk().admin.rules.delete(ruleId), null, 2));
+  } catch (err) {
+    reportSdkError(err);
+  }
+}
+
+async function runRules(args) {
+  const rulesAction = args[0];
+  const rest = args.slice(1);
+  if (!rulesAction || rulesAction === "--help" || rulesAction === "-h") {
+    console.log(RULES_HELP);
+    process.exit(rulesAction ? 0 : 1);
+  }
+  if (rest.includes("--help") || rest.includes("-h")) {
+    console.log(RULES_HELP);
+    process.exit(0);
+  }
+
+  if (rulesAction === "add") {
+    await rulesAdd(rest);
+    return;
+  }
+  if (rulesAction === "list") {
+    await rulesList();
+    return;
+  }
+  if (rulesAction === "rm") {
+    await rulesRm(rest);
+    return;
+  }
+  fail({
+    code: "BAD_USAGE",
+    message: `Unknown 'notifications rules' action: ${rulesAction}. Try add | list | rm.`,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch.
+// ---------------------------------------------------------------------------
+
 export async function run(sub, args) {
   if (!sub || sub === "--help" || sub === "-h") {
     console.log(HELP);
     process.exit(0);
+  }
+  // Nested groups use `if (sub === ...)` (not `case`) so the sync test
+  // extracts their leaf actions via the dedicated channelsAction/rulesAction
+  // parsers, mirroring cli/lib/org.mjs's member/invite groups.
+  if (sub === "channels") {
+    await runChannels(args ?? []);
+    return;
+  }
+  if (sub === "rules") {
+    await runRules(args ?? []);
+    return;
   }
   switch (sub) {
     case "list":

--- a/cli/lib/notifications.mjs
+++ b/cli/lib/notifications.mjs
@@ -565,6 +565,13 @@ export async function run(sub, args) {
     await runRules(args ?? []);
     return;
   }
+  // Flat subcommands share the module-level HELP: --help/-h anywhere in the
+  // argv must short-circuit BEFORE the handlers touch auth/config (the
+  // cli-help.test.mjs contract) — same pre-switch check as cli/lib/org.mjs.
+  if (Array.isArray(args) && (args.includes("--help") || args.includes("-h"))) {
+    console.log(HELP);
+    process.exit(0);
+  }
   switch (sub) {
     case "list":
       await list(args);

--- a/cli/lib/webhook-secret.mjs
+++ b/cli/lib/webhook-secret.mjs
@@ -27,6 +27,12 @@ export async function run(sub, args = []) {
     console.log(HELP);
     process.exit(0);
   }
+  // --help/-h anywhere in the argv must short-circuit BEFORE auth/config side
+  // effects (the cli-help.test.mjs contract) — same check as notifications.mjs.
+  if (Array.isArray(args) && (args.includes("--help") || args.includes("-h"))) {
+    console.log(HELP);
+    process.exit(0);
+  }
   if (sub !== "rotate") {
     fail({
       code: "UNKNOWN_SUBCOMMAND",

--- a/cli/llms-cli.txt
+++ b/cli/llms-cli.txt
@@ -1586,6 +1586,29 @@ KMS signers — provision AWS KMS-backed Ethereum signers per project for signin
 
 `contact` returns `email_verification_status`, `passkey_binding_status`, `assurance_level`. New/changed emails start reply challenge and remain `email_pending` until owner replies. `passkey enroll` requires `email_verified`, emails enrollment link, never prints token.
 
+### notifications
+Operator health notifications (audit log, preferences) plus the self-serve Telegram push channel and its routing rules.
+
+- `run402 notifications list [--type <event_type>] [--since <iso>] [--limit N] [--after <cursor>]` — paginated delivery-attempt audit log.
+- `run402 notifications get <id>` — one audit row.
+- `run402 notifications preferences` / `preferences set <key>=<value> ...` — read/update cadence, per-class toggles, `webhook_url`, locale, timezone. Cross-wallet effects need `email_verified`; `webhook_url` changes need `operator_passkey`.
+- `run402 notifications test [--source app|platform] [--type <event_type>]` — fires a real synthetic event through the FULL pipeline (email/webhook AND Telegram routing rules), rate-limited to 1/min. Omit the flags for the default sample event, or set them to exercise a specific rule's filters. The response's `telegram.destinations[]` reports one delivered/failed outcome per matched Telegram binding — empty when no rule matches (not an error).
+
+**Telegram channel** (`notification-channel-routing-telegram`):
+- `run402 notifications channels connect telegram [--label <name>]` — creates a PENDING binding, prints `connect_url` (private chat) and `connect_group_url` (group chat) — single-use, 15-minute deep links — then POLLS `channels list` until the binding flips to `active` or the code expires, printing progress to stderr. Requires `operator_passkey` assurance AND a VERIFIED operator email (bindings are addressed to it). Until the platform's dedicated bot is provisioned on this deployment, this returns `503 TELEGRAM_CHANNEL_NOT_CONFIGURED` with a `next_actions` entry — printed verbatim.
+- `run402 notifications channels list` — every channel (email, webhook, and every live Telegram binding) for the authenticated wallet.
+- `run402 notifications channels revoke <binding_id>` — requires `operator_passkey`; a missing/already-revoked/foreign binding id all return the same not-found error (no existence oracle).
+
+**Routing rules** — one rule routes to exactly ONE Telegram binding; every match dimension you set (`--project`, `--source`, `--type`, `--class`) is ANDed, and an OMITTED dimension is a wildcard. `--type`/`--class` accept comma-separated lists (matches ANY listed value). **No rules = no Telegram traffic** — Telegram is opt-in per event, per rule; the mandatory email floor (security/recovery/billing_critical/destructive_lifecycle/verification classes) is completely untouched by rules and can never be silenced by one.
+- `run402 notifications rules add --binding <binding_id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]` — requires `operator_passkey`; an unusable/foreign `telegram_binding_id` returns the same 404 as a nonexistent one.
+- `run402 notifications rules list` — the operator's routing rules.
+- `run402 notifications rules rm <rule_id>` — requires `operator_passkey`.
+
+Full rule-model explanation: `run402 notifications channels --help` / `run402 notifications rules --help`.
+
+### webhook-secret
+- `run402 webhook-secret rotate` — new HMAC signing secret for the operator webhook, returned EXACTLY once (store it immediately). Previous secret remains valid for 24h (dual-secret grace window). Requires `operator_passkey` assurance.
+
 ### operator
 Operator = human email identity, distinct from agent wallet/SIWX. One browser login spans wallets that verified the email; `operator overview` returns cross-wallet union. Single-wallet org state: `run402 status`; operator login/approval state: `run402 operator status`.
 

--- a/docs-site/src/content/docs/cli/reference.md
+++ b/docs-site/src/content/docs/cli/reference.md
@@ -1590,6 +1590,29 @@ KMS signers — provision AWS KMS-backed Ethereum signers per project for signin
 
 `contact` returns `email_verification_status`, `passkey_binding_status`, `assurance_level`. New/changed emails start reply challenge and remain `email_pending` until owner replies. `passkey enroll` requires `email_verified`, emails enrollment link, never prints token.
 
+### notifications
+Operator health notifications (audit log, preferences) plus the self-serve Telegram push channel and its routing rules.
+
+- `run402 notifications list [--type <event_type>] [--since <iso>] [--limit N] [--after <cursor>]` — paginated delivery-attempt audit log.
+- `run402 notifications get <id>` — one audit row.
+- `run402 notifications preferences` / `preferences set <key>=<value> ...` — read/update cadence, per-class toggles, `webhook_url`, locale, timezone. Cross-wallet effects need `email_verified`; `webhook_url` changes need `operator_passkey`.
+- `run402 notifications test [--source app|platform] [--type <event_type>]` — fires a real synthetic event through the FULL pipeline (email/webhook AND Telegram routing rules), rate-limited to 1/min. Omit the flags for the default sample event, or set them to exercise a specific rule's filters. The response's `telegram.destinations[]` reports one delivered/failed outcome per matched Telegram binding — empty when no rule matches (not an error).
+
+**Telegram channel** (`notification-channel-routing-telegram`):
+- `run402 notifications channels connect telegram [--label <name>]` — creates a PENDING binding, prints `connect_url` (private chat) and `connect_group_url` (group chat) — single-use, 15-minute deep links — then POLLS `channels list` until the binding flips to `active` or the code expires, printing progress to stderr. Requires `operator_passkey` assurance AND a VERIFIED operator email (bindings are addressed to it). Until the platform's dedicated bot is provisioned on this deployment, this returns `503 TELEGRAM_CHANNEL_NOT_CONFIGURED` with a `next_actions` entry — printed verbatim.
+- `run402 notifications channels list` — every channel (email, webhook, and every live Telegram binding) for the authenticated wallet.
+- `run402 notifications channels revoke <binding_id>` — requires `operator_passkey`; a missing/already-revoked/foreign binding id all return the same not-found error (no existence oracle).
+
+**Routing rules** — one rule routes to exactly ONE Telegram binding; every match dimension you set (`--project`, `--source`, `--type`, `--class`) is ANDed, and an OMITTED dimension is a wildcard. `--type`/`--class` accept comma-separated lists (matches ANY listed value). **No rules = no Telegram traffic** — Telegram is opt-in per event, per rule; the mandatory email floor (security/recovery/billing_critical/destructive_lifecycle/verification classes) is completely untouched by rules and can never be silenced by one.
+- `run402 notifications rules add --binding <binding_id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]` — requires `operator_passkey`; an unusable/foreign `telegram_binding_id` returns the same 404 as a nonexistent one.
+- `run402 notifications rules list` — the operator's routing rules.
+- `run402 notifications rules rm <rule_id>` — requires `operator_passkey`.
+
+Full rule-model explanation: `run402 notifications channels --help` / `run402 notifications rules --help`.
+
+### webhook-secret
+- `run402 webhook-secret rotate` — new HMAC signing secret for the operator webhook, returned EXACTLY once (store it immediately). Previous secret remains valid for 24h (dual-secret grace window). Requires `operator_passkey` assurance.
+
 ### operator
 Operator = human email identity, distinct from agent wallet/SIWX. One browser login spans wallets that verified the email; `operator overview` returns cross-wallet union. Single-wallet org state: `run402 status`; operator login/approval state: `run402 operator status`.
 

--- a/docs-site/src/content/docs/mcp/reference.md
+++ b/docs-site/src/content/docs/mcp/reference.md
@@ -537,6 +537,18 @@ For agents that sign Ethereum transactions. Private keys never leave AWS KMS. $0
 - `verify_agent_contact_email` — start or resend the operator email reply challenge. The challenge secret is never returned.
 - `start_operator_passkey_enrollment` — email a short-lived passkey enrollment link to the verified contact email. Requires `email_verified`.
 
+### Notification channels & routing rules (Telegram)
+
+Self-serve Telegram push on top of the operator-notifications substrate: connect a chat, then add rules so ONLY matching events page it. **No rule = no Telegram traffic** for that operator; the mandatory email floor (security/recovery/billing_critical/destructive_lifecycle/verification classes) is unaffected by any rule.
+
+- `list_notification_channels` — every notification channel (email, webhook, and every live Telegram binding with its id/status/chat metadata/label) for the operator. Use this to find a `telegram_binding_id` for `create_notification_rule`.
+- `list_notification_rules` — the operator's Telegram routing rules.
+- `create_notification_rule` — `telegram_binding_id` (required) + optional `project_id` / `source` (`"app"` or `"platform"`) / `event_types[]` / `classes[]`, all ANDed, each omitted field a wildcard. Requires `operator_passkey` assurance. An unusable or foreign `telegram_binding_id` returns the same 404 as a nonexistent one.
+- `delete_notification_rule` — `rule_id`. Requires `operator_passkey` assurance.
+- `test_notification` (extended) — optional `source` / `event_type` args now exercise a specific rule's filters; the response's `telegram.destinations[]` reports one delivered/failed outcome per matched Telegram binding.
+
+**Connecting and revoking a Telegram binding are CLI/SDK-only in this MCP server** — `connect` blocks on a human tapping a Telegram deep link out-of-band (the CLI polls `notifications channels list` for the flip to `active`; a single MCP tool call can't sensibly block on that), and neither tool was in scope for the initial MCP cascade. Use `run402 notifications channels connect telegram` / `channels revoke <binding_id>`, or `r.admin.channels.connectTelegram()` / `.revokeTelegram()` on the SDK, then come back to `list_notification_channels` here to read the resulting binding id.
+
 ### Project transfer (unified noun, owned-org recipient v1.96+)
 
 Hand off or move a project without redeploying — one noun, three recipient shapes. A **wallet** recipient completes via `accept_project_transfer` (both sides sign SIWX); an **email** recipient completes via `claim_project_transfer` (the recipient claims into an org); an **owned org** recipient (`to_org_id`) is a same-actor move into another org the caller already owns and completes immediately in the first gateway release. Owner-side mutations on pending wallet/email transfers return `409 PROJECT_HAS_PENDING_TRANSFER` for the 72h pending window, so the recipient reviews exactly what they take on.

--- a/docs-site/src/content/docs/sdk/reference.md
+++ b/docs-site/src/content/docs/sdk/reference.md
@@ -2003,6 +2003,31 @@ ArchiveProjectResult:    { status, project_id, archived_at?, reason?, note? }   
 ReactivateProjectResult: { status, project_id, reactivated?: true, note? }      // note: "not archived"
 ```
 
+### `r.admin.channels` + `r.admin.rules` (Telegram notification channel + routing rules)
+
+Self-serve Telegram push on top of the v1.55 operator-notifications substrate: connect a chat, then add filter rules so ONLY matching events page that chat. Two sub-namespaces on `r.admin`, same shape as `r.admin.transfers`.
+
+```
+r.admin.channels.connectTelegram(opts?: { label?: string }): Promise<ConnectTelegramResult>
+r.admin.channels.list(): Promise<NotificationChannelsResult>
+r.admin.channels.revokeTelegram(bindingId: string): Promise<RevokeTelegramResult>
+
+r.admin.rules.list(): Promise<ListRoutingRulesResult>
+r.admin.rules.create(input: CreateRoutingRuleInput): Promise<CreateRoutingRuleResult>
+r.admin.rules.update(ruleId: string, patch: UpdateRoutingRulePatch): Promise<RoutingRule>
+r.admin.rules.delete(ruleId: string): Promise<DeleteRoutingRuleResult>
+```
+
+`connectTelegram` returns two single-use, 15-minute deep links — `connect_url` (private chat) and `connect_group_url` (group chat) — plus a `pending` binding id. A human taps ONE of the links and starts the bot; poll `r.admin.channels.list()` until the matching entry in `telegram[]` shows `status: "active"` (or `code_expires_at` passes and it's swept back to `"revoked"`). Until the platform's dedicated bot is provisioned on this deployment, `connectTelegram` throws with `code: "TELEGRAM_CHANNEL_NOT_CONFIGURED"` (HTTP 503, with a `next_actions` entry); a caller with no verified operator email yet gets `code: "OPERATOR_EMAIL_NOT_VERIFIED"` (HTTP 412) — bindings are addressed to the verified email, the recipient grain every rule/binding keys on. `connectTelegram` / `revokeTelegram` require `operator_passkey` assurance (same ladder as `rotateWebhookSecret`); `list()` is a plain SIWX read.
+
+**Routing rules (design D4).** One rule always targets exactly one Telegram binding — "N destinations" is N rules. Every match dimension you set (`projectId`, `source`, `eventTypes`, `classes`) is ANDed; an OMITTED field is a wildcard (matches anything for that dimension); an explicit empty array (`eventTypes: []`) matches NOTHING (Postgres `TEXT[]` semantics — deliberately different from the "`[]` = unfiltered" convention some read-filter query params use elsewhere in this SDK). `source` is `"app"` (a deployed function's `events.emit(...)` calls) or `"platform"` (deploys, lifecycle, verification, ...); omit to match both. **No rules = no Telegram traffic** for that operator — the channel is opt-in per event, per rule, with no "send everything" default. Rules govern the Telegram channel ONLY in v1: the mandatory email floor (`security`/`recovery`/`billing_critical`/`destructive_lifecycle`/`verification` classes) is completely untouched and can never be silenced by a rule.
+
+`rules.update`'s `patch` uses PATCH semantics at the wire level: a field OMITTED from the object leaves the stored value unchanged; a field explicitly set to `null` CLEARS that dimension back to wildcard. There's no wire difference between "omitted" and "set to `undefined`" — both drop the key from the JSON body, so build the patch object by only assigning the keys you actually want to change.
+
+`rules.create`/`rules.update` reject an unusable or foreign `telegramBindingId` (revoked, not yours, or nonexistent) with the SAME 404 either way (authorize-before-reveal) — call `r.admin.channels.list()` first to confirm the binding is `"active"`.
+
+`admin.testNotification(opts?: { source?, eventType? })` (v1.55, extended) fires the sample event through the FULL pipeline — email/webhook AND Telegram — and its result carries `telegram: { destinations: [...] }`, one delivered/failed outcome per matched Telegram binding (empty when no rule matches — Faithful, not an error). Pass `opts.source` / `opts.eventType` to exercise a specific rule's filters precisely instead of the default sample event.
+
 ### `r.admin.transfers` (unified project transfer, owned-org recipient v1.96+)
 
 Project transfer is exposed as a sub-namespace at `r.admin.transfers` — one noun, three recipient shapes. A **wallet** recipient completes via `accept` (both sides sign SIWX); an **email** recipient completes via `claim` (the recipient claims into an org); an **owned org** recipient completes immediately at initiate time in the same-actor first release. `initiate` is body-discriminated (`toWallet` XOR `toEmail` XOR `toOrgId`); `preview` / `cancel` / `listIncoming` / `listOutgoing` are kind-agnostic for pending rows and tag each row with `recipient_kind`. (The pre-v1.93 `*Handoff` methods and `/handoffs` routes are gone.)

--- a/llms-mcp.txt
+++ b/llms-mcp.txt
@@ -533,6 +533,18 @@ For agents that sign Ethereum transactions. Private keys never leave AWS KMS. $0
 - `verify_agent_contact_email` — start or resend the operator email reply challenge. The challenge secret is never returned.
 - `start_operator_passkey_enrollment` — email a short-lived passkey enrollment link to the verified contact email. Requires `email_verified`.
 
+### Notification channels & routing rules (Telegram)
+
+Self-serve Telegram push on top of the operator-notifications substrate: connect a chat, then add rules so ONLY matching events page it. **No rule = no Telegram traffic** for that operator; the mandatory email floor (security/recovery/billing_critical/destructive_lifecycle/verification classes) is unaffected by any rule.
+
+- `list_notification_channels` — every notification channel (email, webhook, and every live Telegram binding with its id/status/chat metadata/label) for the operator. Use this to find a `telegram_binding_id` for `create_notification_rule`.
+- `list_notification_rules` — the operator's Telegram routing rules.
+- `create_notification_rule` — `telegram_binding_id` (required) + optional `project_id` / `source` (`"app"` or `"platform"`) / `event_types[]` / `classes[]`, all ANDed, each omitted field a wildcard. Requires `operator_passkey` assurance. An unusable or foreign `telegram_binding_id` returns the same 404 as a nonexistent one.
+- `delete_notification_rule` — `rule_id`. Requires `operator_passkey` assurance.
+- `test_notification` (extended) — optional `source` / `event_type` args now exercise a specific rule's filters; the response's `telegram.destinations[]` reports one delivered/failed outcome per matched Telegram binding.
+
+**Connecting and revoking a Telegram binding are CLI/SDK-only in this MCP server** — `connect` blocks on a human tapping a Telegram deep link out-of-band (the CLI polls `notifications channels list` for the flip to `active`; a single MCP tool call can't sensibly block on that), and neither tool was in scope for the initial MCP cascade. Use `run402 notifications channels connect telegram` / `channels revoke <binding_id>`, or `r.admin.channels.connectTelegram()` / `.revokeTelegram()` on the SDK, then come back to `list_notification_channels` here to read the resulting binding id.
+
 ### Project transfer (unified noun, owned-org recipient v1.96+)
 
 Hand off or move a project without redeploying — one noun, three recipient shapes. A **wallet** recipient completes via `accept_project_transfer` (both sides sign SIWX); an **email** recipient completes via `claim_project_transfer` (the recipient claims into an org); an **owned org** recipient (`to_org_id`) is a same-actor move into another org the caller already owns and completes immediately in the first gateway release. Owner-side mutations on pending wallet/email transfers return `409 PROJECT_HAS_PENDING_TRANSFER` for the 72h pending window, so the recipient reviews exactly what they take on.

--- a/sdk/llms-sdk.txt
+++ b/sdk/llms-sdk.txt
@@ -1999,6 +1999,31 @@ ArchiveProjectResult:    { status, project_id, archived_at?, reason?, note? }   
 ReactivateProjectResult: { status, project_id, reactivated?: true, note? }      // note: "not archived"
 ```
 
+### `r.admin.channels` + `r.admin.rules` (Telegram notification channel + routing rules)
+
+Self-serve Telegram push on top of the v1.55 operator-notifications substrate: connect a chat, then add filter rules so ONLY matching events page that chat. Two sub-namespaces on `r.admin`, same shape as `r.admin.transfers`.
+
+```
+r.admin.channels.connectTelegram(opts?: { label?: string }): Promise<ConnectTelegramResult>
+r.admin.channels.list(): Promise<NotificationChannelsResult>
+r.admin.channels.revokeTelegram(bindingId: string): Promise<RevokeTelegramResult>
+
+r.admin.rules.list(): Promise<ListRoutingRulesResult>
+r.admin.rules.create(input: CreateRoutingRuleInput): Promise<CreateRoutingRuleResult>
+r.admin.rules.update(ruleId: string, patch: UpdateRoutingRulePatch): Promise<RoutingRule>
+r.admin.rules.delete(ruleId: string): Promise<DeleteRoutingRuleResult>
+```
+
+`connectTelegram` returns two single-use, 15-minute deep links — `connect_url` (private chat) and `connect_group_url` (group chat) — plus a `pending` binding id. A human taps ONE of the links and starts the bot; poll `r.admin.channels.list()` until the matching entry in `telegram[]` shows `status: "active"` (or `code_expires_at` passes and it's swept back to `"revoked"`). Until the platform's dedicated bot is provisioned on this deployment, `connectTelegram` throws with `code: "TELEGRAM_CHANNEL_NOT_CONFIGURED"` (HTTP 503, with a `next_actions` entry); a caller with no verified operator email yet gets `code: "OPERATOR_EMAIL_NOT_VERIFIED"` (HTTP 412) — bindings are addressed to the verified email, the recipient grain every rule/binding keys on. `connectTelegram` / `revokeTelegram` require `operator_passkey` assurance (same ladder as `rotateWebhookSecret`); `list()` is a plain SIWX read.
+
+**Routing rules (design D4).** One rule always targets exactly one Telegram binding — "N destinations" is N rules. Every match dimension you set (`projectId`, `source`, `eventTypes`, `classes`) is ANDed; an OMITTED field is a wildcard (matches anything for that dimension); an explicit empty array (`eventTypes: []`) matches NOTHING (Postgres `TEXT[]` semantics — deliberately different from the "`[]` = unfiltered" convention some read-filter query params use elsewhere in this SDK). `source` is `"app"` (a deployed function's `events.emit(...)` calls) or `"platform"` (deploys, lifecycle, verification, ...); omit to match both. **No rules = no Telegram traffic** for that operator — the channel is opt-in per event, per rule, with no "send everything" default. Rules govern the Telegram channel ONLY in v1: the mandatory email floor (`security`/`recovery`/`billing_critical`/`destructive_lifecycle`/`verification` classes) is completely untouched and can never be silenced by a rule.
+
+`rules.update`'s `patch` uses PATCH semantics at the wire level: a field OMITTED from the object leaves the stored value unchanged; a field explicitly set to `null` CLEARS that dimension back to wildcard. There's no wire difference between "omitted" and "set to `undefined`" — both drop the key from the JSON body, so build the patch object by only assigning the keys you actually want to change.
+
+`rules.create`/`rules.update` reject an unusable or foreign `telegramBindingId` (revoked, not yours, or nonexistent) with the SAME 404 either way (authorize-before-reveal) — call `r.admin.channels.list()` first to confirm the binding is `"active"`.
+
+`admin.testNotification(opts?: { source?, eventType? })` (v1.55, extended) fires the sample event through the FULL pipeline — email/webhook AND Telegram — and its result carries `telegram: { destinations: [...] }`, one delivered/failed outcome per matched Telegram binding (empty when no rule matches — Faithful, not an error). Pass `opts.source` / `opts.eventType` to exercise a specific rule's filters precisely instead of the default sample event.
+
 ### `r.admin.transfers` (unified project transfer, owned-org recipient v1.96+)
 
 Project transfer is exposed as a sub-namespace at `r.admin.transfers` — one noun, three recipient shapes. A **wallet** recipient completes via `accept` (both sides sign SIWX); an **email** recipient completes via `claim` (the recipient claims into an org); an **owned org** recipient completes immediately at initiate time in the same-actor first release. `initiate` is body-discriminated (`toWallet` XOR `toEmail` XOR `toOrgId`); `preview` / `cancel` / `listIncoming` / `listOutgoing` are kind-agnostic for pending rows and tag each row with `recipient_kind`. (The pre-v1.93 `*Handoff` methods and `/handoffs` routes are gone.)

--- a/sdk/src/namespaces/admin.test.ts
+++ b/sdk/src/namespaces/admin.test.ts
@@ -318,3 +318,301 @@ describe("admin.reactivateProject (v1.57)", () => {
     assert.equal(result.reactivated, undefined);
   });
 });
+
+// ---------------------------------------------------------------------------
+// notification-channel-routing-telegram — r.admin.channels / r.admin.rules.
+// ---------------------------------------------------------------------------
+
+describe("admin.channels.connectTelegram", () => {
+  it("POSTs /agent/v1/notifications/channels/telegram with the label", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json(
+        {
+          binding_id: "bnd_1",
+          status: "pending",
+          connect_url: "https://t.me/run402_notify_bot?start=abc123",
+          connect_group_url: "https://t.me/run402_notify_bot?startgroup=abc123",
+          code_expires_at: "2026-07-16T12:15:00.000Z",
+          label: "kychon alerts",
+          next_actions: [{ type: "open_telegram_connect_url", why: "tap it" }],
+        },
+        201,
+      ),
+    );
+    const result = await sdk(fetch).admin.channels.connectTelegram({ label: "kychon alerts" });
+
+    assert.equal(calls[0]!.method, "POST");
+    assert.equal(calls[0]!.url, "https://api.test/agent/v1/notifications/channels/telegram");
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), { label: "kychon alerts" });
+    assert.equal(result.binding_id, "bnd_1");
+    assert.equal(result.status, "pending");
+    assert.equal(result.connect_url, "https://t.me/run402_notify_bot?start=abc123");
+    assert.equal(result.connect_group_url, "https://t.me/run402_notify_bot?startgroup=abc123");
+    assert.equal(result.next_actions.length, 1);
+  });
+
+  it("sends an empty body when no label is given", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        binding_id: "bnd_2",
+        status: "pending",
+        connect_url: "https://t.me/run402_notify_bot?start=xyz",
+        connect_group_url: "https://t.me/run402_notify_bot?startgroup=xyz",
+        code_expires_at: "2026-07-16T12:15:00.000Z",
+        label: null,
+        next_actions: [],
+      }),
+    );
+    await sdk(fetch).admin.channels.connectTelegram();
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), {});
+  });
+});
+
+describe("admin.channels.list", () => {
+  it("GETs /agent/v1/notifications/channels and returns email/webhook/telegram", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        email: { address: "ops@example.com", verified: true },
+        webhook: { configured: false, url: null, secret_configured: false },
+        telegram: [
+          {
+            id: "bnd_1",
+            recipient_email: "ops@example.com",
+            status: "active",
+            chat_id: 12345,
+            chat_type: "private",
+            chat_title: null,
+            label: "kychon alerts",
+            consecutive_failures: 0,
+            disabled_at: null,
+            code_expires_at: null,
+            created_at: "2026-07-16T12:00:00.000Z",
+            activated_at: "2026-07-16T12:05:00.000Z",
+          },
+        ],
+      }),
+    );
+    const result = await sdk(fetch).admin.channels.list();
+
+    assert.equal(calls[0]!.method, "GET");
+    assert.equal(calls[0]!.url, "https://api.test/agent/v1/notifications/channels");
+    assert.equal(result.email.verified, true);
+    assert.equal(result.telegram.length, 1);
+    assert.equal(result.telegram[0]!.status, "active");
+  });
+});
+
+describe("admin.channels.revokeTelegram", () => {
+  it("DELETEs /agent/v1/notifications/channels/telegram/:binding_id", async () => {
+    const { fetch, calls } = mockFetch(() => json({ status: "revoked", binding_id: "bnd_1" }));
+    const result = await sdk(fetch).admin.channels.revokeTelegram("bnd_1");
+
+    assert.equal(calls[0]!.method, "DELETE");
+    assert.equal(calls[0]!.url, "https://api.test/agent/v1/notifications/channels/telegram/bnd_1");
+    assert.equal(result.status, "revoked");
+    assert.equal(result.binding_id, "bnd_1");
+  });
+
+  it("URI-encodes the binding id", async () => {
+    const { fetch, calls } = mockFetch(() => json({ status: "revoked", binding_id: "bnd/weird id" }));
+    await sdk(fetch).admin.channels.revokeTelegram("bnd/weird id");
+    assert.equal(
+      calls[0]!.url,
+      "https://api.test/agent/v1/notifications/channels/telegram/bnd%2Fweird%20id",
+    );
+  });
+});
+
+describe("admin.rules.list", () => {
+  it("GETs /agent/v1/notifications/rules", async () => {
+    const { fetch, calls } = mockFetch(() => json({ rules: [] }));
+    const result = await sdk(fetch).admin.rules.list();
+    assert.equal(calls[0]!.method, "GET");
+    assert.equal(calls[0]!.url, "https://api.test/agent/v1/notifications/rules");
+    assert.deepEqual(result.rules, []);
+  });
+});
+
+describe("admin.rules.create", () => {
+  it("POSTs snake_case body with only telegram_binding_id when no filters are given", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json(
+        {
+          id: "rule_1",
+          recipient_email: "ops@example.com",
+          project_id: null,
+          source: null,
+          event_types: null,
+          classes: null,
+          channel: "telegram",
+          telegram_binding_id: "bnd_1",
+          enabled: true,
+          created_at: "2026-07-16T12:00:00.000Z",
+          updated_at: "2026-07-16T12:00:00.000Z",
+          next_actions: [{ type: "test_notification", method: "POST", path: "/agent/v1/notifications/test" }],
+        },
+        201,
+      ),
+    );
+    const result = await sdk(fetch).admin.rules.create({ telegramBindingId: "bnd_1" });
+
+    assert.equal(calls[0]!.method, "POST");
+    assert.equal(calls[0]!.url, "https://api.test/agent/v1/notifications/rules");
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), { telegram_binding_id: "bnd_1" });
+    assert.equal(result.id, "rule_1");
+    assert.equal(result.telegram_binding_id, "bnd_1");
+    assert.equal(result.next_actions.length, 1);
+  });
+
+  it("forwards every match dimension in snake_case", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        id: "rule_2",
+        recipient_email: "ops@example.com",
+        project_id: "prj_abc",
+        source: "app",
+        event_types: ["signature_failed"],
+        classes: null,
+        channel: "telegram",
+        telegram_binding_id: "bnd_1",
+        enabled: true,
+        created_at: "2026-07-16T12:00:00.000Z",
+        updated_at: "2026-07-16T12:00:00.000Z",
+        next_actions: [],
+      }),
+    );
+    await sdk(fetch).admin.rules.create({
+      telegramBindingId: "bnd_1",
+      projectId: "prj_abc",
+      source: "app",
+      eventTypes: ["signature_failed"],
+      classes: null,
+    });
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), {
+      telegram_binding_id: "bnd_1",
+      project_id: "prj_abc",
+      source: "app",
+      event_types: ["signature_failed"],
+      classes: null,
+    });
+  });
+});
+
+describe("admin.rules.update — PATCH null-vs-absent semantics", () => {
+  it("omits a field entirely from the wire body when not present in the patch", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        id: "rule_1",
+        recipient_email: "ops@example.com",
+        project_id: "prj_abc",
+        source: null,
+        event_types: null,
+        classes: null,
+        channel: "telegram",
+        telegram_binding_id: "bnd_1",
+        enabled: false,
+        created_at: "2026-07-16T12:00:00.000Z",
+        updated_at: "2026-07-16T12:10:00.000Z",
+      }),
+    );
+    await sdk(fetch).admin.rules.update("rule_1", { enabled: false });
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), { enabled: false });
+  });
+
+  it("sends an explicit null to CLEAR a dimension back to wildcard", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        id: "rule_1",
+        recipient_email: "ops@example.com",
+        project_id: null,
+        source: null,
+        event_types: null,
+        classes: null,
+        channel: "telegram",
+        telegram_binding_id: "bnd_1",
+        enabled: true,
+        created_at: "2026-07-16T12:00:00.000Z",
+        updated_at: "2026-07-16T12:10:00.000Z",
+      }),
+    );
+    await sdk(fetch).admin.rules.update("rule_1", { projectId: null });
+    const body = JSON.parse(calls[0]!.body as string);
+    assert.equal("project_id" in body, true);
+    assert.equal(body.project_id, null);
+  });
+
+  it("PATCHes /agent/v1/notifications/rules/:rule_id (URI-encoded)", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        id: "rule/weird",
+        recipient_email: "ops@example.com",
+        project_id: null,
+        source: null,
+        event_types: null,
+        classes: null,
+        channel: "telegram",
+        telegram_binding_id: "bnd_1",
+        enabled: true,
+        created_at: "2026-07-16T12:00:00.000Z",
+        updated_at: "2026-07-16T12:10:00.000Z",
+      }),
+    );
+    await sdk(fetch).admin.rules.update("rule/weird", { telegramBindingId: "bnd_2" });
+    assert.equal(calls[0]!.method, "PATCH");
+    assert.equal(calls[0]!.url, "https://api.test/agent/v1/notifications/rules/rule%2Fweird");
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), { telegram_binding_id: "bnd_2" });
+  });
+});
+
+describe("admin.rules.delete", () => {
+  it("DELETEs /agent/v1/notifications/rules/:rule_id", async () => {
+    const { fetch, calls } = mockFetch(() => json({ deleted: true, rule_id: "rule_1" }));
+    const result = await sdk(fetch).admin.rules.delete("rule_1");
+    assert.equal(calls[0]!.method, "DELETE");
+    assert.equal(calls[0]!.url, "https://api.test/agent/v1/notifications/rules/rule_1");
+    assert.equal(result.deleted, true);
+    assert.equal(result.rule_id, "rule_1");
+  });
+});
+
+describe("admin.testNotification — optional source/event_type override", () => {
+  it("sends an empty body when no override is given", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        status: "queued",
+        source_event_id: "0xabc:123",
+        drained: { claimed: 0, delivered: 0, skipped: 0, failed_transient: 0, failed_permanent: 0 },
+        telegram: { destinations: [] },
+        note: "queued",
+      }),
+    );
+    await sdk(fetch).admin.testNotification();
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), {});
+  });
+
+  it("forwards source/event_type in snake_case and returns telegram.destinations", async () => {
+    const { fetch, calls } = mockFetch(() =>
+      json({
+        status: "delivered",
+        source_event_id: "0xabc:123",
+        drained: { claimed: 1, delivered: 1, skipped: 0, failed_transient: 0, failed_permanent: 0 },
+        telegram: {
+          destinations: [
+            { binding_id: "bnd_1", label: "kychon alerts", delivered: true },
+            { binding_id: "bnd_2", label: null, delivered: false, transient: false, description: "http_403" },
+          ],
+        },
+        note: "delivered",
+      }),
+    );
+    const result = await sdk(fetch).admin.testNotification({ source: "app", eventType: "signature_failed" });
+
+    assert.deepEqual(JSON.parse(calls[0]!.body as string), {
+      source: "app",
+      event_type: "signature_failed",
+    });
+    assert.equal(result.telegram.destinations.length, 2);
+    assert.equal(result.telegram.destinations[0]!.delivered, true);
+    assert.equal(result.telegram.destinations[1]!.description, "http_403");
+  });
+});

--- a/sdk/src/namespaces/admin.ts
+++ b/sdk/src/namespaces/admin.ts
@@ -155,9 +155,50 @@ export type NotificationPreferencesPatch = Partial<
   security_events?: "always";
 };
 
+export interface TestNotificationOptions {
+  /**
+   * Route the synthetic test event as if it came from the app lane
+   * (`project_events.source = 'app'`) or the platform. Defaults to
+   * `"platform"` on the gateway when omitted.
+   */
+  source?: "app" | "platform";
+  /**
+   * Synthetic `event_type` override (flat snake_case,
+   * `^[a-z][a-z0-9_]{2,63}$`). Use this to exercise a specific routing rule's
+   * `event_types` filter precisely. Defaults to the gateway's built-in
+   * sample event when omitted.
+   */
+  eventType?: string;
+}
+
+/** One Telegram destination's outcome from a `testNotification()` call —
+ *  present only when the operator has a routing rule matching the synthetic
+ *  event. Empty `telegram.destinations` is Faithful (no matching rule), not
+ *  an error. */
+export interface TestNotificationDestination {
+  binding_id: string;
+  label: string | null;
+  delivered: boolean;
+  /** Present on failures. `true` = retryable (429/5xx/timeout/rate-limited);
+   *  `false` = permanent (bad chat, bot blocked/removed). */
+  transient?: boolean;
+  description?: string;
+}
+
 export interface TestNotificationResult {
-  status: "queued";
+  status: "delivered" | "skipped" | "queued";
   source_event_id: string;
+  drained: {
+    claimed: number;
+    delivered: number;
+    skipped: number;
+    failed_transient: number;
+    failed_permanent: number;
+  };
+  /** Telegram delivery report for the synthetic event, routed through the
+   *  operator's normal rules — the full binding + rule + render + send
+   *  chain, not just email/webhook. */
+  telegram: { destinations: TestNotificationDestination[] };
   note: string;
 }
 
@@ -166,6 +207,272 @@ export interface RotateWebhookSecretResult {
   rotated_at: string;
   grace_window_hours: number;
   note: string;
+}
+
+// ---------------------------------------------------------------------------
+// Telegram notification channel + routing rules
+// (notification-channel-routing-telegram). Exposed as `r.admin.channels.*`
+// and `r.admin.rules.*` — nested sub-namespaces on `r.admin`, the same shape
+// as `r.admin.transfers`.
+// ---------------------------------------------------------------------------
+
+export type TelegramBindingStatus = "pending" | "active" | "revoked";
+
+/**
+ * One Telegram binding as returned by `GET /agent/v1/notifications/channels`
+ * (`telegram[]`) and `r.admin.channels.list()`. Never carries the raw
+ * connect code — codes are single-use, hashed at rest, and returned only
+ * once, inline in {@link ConnectTelegramResult}.
+ */
+export interface TelegramChannelBinding {
+  id: string;
+  recipient_email: string;
+  status: TelegramBindingStatus;
+  chat_id: number | null;
+  chat_type: string | null;
+  chat_title: string | null;
+  label: string | null;
+  consecutive_failures: number;
+  /** Set once auto-disabled after 10 consecutive hard delivery failures. */
+  disabled_at: string | null;
+  /** Only set while `status === "pending"` — the connect code's 15-min TTL. */
+  code_expires_at: string | null;
+  created_at: string;
+  activated_at: string | null;
+}
+
+export interface ConnectTelegramOptions {
+  /** Human-readable label for the chat (e.g. `"kychon alerts"`), 1-64 chars. */
+  label?: string;
+}
+
+export interface ConnectTelegramNextAction {
+  type: string;
+  method?: string;
+  path?: string;
+  why?: string;
+}
+
+export interface ConnectTelegramResult {
+  binding_id: string;
+  status: "pending";
+  /** `t.me/<bot>?start=<code>` — tap to bind a PRIVATE chat. Single-use, 15-min TTL. */
+  connect_url: string;
+  /** `t.me/<bot>?startgroup=<code>` — tap to bind a GROUP chat. Same code/TTL as {@link connect_url} (whichever is tapped first consumes it). */
+  connect_group_url: string;
+  code_expires_at: string;
+  label: string | null;
+  next_actions: ConnectTelegramNextAction[];
+}
+
+export interface NotificationChannelsResult {
+  email: { address: string | null; verified: boolean };
+  webhook: { configured: boolean; url: string | null; secret_configured: boolean };
+  /** Every live (non-revoked) Telegram binding for this operator, newest first. */
+  telegram: TelegramChannelBinding[];
+}
+
+export interface RevokeTelegramResult {
+  status: "revoked";
+  binding_id: string;
+}
+
+// ─── Routing rules ──────────────────────────────────────────────────────
+
+/**
+ * `"app"` = app-emitted business events (`project_events.source = 'app'`,
+ * e.g. `events.emit(...)` from `@run402/functions`); `"platform"` = every
+ * non-app platform event (deploys, lifecycle, verification, ...). Absent /
+ * `null` on a rule is a wildcard — matches both.
+ */
+export type RoutingRuleSource = "app" | "platform";
+
+/**
+ * Wire-shaped routing rule. Every match dimension (`project_id`, `source`,
+ * `event_types`, `classes`) is ANDed; `null` is a wildcard for that
+ * dimension. An explicit empty array (`event_types: []` / `classes: []`)
+ * matches NOTHING — Postgres `TEXT[]` semantics, deliberately different from
+ * the "`[]` means unfiltered" convention used by some read-filter query
+ * params elsewhere in this SDK. One rule always targets exactly one Telegram
+ * binding; overlapping rules that resolve to the same binding are deduped by
+ * the gateway at delivery time (one message, not one per matching rule).
+ */
+export interface RoutingRule {
+  id: string;
+  recipient_email: string;
+  project_id: string | null;
+  source: RoutingRuleSource | null;
+  event_types: string[] | null;
+  classes: string[] | null;
+  channel: "telegram";
+  telegram_binding_id: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * `r.admin.rules.create(...)` input. Every match dimension is optional
+ * (absent = wildcard); `telegramBindingId` is the only required field. An
+ * all-wildcard rule (every event on every project routes to one chat) is
+ * legal.
+ */
+export interface CreateRoutingRuleInput {
+  telegramBindingId: string;
+  projectId?: string | null;
+  source?: RoutingRuleSource | null;
+  eventTypes?: string[] | null;
+  classes?: string[] | null;
+}
+
+/**
+ * `r.admin.rules.update(...)` patch. PATCH semantics: a field OMITTED from
+ * this object leaves the stored value unchanged; a field explicitly set to
+ * `null` CLEARS that dimension back to wildcard. There is no wire difference
+ * between "omitted" and "set to `undefined`" — both drop the key from the
+ * JSON request body, so the gateway sees no instruction to change it.
+ */
+export interface UpdateRoutingRulePatch {
+  projectId?: string | null;
+  source?: RoutingRuleSource | null;
+  eventTypes?: string[] | null;
+  classes?: string[] | null;
+  telegramBindingId?: string;
+  enabled?: boolean;
+}
+
+export interface ListRoutingRulesResult {
+  rules: RoutingRule[];
+}
+
+export interface CreateRoutingRuleResult extends RoutingRule {
+  next_actions: ConnectTelegramNextAction[];
+}
+
+export interface DeleteRoutingRuleResult {
+  deleted: true;
+  rule_id: string;
+}
+
+/**
+ * `r.admin.channels` — the Telegram notification-channel binding lifecycle
+ * (connect / list / revoke). Mutations (`connectTelegram`, `revokeTelegram`)
+ * require `operator_passkey` assurance; `connectTelegram` additionally
+ * requires a VERIFIED operator email (bindings are addressed to it). See
+ * `r.admin.setAgentContact` / `r.admin.verifyAgentContactEmail` and
+ * `r.admin.startOperatorPasskeyEnrollment` to reach that assurance level —
+ * same ladder as {@link Admin.rotateWebhookSecret}.
+ */
+export class Channels {
+  constructor(private readonly client: Client) {}
+
+  /**
+   * Start binding a Telegram chat. Returns two single-use, 15-minute deep
+   * links — `connect_url` for a private chat, `connect_group_url` for a
+   * group — plus a `pending` binding id. A human taps ONE of the links and
+   * starts the bot; poll {@link Channels.list} until the binding's `status`
+   * flips to `"active"` (or `code_expires_at` passes and it's swept back to
+   * `"revoked"`).
+   *
+   * Throws (via the generic SDK error hierarchy — check `err.code`) HTTP 503
+   * `TELEGRAM_CHANNEL_NOT_CONFIGURED` until the platform's dedicated
+   * notification bot is provisioned, and HTTP 412
+   * `OPERATOR_EMAIL_NOT_VERIFIED` when the caller has no verified email yet.
+   */
+  async connectTelegram(opts: ConnectTelegramOptions = {}): Promise<ConnectTelegramResult> {
+    const body: Record<string, unknown> = {};
+    if (opts.label !== undefined) body.label = opts.label;
+    return this.client.request<ConnectTelegramResult>(
+      "/agent/v1/notifications/channels/telegram",
+      { method: "POST", body, context: "connecting a Telegram notification channel" },
+    );
+  }
+
+  /** List every notification channel — email, webhook, and every live
+   *  (non-revoked) Telegram binding — for the authenticated wallet. */
+  async list(): Promise<NotificationChannelsResult> {
+    return this.client.request<NotificationChannelsResult>(
+      "/agent/v1/notifications/channels",
+      { context: "listing notification channels" },
+    );
+  }
+
+  /**
+   * Revoke a Telegram binding. Missing / already-revoked / another
+   * operator's binding id all return the SAME not-found error
+   * (authorize-before-reveal) — no existence oracle.
+   */
+  async revokeTelegram(bindingId: string): Promise<RevokeTelegramResult> {
+    return this.client.request<RevokeTelegramResult>(
+      `/agent/v1/notifications/channels/telegram/${encodeURIComponent(bindingId)}`,
+      { method: "DELETE", context: "revoking a Telegram notification channel" },
+    );
+  }
+}
+
+/**
+ * `r.admin.rules` — Telegram routing rules (design D4): one match (ANDed
+ * dimensions; an omitted dimension is a wildcard) → one Telegram binding.
+ * Rules govern the Telegram channel ONLY in v1 — email/webhook keep their
+ * existing preference-toggle semantics untouched. Mutations require
+ * `operator_passkey` assurance.
+ */
+export class Rules {
+  constructor(private readonly client: Client) {}
+
+  /** List the operator's routing rules, newest first. */
+  async list(): Promise<ListRoutingRulesResult> {
+    return this.client.request<ListRoutingRulesResult>(
+      "/agent/v1/notifications/rules",
+      { context: "listing notification routing rules" },
+    );
+  }
+
+  /**
+   * Create a routing rule. `telegramBindingId` must reference a binding this
+   * operator owns and that is currently usable (`status: "active"`); an
+   * unusable or foreign binding id returns the same 404 as a nonexistent one
+   * (authorize-before-reveal).
+   */
+  async create(input: CreateRoutingRuleInput): Promise<CreateRoutingRuleResult> {
+    const body: Record<string, unknown> = { telegram_binding_id: input.telegramBindingId };
+    if (input.projectId !== undefined) body.project_id = input.projectId;
+    if (input.source !== undefined) body.source = input.source;
+    if (input.eventTypes !== undefined) body.event_types = input.eventTypes;
+    if (input.classes !== undefined) body.classes = input.classes;
+    return this.client.request<CreateRoutingRuleResult>(
+      "/agent/v1/notifications/rules",
+      { method: "POST", body, context: "creating a notification routing rule" },
+    );
+  }
+
+  /**
+   * Patch a routing rule. PATCH semantics: only fields PRESENT on `patch`
+   * are sent — `{ projectId: null }` clears that dimension back to
+   * wildcard; omitting a field leaves it unchanged (see
+   * {@link UpdateRoutingRulePatch}).
+   */
+  async update(ruleId: string, patch: UpdateRoutingRulePatch): Promise<RoutingRule> {
+    const body: Record<string, unknown> = {};
+    if ("projectId" in patch) body.project_id = patch.projectId;
+    if ("source" in patch) body.source = patch.source;
+    if ("eventTypes" in patch) body.event_types = patch.eventTypes;
+    if ("classes" in patch) body.classes = patch.classes;
+    if ("telegramBindingId" in patch) body.telegram_binding_id = patch.telegramBindingId;
+    if ("enabled" in patch) body.enabled = patch.enabled;
+    return this.client.request<RoutingRule>(
+      `/agent/v1/notifications/rules/${encodeURIComponent(ruleId)}`,
+      { method: "PATCH", body, context: "updating a notification routing rule" },
+    );
+  }
+
+  /** Delete a routing rule. */
+  async delete(ruleId: string): Promise<DeleteRoutingRuleResult> {
+    return this.client.request<DeleteRoutingRuleResult>(
+      `/agent/v1/notifications/rules/${encodeURIComponent(ruleId)}`,
+      { method: "DELETE", context: "deleting a notification routing rule" },
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -276,8 +583,22 @@ export class Admin {
    */
   readonly transfers: Transfers;
 
+  /**
+   * Telegram notification-channel binding lifecycle. Access via
+   * `r.admin.channels.{connectTelegram, list, revokeTelegram}`.
+   */
+  readonly channels: Channels;
+
+  /**
+   * Telegram routing rules — one match (ANDed dimensions) to one binding.
+   * Access via `r.admin.rules.{list, create, update, delete}`.
+   */
+  readonly rules: Rules;
+
   constructor(private readonly client: Client) {
     this.transfers = new Transfers(client);
+    this.channels = new Channels(client);
+    this.rules = new Rules(client);
   }
 
   /**
@@ -397,13 +718,21 @@ export class Admin {
 
   /**
    * Trigger a real test notification. Sends a sample `project_past_due`
-   * event through the normal worker pipeline; the audit row is marked
-   * `is_test: true`. Rate-limited per wallet at 1/min.
+   * event through the normal worker pipeline (email/webhook); the audit row
+   * is marked `is_test: true`. ALSO delivers a synthetic event through the
+   * operator's Telegram routing rules end-to-end (binding + rule + render +
+   * send) and reports a per-destination outcome in `telegram.destinations`
+   * — pass `opts.source` / `opts.eventType` to target a specific rule's
+   * filters instead of the default sample event. Rate-limited per wallet at
+   * 1/min.
    */
-  async testNotification(): Promise<TestNotificationResult> {
+  async testNotification(opts: TestNotificationOptions = {}): Promise<TestNotificationResult> {
+    const body: Record<string, unknown> = {};
+    if (opts.source !== undefined) body.source = opts.source;
+    if (opts.eventType !== undefined) body.event_type = opts.eventType;
     return this.client.request<TestNotificationResult>(
       "/agent/v1/notifications/test",
-      { method: "POST", context: "triggering test notification" },
+      { method: "POST", body, context: "triggering test notification" },
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,6 +315,10 @@ import { listProjectEventsSchema, handleListProjectEvents } from "./tools/list-p
 import { errorsListSchema, handleErrorsList } from "./tools/errors-list.js";
 import { testNotificationSchema, handleTestNotification } from "./tools/test-notification.js";
 import { rotateWebhookSecretSchema, handleRotateWebhookSecret } from "./tools/rotate-webhook-secret.js";
+import { listNotificationChannelsSchema, handleListNotificationChannels } from "./tools/list-notification-channels.js";
+import { listNotificationRulesSchema, handleListNotificationRules } from "./tools/list-notification-rules.js";
+import { createNotificationRuleSchema, handleCreateNotificationRule } from "./tools/create-notification-rule.js";
+import { deleteNotificationRuleSchema, handleDeleteNotificationRule } from "./tools/delete-notification-rule.js";
 import { createCheckoutSchema, handleCreateCheckout } from "./tools/create-checkout.js";
 import { billingHistorySchema, handleBillingHistory } from "./tools/billing-history.js";
 import { updateVersionSchema, handleUpdateVersion } from "./tools/update-version.js";
@@ -1321,6 +1325,46 @@ server.tool(
   "Generate a fresh HMAC signing secret for the operator's webhook endpoint. Returned EXACTLY once. Previous secret remains valid for 24h. Requires operator_passkey assurance.",
   rotateWebhookSecretSchema,
   async (args) => handleRotateWebhookSecret(args),
+);
+
+// ─── Telegram notification channel + routing rules
+//     (notification-channel-routing-telegram) ──────────────────────────────
+// Self-serve Telegram push on top of the operator-notifications substrate
+// above: connect a chat, then add per-project/source/event_type/class rules
+// so ONLY matching events page that chat. No rule = no Telegram traffic;
+// the mandatory email floor (security/recovery/billing_critical/
+// destructive_lifecycle/verification) is unaffected by any rule. Connecting
+// and revoking a Telegram binding are CLI/SDK-only in v1 (connect blocks on
+// a human tapping a Telegram deep link out-of-band — the CLI polls for
+// that; a single MCP tool call can't sensibly block on it) — use
+// list_notification_channels here to read binding ids and status.
+
+server.tool(
+  "list_notification_channels",
+  "List every notification channel for the operator: email, webhook, and every live (non-revoked) Telegram binding with its id, status (pending/active/revoked), chat metadata, and label. Use this to find a telegram_binding_id for create_notification_rule.",
+  listNotificationChannelsSchema,
+  async (args) => handleListNotificationChannels(args),
+);
+
+server.tool(
+  "list_notification_rules",
+  "List the operator's Telegram routing rules. Each rule ANDs its match dimensions (project_id, source, event_types, classes); an omitted dimension is a wildcard. One rule always targets exactly one Telegram binding.",
+  listNotificationRulesSchema,
+  async (args) => handleListNotificationRules(args),
+);
+
+server.tool(
+  "create_notification_rule",
+  "Create a Telegram routing rule: one match (project_id / source / event_types / classes, all ANDed, each optional — omitted = wildcard) routes to one Telegram binding. Requires operator_passkey assurance. An unusable or foreign telegram_binding_id returns the same 404 as a nonexistent one.",
+  createNotificationRuleSchema,
+  async (args) => handleCreateNotificationRule(args),
+);
+
+server.tool(
+  "delete_notification_rule",
+  "Delete a Telegram routing rule. Requires operator_passkey assurance.",
+  deleteNotificationRuleSchema,
+  async (args) => handleDeleteNotificationRule(args),
 );
 
 // ─── Billing tools ─────────────────────────────────────────────────────────

--- a/src/tools/create-notification-rule.test.ts
+++ b/src/tools/create-notification-rule.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let calls: unknown[] = [];
+let nextCreateImpl: (input: unknown) => Promise<unknown> = async (input) => ({
+  id: "rule_1",
+  recipient_email: "ops@example.com",
+  project_id: null,
+  source: null,
+  event_types: null,
+  classes: null,
+  channel: "telegram",
+  telegram_binding_id: (input as { telegramBindingId: string }).telegramBindingId,
+  enabled: true,
+  created_at: "2026-07-16T00:00:00Z",
+  updated_at: "2026-07-16T00:00:00Z",
+  next_actions: [],
+});
+
+mock.module("../allowance-auth.js", {
+  namedExports: {
+    requireAllowanceAuth: () => ({ headers: { "SIGN-IN-WITH-X": "dGVzdA==" } }),
+  },
+});
+
+mock.module("../sdk.js", {
+  namedExports: {
+    getSdk: () => ({
+      admin: {
+        rules: {
+          create: async (input: unknown) => {
+            calls.push(input);
+            return nextCreateImpl(input);
+          },
+        },
+      },
+    }),
+    _resetSdk: () => {},
+  },
+});
+
+mock.module("../errors.js", {
+  namedExports: {
+    mapSdkError: () => ({
+      content: [{ type: "text", text: "mapped SDK error" }],
+      isError: true,
+    }),
+  },
+});
+
+const { handleCreateNotificationRule } = await import("./create-notification-rule.js");
+
+beforeEach(() => {
+  calls = [];
+});
+
+describe("create_notification_rule", () => {
+  it("maps only telegram_binding_id when no filters are given (undefined dimensions omitted downstream by the SDK)", async () => {
+    const result = await handleCreateNotificationRule({ telegram_binding_id: "bnd_1" });
+
+    assert.deepEqual(calls, [
+      { telegramBindingId: "bnd_1", projectId: undefined, source: undefined, eventTypes: undefined, classes: undefined },
+    ]);
+    assert.equal(result.isError, undefined);
+    const parsed = JSON.parse(result.content[0]!.text);
+    assert.equal(parsed.telegram_binding_id, "bnd_1");
+  });
+
+  it("maps every snake_case arg to its camelCase SDK input field", async () => {
+    await handleCreateNotificationRule({
+      telegram_binding_id: "bnd_1",
+      project_id: "prj_abc",
+      source: "app",
+      event_types: ["signature_failed"],
+      classes: ["security"],
+    });
+
+    assert.deepEqual(calls, [
+      {
+        telegramBindingId: "bnd_1",
+        projectId: "prj_abc",
+        source: "app",
+        eventTypes: ["signature_failed"],
+        classes: ["security"],
+      },
+    ]);
+  });
+
+  it("maps SDK errors via mapSdkError", async () => {
+    nextCreateImpl = async () => {
+      throw new Error("boom");
+    };
+    const result = await handleCreateNotificationRule({ telegram_binding_id: "bnd_bad" });
+    assert.equal(result.isError, true);
+    assert.equal(result.content[0]!.text, "mapped SDK error");
+  });
+});

--- a/src/tools/create-notification-rule.ts
+++ b/src/tools/create-notification-rule.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { getSdk } from "../sdk.js";
+import { mapSdkError } from "../errors.js";
+import { requireAllowanceAuth } from "../allowance-auth.js";
+
+export const createNotificationRuleSchema = {
+  telegram_binding_id: z
+    .string()
+    .describe(
+      "The Telegram binding (chat) this rule routes matching events to. Must be an active binding owned by this operator — see list_notification_channels.",
+    ),
+  project_id: z.string().optional().describe("Only match events for this project. Omit to match every project (wildcard)."),
+  source: z
+    .enum(["app", "platform"])
+    .optional()
+    .describe(
+      "Only match events from this source: 'app' (a deployed function's events.emit(...) calls) or 'platform' (deploys, lifecycle, verification, ...). Omit to match both.",
+    ),
+  event_types: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Only match these exact event_type names (matches ANY listed value). Omit to match any event_type. An empty array matches NOTHING (not a wildcard).",
+    ),
+  classes: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Only match these notification classes (matches ANY listed value), e.g. 'lifecycle', 'app'. Omit to match any class. An empty array matches NOTHING (not a wildcard).",
+    ),
+};
+
+export async function handleCreateNotificationRule(args: {
+  telegram_binding_id: string;
+  project_id?: string;
+  source?: "app" | "platform";
+  event_types?: string[];
+  classes?: string[];
+}): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const auth = requireAllowanceAuth("/agent/v1/notifications/rules");
+  if ("error" in auth) return auth.error;
+
+  try {
+    const result = await getSdk().admin.rules.create({
+      telegramBindingId: args.telegram_binding_id,
+      projectId: args.project_id,
+      source: args.source,
+      eventTypes: args.event_types,
+      classes: args.classes,
+    });
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    return mapSdkError(err, "creating notification routing rule");
+  }
+}

--- a/src/tools/delete-notification-rule.test.ts
+++ b/src/tools/delete-notification-rule.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let calls: unknown[] = [];
+let nextDeleteImpl: (ruleId: string) => Promise<unknown> = async (ruleId) => ({
+  deleted: true,
+  rule_id: ruleId,
+});
+
+mock.module("../allowance-auth.js", {
+  namedExports: {
+    requireAllowanceAuth: () => ({ headers: { "SIGN-IN-WITH-X": "dGVzdA==" } }),
+  },
+});
+
+mock.module("../sdk.js", {
+  namedExports: {
+    getSdk: () => ({
+      admin: {
+        rules: {
+          delete: async (ruleId: string) => {
+            calls.push(ruleId);
+            return nextDeleteImpl(ruleId);
+          },
+        },
+      },
+    }),
+    _resetSdk: () => {},
+  },
+});
+
+mock.module("../errors.js", {
+  namedExports: {
+    mapSdkError: () => ({
+      content: [{ type: "text", text: "mapped SDK error" }],
+      isError: true,
+    }),
+  },
+});
+
+const { handleDeleteNotificationRule } = await import("./delete-notification-rule.js");
+
+beforeEach(() => {
+  calls = [];
+  nextDeleteImpl = async (ruleId) => ({ deleted: true, rule_id: ruleId });
+});
+
+describe("delete_notification_rule", () => {
+  it("forwards rule_id to admin.rules.delete and returns the envelope verbatim", async () => {
+    const result = await handleDeleteNotificationRule({ rule_id: "rule_1" });
+
+    assert.deepEqual(calls, ["rule_1"]);
+    assert.equal(result.isError, undefined);
+    const parsed = JSON.parse(result.content[0]!.text);
+    assert.equal(parsed.deleted, true);
+    assert.equal(parsed.rule_id, "rule_1");
+  });
+
+  it("maps SDK errors via mapSdkError", async () => {
+    nextDeleteImpl = async () => {
+      throw new Error("not found");
+    };
+    const result = await handleDeleteNotificationRule({ rule_id: "rule_missing" });
+    assert.equal(result.isError, true);
+  });
+});

--- a/src/tools/delete-notification-rule.ts
+++ b/src/tools/delete-notification-rule.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { getSdk } from "../sdk.js";
+import { mapSdkError } from "../errors.js";
+import { requireAllowanceAuth } from "../allowance-auth.js";
+
+export const deleteNotificationRuleSchema = {
+  rule_id: z.string().describe("The routing rule id to delete."),
+};
+
+export async function handleDeleteNotificationRule(args: {
+  rule_id: string;
+}): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const auth = requireAllowanceAuth("/agent/v1/notifications/rules");
+  if ("error" in auth) return auth.error;
+
+  try {
+    const result = await getSdk().admin.rules.delete(args.rule_id);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    return mapSdkError(err, "deleting notification routing rule");
+  }
+}

--- a/src/tools/list-notification-channels.test.ts
+++ b/src/tools/list-notification-channels.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let calls: unknown[] = [];
+let nextListImpl: () => Promise<unknown> = async () => ({
+  email: { address: null, verified: false },
+  webhook: { configured: false, url: null, secret_configured: false },
+  telegram: [],
+});
+
+mock.module("../allowance-auth.js", {
+  namedExports: {
+    requireAllowanceAuth: () => ({ headers: { "SIGN-IN-WITH-X": "dGVzdA==" } }),
+  },
+});
+
+mock.module("../sdk.js", {
+  namedExports: {
+    getSdk: () => ({
+      admin: {
+        channels: {
+          list: async () => {
+            calls.push("list");
+            return nextListImpl();
+          },
+        },
+      },
+    }),
+    _resetSdk: () => {},
+  },
+});
+
+mock.module("../errors.js", {
+  namedExports: {
+    mapSdkError: () => ({
+      content: [{ type: "text", text: "mapped SDK error" }],
+      isError: true,
+    }),
+  },
+});
+
+const { handleListNotificationChannels } = await import("./list-notification-channels.js");
+
+beforeEach(() => {
+  calls = [];
+  nextListImpl = async () => ({
+    email: { address: null, verified: false },
+    webhook: { configured: false, url: null, secret_configured: false },
+    telegram: [],
+  });
+});
+
+describe("list_notification_channels", () => {
+  it("calls admin.channels.list with no args and returns the envelope verbatim", async () => {
+    nextListImpl = async () => ({
+      email: { address: "ops@example.com", verified: true },
+      webhook: { configured: false, url: null, secret_configured: false },
+      telegram: [
+        { id: "bnd_1", recipient_email: "ops@example.com", status: "active", chat_id: 1, chat_type: "private", chat_title: null, label: "alerts", consecutive_failures: 0, disabled_at: null, code_expires_at: null, created_at: "2026-07-16T00:00:00Z", activated_at: "2026-07-16T00:05:00Z" },
+      ],
+    });
+
+    const result = await handleListNotificationChannels({});
+
+    assert.deepEqual(calls, ["list"]);
+    assert.equal(result.isError, undefined);
+    const parsed = JSON.parse(result.content[0]!.text);
+    assert.equal(parsed.email.verified, true);
+    assert.equal(parsed.telegram.length, 1);
+    assert.equal(parsed.telegram[0].status, "active");
+  });
+});

--- a/src/tools/list-notification-channels.ts
+++ b/src/tools/list-notification-channels.ts
@@ -1,0 +1,19 @@
+import { getSdk } from "../sdk.js";
+import { mapSdkError } from "../errors.js";
+import { requireAllowanceAuth } from "../allowance-auth.js";
+
+export const listNotificationChannelsSchema = {};
+
+export async function handleListNotificationChannels(
+  _args: Record<string, never>,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const auth = requireAllowanceAuth("/agent/v1/notifications/channels");
+  if ("error" in auth) return auth.error;
+
+  try {
+    const result = await getSdk().admin.channels.list();
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    return mapSdkError(err, "listing notification channels");
+  }
+}

--- a/src/tools/list-notification-rules.test.ts
+++ b/src/tools/list-notification-rules.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let calls: unknown[] = [];
+let nextListImpl: () => Promise<unknown> = async () => ({ rules: [] });
+
+mock.module("../allowance-auth.js", {
+  namedExports: {
+    requireAllowanceAuth: () => ({ headers: { "SIGN-IN-WITH-X": "dGVzdA==" } }),
+  },
+});
+
+mock.module("../sdk.js", {
+  namedExports: {
+    getSdk: () => ({
+      admin: {
+        rules: {
+          list: async () => {
+            calls.push("list");
+            return nextListImpl();
+          },
+        },
+      },
+    }),
+    _resetSdk: () => {},
+  },
+});
+
+mock.module("../errors.js", {
+  namedExports: {
+    mapSdkError: () => ({
+      content: [{ type: "text", text: "mapped SDK error" }],
+      isError: true,
+    }),
+  },
+});
+
+const { handleListNotificationRules } = await import("./list-notification-rules.js");
+
+beforeEach(() => {
+  calls = [];
+  nextListImpl = async () => ({ rules: [] });
+});
+
+describe("list_notification_rules", () => {
+  it("calls admin.rules.list with no args and returns the envelope verbatim", async () => {
+    nextListImpl = async () => ({
+      rules: [
+        {
+          id: "rule_1",
+          recipient_email: "ops@example.com",
+          project_id: null,
+          source: "app",
+          event_types: ["signature_failed"],
+          classes: null,
+          channel: "telegram",
+          telegram_binding_id: "bnd_1",
+          enabled: true,
+          created_at: "2026-07-16T00:00:00Z",
+          updated_at: "2026-07-16T00:00:00Z",
+        },
+      ],
+    });
+
+    const result = await handleListNotificationRules({});
+
+    assert.deepEqual(calls, ["list"]);
+    assert.equal(result.isError, undefined);
+    const parsed = JSON.parse(result.content[0]!.text);
+    assert.equal(parsed.rules.length, 1);
+    assert.equal(parsed.rules[0].telegram_binding_id, "bnd_1");
+  });
+});

--- a/src/tools/list-notification-rules.ts
+++ b/src/tools/list-notification-rules.ts
@@ -1,0 +1,19 @@
+import { getSdk } from "../sdk.js";
+import { mapSdkError } from "../errors.js";
+import { requireAllowanceAuth } from "../allowance-auth.js";
+
+export const listNotificationRulesSchema = {};
+
+export async function handleListNotificationRules(
+  _args: Record<string, never>,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const auth = requireAllowanceAuth("/agent/v1/notifications/rules");
+  if ("error" in auth) return auth.error;
+
+  try {
+    const result = await getSdk().admin.rules.list();
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    return mapSdkError(err, "listing notification routing rules");
+  }
+}

--- a/src/tools/test-notification.test.ts
+++ b/src/tools/test-notification.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let calls: unknown[] = [];
+let nextTestImpl: (opts: unknown) => Promise<unknown> = async () => ({
+  status: "queued",
+  source_event_id: "0xabc:123",
+  drained: { claimed: 0, delivered: 0, skipped: 0, failed_transient: 0, failed_permanent: 0 },
+  telegram: { destinations: [] },
+  note: "queued",
+});
+
+mock.module("../allowance-auth.js", {
+  namedExports: {
+    requireAllowanceAuth: () => ({ headers: { "SIGN-IN-WITH-X": "dGVzdA==" } }),
+  },
+});
+
+mock.module("../sdk.js", {
+  namedExports: {
+    getSdk: () => ({
+      admin: {
+        testNotification: async (opts: unknown) => {
+          calls.push(opts);
+          return nextTestImpl(opts);
+        },
+      },
+    }),
+    _resetSdk: () => {},
+  },
+});
+
+mock.module("../errors.js", {
+  namedExports: {
+    mapSdkError: () => ({
+      content: [{ type: "text", text: "mapped SDK error" }],
+      isError: true,
+    }),
+  },
+});
+
+const { handleTestNotification } = await import("./test-notification.js");
+
+beforeEach(() => {
+  calls = [];
+  nextTestImpl = async () => ({
+    status: "queued",
+    source_event_id: "0xabc:123",
+    drained: { claimed: 0, delivered: 0, skipped: 0, failed_transient: 0, failed_permanent: 0 },
+    telegram: { destinations: [] },
+    note: "queued",
+  });
+});
+
+describe("test_notification", () => {
+  it("forwards undefined source/event_type when omitted", async () => {
+    await handleTestNotification({});
+    assert.deepEqual(calls, [{ source: undefined, eventType: undefined }]);
+  });
+
+  it("maps source/event_type (snake_case args) to source/eventType (SDK opts)", async () => {
+    nextTestImpl = async () => ({
+      status: "delivered",
+      source_event_id: "0xabc:123",
+      drained: { claimed: 1, delivered: 1, skipped: 0, failed_transient: 0, failed_permanent: 0 },
+      telegram: {
+        destinations: [{ binding_id: "bnd_1", label: "alerts", delivered: true }],
+      },
+      note: "delivered",
+    });
+
+    const result = await handleTestNotification({ source: "app", event_type: "signature_failed" });
+
+    assert.deepEqual(calls, [{ source: "app", eventType: "signature_failed" }]);
+    assert.equal(result.isError, undefined);
+    const parsed = JSON.parse(result.content[0]!.text);
+    assert.equal(parsed.telegram.destinations.length, 1);
+    assert.equal(parsed.telegram.destinations[0].delivered, true);
+  });
+});

--- a/src/tools/test-notification.ts
+++ b/src/tools/test-notification.ts
@@ -1,17 +1,32 @@
+import { z } from "zod";
 import { getSdk } from "../sdk.js";
 import { mapSdkError } from "../errors.js";
 import { requireAllowanceAuth } from "../allowance-auth.js";
 
-export const testNotificationSchema = {};
+export const testNotificationSchema = {
+  source: z
+    .enum(["app", "platform"])
+    .optional()
+    .describe(
+      "Route the synthetic test event as if it came from the app lane or the platform, so it exercises a specific Telegram routing rule's `source` filter. Defaults to 'platform' when omitted.",
+    ),
+  event_type: z
+    .string()
+    .optional()
+    .describe(
+      "Synthetic event_type override (flat snake_case, e.g. `signature_failed`) — use this to exercise a specific routing rule's `event_types` filter precisely. Defaults to the gateway's built-in sample event when omitted.",
+    ),
+};
 
-export async function handleTestNotification(
-  _args: Record<string, never>,
-): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+export async function handleTestNotification(args: {
+  source?: "app" | "platform";
+  event_type?: string;
+}): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   const auth = requireAllowanceAuth("/agent/v1/notifications/test");
   if ("error" in auth) return auth.error;
 
   try {
-    const result = await getSdk().admin.testNotification();
+    const result = await getSdk().admin.testNotification({ source: args.source, eventType: args.event_type });
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   } catch (err) {
     return mapSdkError(err, "triggering test notification");

--- a/sync.test.ts
+++ b/sync.test.ts
@@ -88,6 +88,8 @@ function parseCliCommands(): string[] {
   }
   for (const action of parseOrgGroupActions("memberAction")) cmds.push(`org:member:${action}`);
   for (const action of parseOrgGroupActions("inviteAction")) cmds.push(`org:invite:${action}`);
+  for (const action of parseNotificationsGroupActions("channelsAction")) cmds.push(`notifications:channels:${action}`);
+  for (const action of parseNotificationsGroupActions("rulesAction")) cmds.push(`notifications:rules:${action}`);
   if (existsSync(join(__dirname, "cli/lib/init.mjs"))) cmds.push("init");
   if (existsSync(join(__dirname, "cli/lib/up.mjs"))) cmds.push("up");
   if (existsSync(join(__dirname, "cli/lib/status.mjs"))) cmds.push("status");
@@ -118,6 +120,8 @@ function parseOpenClawCommands(): string[] {
   }
   for (const action of parseOrgGroupActions("memberAction")) cmds.push(`org:member:${action}`);
   for (const action of parseOrgGroupActions("inviteAction")) cmds.push(`org:invite:${action}`);
+  for (const action of parseNotificationsGroupActions("channelsAction")) cmds.push(`notifications:channels:${action}`);
+  for (const action of parseNotificationsGroupActions("rulesAction")) cmds.push(`notifications:rules:${action}`);
   if (existsSync(join(__dirname, "openclaw/scripts/init.mjs"))) cmds.push("init");
   if (existsSync(join(__dirname, "openclaw/scripts/up.mjs"))) cmds.push("up");
   if (existsSync(join(__dirname, "openclaw/scripts/status.mjs"))) cmds.push("status");
@@ -193,6 +197,22 @@ function parseCoreProjectActions(relativePath: string): string[] {
  *  so parseSubcommands skips them; these surface their leaves instead. */
 function parseOrgGroupActions(varName: "memberAction" | "inviteAction"): string[] {
   const filePath = join(__dirname, "cli/lib/org.mjs");
+  if (!existsSync(filePath)) return [];
+  const src = readFileSync(filePath, "utf-8");
+  const actions: string[] = [];
+  const re = new RegExp(`${varName}\\s*===\\s*"([\\w-]+)"`, "g");
+  let m;
+  while ((m = re.exec(src))) actions.push(m[1]);
+  return [...new Set(actions)].filter((c) => c !== "help" && !c.startsWith("-")).sort();
+}
+
+/** Parse the nested `notifications channels <action>` / `notifications rules
+ *  <action>` leaf actions from cli/lib/notifications.mjs (matched on
+ *  `channelsAction === "..."` / `rulesAction === "..."`), mirroring `org
+ *  member`/`org invite`. Both groups dispatch via `if (sub === ...)` so
+ *  parseSubcommands skips them; these surface their leaves instead. */
+function parseNotificationsGroupActions(varName: "channelsAction" | "rulesAction"): string[] {
+  const filePath = join(__dirname, "cli/lib/notifications.mjs");
   if (!existsSync(filePath)) return [];
   const src = readFileSync(filePath, "utf-8");
   const actions: string[] = [];
@@ -440,6 +460,22 @@ const SURFACE: Capability[] = [
   { id: "set_notification_preferences", endpoint: "PATCH /agent/v1/notifications/preferences",     mcp: "set_notification_preferences", cli: null,                            openclaw: null },
   { id: "test_notification",            endpoint: "POST /agent/v1/notifications/test",             mcp: "test_notification",            cli: "notifications:test",            openclaw: "notifications:test" },
   { id: "rotate_webhook_secret",        endpoint: "POST /agent/v1/webhook-secret/rotate",          mcp: "rotate_webhook_secret",        cli: "webhook-secret:rotate",         openclaw: "webhook-secret:rotate" },
+
+  // ── Telegram notification channel + routing rules
+  //    (notification-channel-routing-telegram) ─────────────────────────────
+  // `connect`/`revoke` are CLI/SDK-only by design: connect blocks on a human
+  // tapping a Telegram deep link out-of-band (the CLI polls; a single MCP
+  // tool call can't sensibly block on that), and neither was in the MCP
+  // scope this change shipped (channels list + rules list/add/rm only) — see
+  // the PR description for the full write-tool-parity rationale.
+  { id: "connect_telegram_channel", endpoint: "POST /agent/v1/notifications/channels/telegram",              mcp: null,                          cli: "notifications:channels:connect", openclaw: "notifications:channels:connect" },
+  { id: "list_notification_channels", endpoint: "GET /agent/v1/notifications/channels",                      mcp: "list_notification_channels", cli: "notifications:channels:list",    openclaw: "notifications:channels:list" },
+  { id: "revoke_telegram_channel",  endpoint: "DELETE /agent/v1/notifications/channels/telegram/:binding_id", mcp: null,                          cli: "notifications:channels:revoke",  openclaw: "notifications:channels:revoke" },
+  { id: "list_notification_rules",  endpoint: "GET /agent/v1/notifications/rules",                           mcp: "list_notification_rules",    cli: "notifications:rules:list",       openclaw: "notifications:rules:list" },
+  { id: "create_notification_rule", endpoint: "POST /agent/v1/notifications/rules",                          mcp: "create_notification_rule",   cli: "notifications:rules:add",        openclaw: "notifications:rules:add" },
+  // update_notification_rule (PATCH .../rules/:rule_id) is SDK-typed only in
+  // v1 (admin.rules.update) — no CLI verb or MCP tool; see SDK_ONLY_METHODS.
+  { id: "delete_notification_rule", endpoint: "DELETE /agent/v1/notifications/rules/:rule_id",               mcp: "delete_notification_rule",   cli: "notifications:rules:rm",         openclaw: "notifications:rules:rm" },
 
   // ── Project events feed (project-events-outbox) ─────────────────────────
   // One CLI command + one MCP tool cover both scopes: the org-wide union
@@ -787,6 +823,16 @@ const SDK_BY_CAPABILITY: Record<string, string | null> = {
   test_notification: "admin.testNotification",
   rotate_webhook_secret: "admin.rotateWebhookSecret",
   start_operator_passkey_enrollment: "admin.startOperatorPasskeyEnrollment",
+
+  // Telegram notification channel + routing rules
+  // (notification-channel-routing-telegram) — sub-namespaces on admin, same
+  // shape as admin.transfers.
+  connect_telegram_channel: "admin.channels.connectTelegram",
+  list_notification_channels: "admin.channels.list",
+  revoke_telegram_channel: "admin.channels.revokeTelegram",
+  list_notification_rules: "admin.rules.list",
+  create_notification_rule: "admin.rules.create",
+  delete_notification_rule: "admin.rules.delete",
 
   // Operator session (human/email, RFC 8628 device-auth). `operator login`
   // brokers deviceStart + devicePoll; devicePoll has no dedicated capability
@@ -1192,6 +1238,13 @@ describe("SDK surface alignment", () => {
       "admin.org",
       "admin.project",
       "admin._setLeasePerpetual",
+      // notification-channel-routing-telegram: admin.rules.update (PATCH
+      // .../rules/:rule_id) is SDK-typed for programmatic PATCH null-vs-absent
+      // semantics but has no dedicated CLI verb or MCP tool in v1 — the
+      // shipped surface is list/create(add)/delete(rm) only (create + delete
+      // already cover the "toggle enabled" / "change binding" use cases via
+      // rm-then-add for the CLI's flag-based UX).
+      "admin.rules.update",
       // Removed ProjectDomain predecessor methods: kept only as local
       // COMMAND_REMOVED shims so old callers get a replacement path.
       "domains.add",


### PR DESCRIPTION
Client-side cascade for the gateway change `notification-channel-routing-telegram` (self-serve Telegram push bindings + per-rule routing on top of the v1.55 operator-notifications substrate). Closes the SDK/CLI/MCP/docs half of #503.

## SDK (`@run402/sdk`)

- `r.admin.channels.connectTelegram({label?})` → `POST /agent/v1/notifications/channels/telegram` (201 `{binding_id, status: "pending", connect_url, connect_group_url, code_expires_at, label, next_actions}`).
- `r.admin.channels.list()` → `GET /agent/v1/notifications/channels` (`{email, webhook, telegram: [bindings]}`).
- `r.admin.channels.revokeTelegram(bindingId)` → `DELETE .../channels/telegram/:binding_id` (`{status: "revoked", binding_id}`; no-oracle 404).
- `r.admin.rules.{list, create, update, delete}` → `GET/POST /agent/v1/notifications/rules`, `PATCH/DELETE .../rules/:rule_id`. `update` preserves the gateway's PATCH null-vs-absent contract: an omitted field is dropped from the JSON body (unchanged), an explicit `null` clears the dimension back to wildcard.
- `admin.testNotification(opts?)` extended with `{source?, eventType?}`; result now types `telegram: {destinations: [{binding_id, label, delivered, transient?, description?}]}` plus the `drained` block.
- Sub-namespace shape mirrors `r.admin.transfers`; types exported via the existing `export type * from "./namespaces/admin.js"`.

## CLI (`run402`)

- `run402 notifications channels connect telegram [--label X]` — prints `connect_url` + `connect_group_url` prominently (stderr), then polls `GET .../channels` every 3s until the binding flips `active` or `code_expires_at` passes, with progress lines; exits 1 with `{connected: false, timed_out: true}` on expiry. A 503 `TELEGRAM_CHANNEL_NOT_CONFIGURED` surfaces verbatim (message + code + `next_actions`) via the standard `reportSdkError` envelope.
- `run402 notifications channels list` / `channels revoke <binding_id>`.
- `run402 notifications rules add --binding <id> [--project <id>] [--source app|platform] [--type a,b] [--class a,b]` / `rules list` / `rules rm <rule_id>` (`--type`/`--class` are comma-separated lists).
- `run402 notifications test [--source app|platform] [--type <event_type>]`.
- `--help` on `channels`/`rules` teaches the full rule model: ANDed dimensions, absent = wildcard, one rule → one chat, no rules = no Telegram traffic, mandatory email floor untouched.
- `channels`/`rules` are nested groups dispatched via `if (sub === ...)` (the `org member`/`org invite` pattern) so `sync.test.ts` extracts their leaf actions.

## MCP (`run402-mcp`)

- New tools: `list_notification_channels`, `list_notification_rules`, `create_notification_rule`, `delete_notification_rule`.
- `test_notification` gained optional `source`/`event_type` params.
- **Write-tool decision:** rule writes (`create`/`delete`) ARE exposed — the repo's convention is that MCP does not skip passkey-gated writes (`rotate_webhook_secret` and webhook-URL preference writes are precedent; the gateway enforces `operator_passkey` and the 403 surfaces with its assurance hint). Channel `connect`/`revoke` are deliberately CLI/SDK-only: connect blocks on a human tapping a Telegram deep link out-of-band (the CLI polls for the flip; a single MCP tool call can't sensibly block on that), and revoke is kept symmetric with connect. `list_notification_channels` gives MCP agents the binding ids/status they need.

## Docs

- docs-site CLI/SDK/MCP reference sections + regenerated `cli/llms-cli.txt`, `sdk/llms-sdk.txt`, `llms-mcp.txt` via `scripts/build-agent-flat-docs.mjs`; SKILL.md one-liner in the notifications tool list (+ regenerated `.well-known/agent-skills/index.json` digest); CHANGELOG.md entry.

## Also in this PR: `--help` short-circuit fix (second commit)

While verifying, the pre-existing flat subcommands (`notifications list/get/preferences/test --help`, `webhook-secret rotate --help`) turned out to error with `NO_ALLOWANCE` instead of printing usage — they listed `--help` as a known flag but never branched on it before touching auth/config. The second commit adds the same pre-switch short-circuit `cli/lib/org.mjs` uses (and the new `channels`/`rules` groups already follow), and adds `notifications` + `webhook-secret` to `cli-help.test.mjs`'s MATRIX plus nested-group coverage for `channels`/`rules` (17 new help-contract cases) so the contract is enforced going forward.

## Tests

- Full `npm test` green on the branch rebased onto v4.7.0/#504: **2707 pass / 0 fail / 1 pre-existing skip** (1870 main run + 2 + 14 + 821 CLI subprocess suites).
- New coverage: 31 SDK admin namespace tests (14 suites, incl. 15 new for channels/rules/test-override wire shapes — URL/method/body byte-exactness, PATCH null-vs-absent), 9 MCP tool tests (5 files, `mock.module` convention), `sync.test.ts` SURFACE + `SDK_BY_CAPABILITY` entries for all six capabilities (with `admin.rules.update` in `SDK_ONLY_METHODS`), 17 new CLI help-contract cases; output-contract matrices pass unchanged.

Refs #503. Ships additively; safe against pre-Telegram gateways (the connect route 503s fail-closed until the platform bot is provisioned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
